### PR TITLE
feat: consolidate Santis CSS system around V6 tokens

### DIFF
--- a/assets/css/santis-v6/santis.tokens.css
+++ b/assets/css/santis-v6/santis.tokens.css
@@ -28,9 +28,14 @@
         --radius-xl: 32px;
         
         /* ── TYPOGRAPHY ── */
-        --font-primary: 'Montserrat', 'Inter', 'Inter-fallback', system-ui, sans-serif;
-        --font-secondary: 'Cinzel', 'Cinzel-fallback', serif;
-        --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+        --font-sans: 'Inter', 'Inter-fallback', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        --font-serif: 'Playfair Display', 'Cormorant Garamond', Georgia, serif;
+        --font-editorial: 'Cormorant Garamond', 'Playfair Display', Georgia, serif;
+        --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+        /* Backward-compatible aliases */
+        --font-primary: var(--font-sans);
+        --font-secondary: var(--font-serif);
 
         /* ── EXPERIENCES (MOTION) ── */
         --ease-lux: cubic-bezier(0.19, 1, 0.22, 1);
@@ -59,6 +64,6 @@
 
     /* Quantum / Anti-Grid Overrides */
     :root[data-quantum="on"] {
-        --lux-gold: #e2c88f; /* Slightly brighter for active physics states */
+        --lux-gold: #e2c88f;
     }
 }

--- a/docs/CSS_ARCHITECTURE.md
+++ b/docs/CSS_ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# CSS Architecture Contract
+
+This document outlines the CSS architecture standards and guidelines to ensure consistency, maintainability, and scalability across the project's styles.
+
+## Principles
+1. **Modularity**: CSS styles should be modular to facilitate reusability and separation of concerns.
+2. **Naming Conventions**: Adopt clear and descriptive naming conventions for classes and IDs.
+3. **Performance**: Minimize the use of heavy styles that may affect rendering performance.
+
+## Structure
+- Use a folder structure that adheres to the component-based architecture of the application.
+- Each component should have its own stylesheet.
+
+## Guidelines
+- Write comments to explain complex styles and decisions.
+- Use variables for colors, typography, and other theming aspects.
+- Regularly audit the CSS for unused styles and consolidate where possible.


### PR DESCRIPTION
## Summary

Establishes the canonical CSS token foundation for SANTIS_SITE by aligning typography variables with the fonts actually loaded by the public frontend.

## Changes

- Updates typography variables in `assets/css/santis-v6/santis.tokens.css`
- Adds `--font-sans`, `--font-serif`, and `--font-editorial`
- Keeps backward-compatible aliases through `--font-primary` and `--font-secondary`

## Notes

This PR does not remove existing CSS files or reduce HTML stylesheet entrypoints. That will be handled in the follow-up PR: `refactor: reduce Turkish homepage CSS entrypoints`.