### PR TITLE
fix: add public runtime shims for static serving

### DIFF
--- a/assets/js/modules/haptic-engine.js
+++ b/assets/js/modules/haptic-engine.js
@@ -1,0 +1,3 @@
+﻿// Public runtime compatibility shim.
+// This module is intentionally lightweight for static/local serving.
+export default {};

--- a/assets/js/modules/santis-intent-engine.js
+++ b/assets/js/modules/santis-intent-engine.js
@@ -1,0 +1,3 @@
+﻿// Public runtime compatibility shim.
+// This module is intentionally lightweight for static/local serving.
+export default {};

--- a/assets/js/modules/santis-reservation.js
+++ b/assets/js/modules/santis-reservation.js
@@ -1,0 +1,3 @@
+﻿// Public runtime compatibility shim.
+// This module is intentionally lightweight for static/local serving.
+export default {};

--- a/assets/js/modules/sovereign-cart.js
+++ b/assets/js/modules/sovereign-cart.js
@@ -1,0 +1,3 @@
+﻿// Public runtime compatibility shim.
+// This module is intentionally lightweight for static/local serving.
+export default {};

--- a/assets/js/modules/sovereign-command.js
+++ b/assets/js/modules/sovereign-command.js
@@ -1,0 +1,3 @@
+﻿// Public runtime compatibility shim.
+// This module is intentionally lightweight for static/local serving.
+export default {};

--- a/assets/js/santis-public-runtime-shim.js
+++ b/assets/js/santis-public-runtime-shim.js
@@ -1,0 +1,21 @@
+﻿(function santisPublicRuntimeShim() {
+  if (!window.SantisApi) {
+    window.SantisApi = {
+      async getCoreState() {
+        console.warn('[Santis Public Shim] SantisApi.getCoreState fallback active.');
+        return {
+          ok: true,
+          mode: 'public-static',
+          coreState: {
+            health: 'degraded',
+            runtime: 'static',
+            booking: null,
+            telemetry: null
+          }
+        };
+      }
+    };
+  }
+
+  window.__SANTIS_PUBLIC_RUNTIME_SHIM__ = true;
+})();

--- a/tr/index.html
+++ b/tr/index.html
@@ -16,6 +16,7 @@ if (window.location.protocol === 'file:') {
 </script>
 <script src="/assets/js/santis-config.js"></script>
 <script src="/assets/js/api-client.js"></script>
+<script src="/assets/js/santis-public-runtime-shim.js"></script>
 
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>


### PR DESCRIPTION
## Summary

Adds public runtime compatibility shims so the Turkish homepage can run cleanly in static/local serving mode.

## Changes

- Adds lightweight module shims for previously missing public JS paths
- Adds `santis-public-runtime-shim.js` with a safe `SantisApi.getCoreState` fallback
- Loads the runtime shim after `api-client.js` on `tr/index.html`

## Validation Scope

Expected to remove 404s for these static module paths:

- `/assets/js/modules/haptic-engine.js`
- `/assets/js/modules/santis-intent-engine.js`
- `/assets/js/modules/sovereign-cart.js`
- `/assets/js/modules/sovereign-command.js`
- `/assets/js/modules/santis-reservation.js`

## Notes

This PR does not implement backend SSE behavior. EventSource soft-fail handling should be handled in a separate PR.