### PR TITLE
refactor: reduce Turkish homepage CSS entrypoints

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -24,6 +24,23 @@
 @import url('media-skeleton.css');
 @import url('view-transitions.css');
 
+/* PAGE MODULES — Temporary compatibility imports while HTML entrypoints converge */
+@import url('editorial.css');
+@import url('bento-grid.css');
+@import url('santis-v6/santis.bento-grid.css');
+@import url('modules/cards.css');
+@import url('gallery.css');
+@import url('video-hero.css');
+@import url('hero-slider.css');
+@import url('modules/global-trends.css');
+@import url('concierge.css');
+@import url('modules/testimonials.css');
+@import url('modules/sticky-booking.css');
+@import url('modules/signature-cards.css');
+@import url('santis-soul.css');
+@import url('modules/santis-cinematic.css');
+
+
 /* --- Z-Index Master Map & Variables --- */
 :root {
   --z-overlay: 9998;

--- a/tr/index.html
+++ b/tr/index.html
@@ -16,10 +16,33 @@ if (window.location.protocol === 'file:') {
 </script>
 <script src="/assets/js/santis-config.js"></script>
 <script src="/assets/js/api-client.js"></script>
+
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <title>Santis Club • Spa &amp; Wellness</title>
 <meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." name="description"/>
+<meta name="theme-color" content="#000000">
+<link href="/manifest.json" rel="manifest"/>
+<link href="/assets/img/icons/icon-192x192.webp" rel="apple-touch-icon"/>
+
+<meta content="/assets/img/og-standard.webp" property="og:image"/>
+<meta content="Santis Club – Spa &amp; Wellness" property="og:title"/>
+<meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." property="og:description"/>
+<meta content="https://santis-club.com/" property="og:url"/>
+<meta content="website" property="og:type"/>
+<meta content="Santis Club" property="og:site_name"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Santis Club • Spa &amp; Wellness" name="twitter:title"/>
+<meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." name="twitter:description"/>
+<meta content="https://santisclub.com/assets/img/cards/hammam.webp" name="twitter:image"/>
+
+<link rel="preload" href="/assets/css/fonts.css" as="style">
+<link rel="stylesheet" href="/assets/css/fonts.css" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="/assets/css/fonts.css"></noscript>
+
+<link rel="preload" href="/assets/css/style.css" as="style">
+<link rel="stylesheet" href="/assets/css/style.css" media="print" onload="this.media='all'">
+<noscript><link rel="stylesheet" href="/assets/css/style.css"></noscript>
 
 <style id="critical-css">
 /* Temel sıfırlama ve tipografi iskeleti */
@@ -33,95 +56,25 @@ body { margin: 0; background-color: #101010; font-family: 'Outfit', 'Inter', sys
 html { font-display: optional; }
 </style>
 
-  <link rel="preload" href="/assets/css/fonts.css" as="style">
-  <link rel="stylesheet" href="/assets/css/fonts.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/fonts.css"></noscript>
-<meta name="theme-color" content="#000000">
-<link href="/manifest.json" rel="manifest"/>
-<link href="/assets/img/icons/icon-192x192.webp" rel="apple-touch-icon"/>
-
-  <link rel="preload" href="/assets/css/style.css" as="style">
-  <link rel="stylesheet" href="/assets/css/style.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/style.css"></noscript>
-
-  <link rel="preload" href="/assets/css/editorial.css" as="style">
-  <link rel="stylesheet" href="/assets/css/editorial.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/editorial.css"></noscript>
-
-  <link rel="preload" href="/assets/css/bento-grid.css" as="style">
-  <link rel="stylesheet" href="/assets/css/bento-grid.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/bento-grid.css"></noscript>
-
-  <link rel="preload" href="/assets/css/santis-v6/santis.bento-grid.css" as="style">
-  <link rel="stylesheet" href="/assets/css/santis-v6/santis.bento-grid.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/santis-v6/santis.bento-grid.css"></noscript>
-
-  <link rel="preload" href="/assets/css/modules/cards.css" as="style">
-  <link rel="stylesheet" href="/assets/css/modules/cards.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/modules/cards.css"></noscript>
-
-  <link rel="preload" href="/assets/css/gallery.css" as="style">
-  <link rel="stylesheet" href="/assets/css/gallery.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/gallery.css"></noscript>
-
-  <link rel="preload" href="/assets/css/video-hero.css" as="style">
-  <link rel="stylesheet" href="/assets/css/video-hero.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/video-hero.css"></noscript>
-
-  <link rel="preload" href="/assets/css/hero-slider.css" as="style">
-  <link rel="stylesheet" href="/assets/css/hero-slider.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/hero-slider.css"></noscript>
-
-  <link rel="preload" href="/assets/css/modules/global-trends.css" as="style">
-  <link rel="stylesheet" href="/assets/css/modules/global-trends.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/modules/global-trends.css"></noscript>
-
-  <link rel="preload" href="/assets/css/concierge.css" as="style">
-  <link rel="stylesheet" href="/assets/css/concierge.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/concierge.css"></noscript>
-
-  <link rel="preload" href="/assets/css/modules/testimonials.css" as="style">
-  <link rel="stylesheet" href="/assets/css/modules/testimonials.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/modules/testimonials.css"></noscript>
-
-  <link rel="preload" href="/assets/css/modules/sticky-booking.css" as="style">
-  <link rel="stylesheet" href="/assets/css/modules/sticky-booking.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/modules/sticky-booking.css"></noscript>
-
-  <link rel="preload" href="/assets/css/modules/signature-cards.css" as="style">
-  <link rel="stylesheet" href="/assets/css/modules/signature-cards.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/modules/signature-cards.css"></noscript>
-
-  <link rel="preload" href="/assets/css/santis-soul.css" as="style">
-  <link rel="stylesheet" href="/assets/css/santis-soul.css" media="print" onload="this.media='all'">
-  <noscript><link rel="stylesheet" href="/assets/css/santis-soul.css"></noscript>
-  <link rel="stylesheet" href="/assets/css/modules/santis-cinematic.css">
-<meta content="/assets/img/og-standard.webp" property="og:image"/>
-<meta content="Santis Club – Spa &amp; Wellness" property="og:title"/>
-<meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." property="og:description"/>
-<meta content="https://santis-club.com/" property="og:url"/>
-<meta content="website" property="og:type"/>
-<!-- HREFLANG CLUSTER -->
 <!-- SCHEMA: Service -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"Service","name":"Index","provider":{"@type":"LocalBusiness","name":"Santis Club"}}</script>
 <!-- SCHEMA: BreadcrumbList -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https://santis-club.com/index.html"},{"@type":"ListItem","position":2,"name":"Ana Sayfa","item":"https://santis-club.com/"}]}</script>
 <!-- SCHEMA: FAQPage -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type": "Question", "name": "Masaj seansı ne kadar sürer?", "acceptedAnswer": {"@type": "Answer", "text": "Masaj seanslarımız 30 ile 90 dakika arasında sürer. Süre seçilen terapiye bağlıdır."}},{"@type": "Question", "name": "Masaj öncesi ne yapmalıyım?", "acceptedAnswer": {"@type": "Answer", "text": "Bir saat önce ağır yemek yememenizi ve bol su içmenizi öneririz. Lütfen 15 dakika erken gelin."}},{"@type": "Question", "name": "Bana hangi masaj türü uygun?", "acceptedAnswer": {"@type": "Answer", "text": "Terapistlerimiz ilk görüşmede ihtiyaçlarınızı değerlendirir ve en uygun masajı önerir."}}]}</script>
+
 <!-- SCHEMA: HealthAndBeautyBusiness -->
 <script type="application/ld+json">{"@context":"https://schema.org","@type":"HealthAndBeautyBusiness","name":"Santis Club Spa & Wellness","url":"https://santis-club.com","telephone":"+905348350169","address":{"@type":"PostalAddress","streetAddress":"Çolaklı Mah.","addressLocality":"Manavgat","addressRegion":"Antalya","postalCode":"07600","addressCountry":"TR"},"geo":{"@type":"GeoCoordinates","latitude":"36.7633","longitude":"31.3864"},"priceRange":"€€€","openingHoursSpecification":{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"],"opens":"09:00","closes":"22:00"}}</script>
+
 <!-- HREFLANG CLUSTER SYNC & SOVEREIGN SEO ARMOR -->
 <link rel="canonical" href="https://santis-club.com/" id="santis-canonical" />
-
 <link rel="alternate" hreflang="tr" href="https://santis-club.com/" />
-
 <link rel="alternate" hreflang="ru" href="https://santis-club.com/?lang=ru" />
 <link rel="alternate" hreflang="de" href="https://santis-club.com/?lang=de" />
 <link rel="alternate" hreflang="ar" href="https://santis-club.com/?lang=ar" />
 <link rel="alternate" hreflang="fr" href="https://santis-club.com/?lang=fr" />
-
 <link rel="alternate" hreflang="x-default" href="https://santis-club.com/" />
-<meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Santis Club • Spa &amp; Wellness" name="twitter:title"/><meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/hammam.webp" name="twitter:image"/>
+
 <!-- RUM: Core Web Vitals Gözlemcisi -->
 <script src="/assets/js/santis-vitals.js" async></script>
 


### PR DESCRIPTION
## Summary

Reduces CSS entrypoint fragmentation on the Turkish homepage by routing page-level CSS modules through the canonical `assets/css/style.css` manifest.

## Changes

- Adds temporary compatibility imports for homepage CSS modules into `assets/css/style.css`
- Removes duplicate page-level stylesheet links from `tr/index.html`
- Reduces Turkish homepage CSS entrypoints from 16 to 2
- Keeps `fonts.css` separate to preserve font loading behavior and minimize FOIT/FOUT risk
- Restores head architecture and cinematic body lock behavior for the homepage

## Notes

This PR does not delete legacy CSS files. It only reduces HTML stylesheet entrypoints and prepares the codebase for future V6 module migration.