### PR TITLE
feat: add WhatsApp booking funnel

### DIFF
--- a/assets/css/modules/santis-booking-funnel.css
+++ b/assets/css/modules/santis-booking-funnel.css
@@ -1,0 +1,177 @@
+.santis-booking-open {
+  overflow: hidden;
+}
+
+.santis-booking-drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483000;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 320ms var(--ease-lux, ease);
+}
+
+.santis-booking-drawer.is-open {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.santis-booking-backdrop {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 70% 20%, rgba(198, 169, 107, 0.16), transparent 34%),
+    rgba(5, 5, 5, 0.72);
+  backdrop-filter: blur(16px);
+}
+
+.santis-booking-panel {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(520px, 100%);
+  height: 100%;
+  overflow-y: auto;
+  padding: clamp(28px, 4vw, 56px);
+  background:
+    linear-gradient(180deg, rgba(20, 20, 22, 0.98), rgba(10, 10, 12, 0.98));
+  border-left: 1px solid rgba(198, 169, 107, 0.25);
+  box-shadow: -40px 0 120px rgba(0, 0, 0, 0.52);
+  color: var(--color-text, #f5f5f7);
+  transform: translateX(32px);
+  transition: transform 420ms var(--ease-lux, ease);
+}
+
+.santis-booking-drawer.is-open .santis-booking-panel {
+  transform: translateX(0);
+}
+
+.santis-booking-close {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: currentColor;
+  font-size: 28px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.santis-booking-kicker {
+  margin: 0 0 14px;
+  color: var(--lux-gold, #c6a96b);
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.santis-booking-title {
+  margin: 0 0 18px;
+  font-family: var(--font-serif, Georgia, serif);
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  font-weight: 400;
+  line-height: 1.05;
+}
+
+.santis-booking-copy {
+  margin: 0 0 32px;
+  color: var(--color-text-muted, #a1a1aa);
+  line-height: 1.75;
+}
+
+.santis-booking-step {
+  margin: 28px 0;
+}
+
+.santis-booking-step h3 {
+  margin: 0 0 14px;
+  font-size: 0.86rem;
+  color: rgba(255, 255, 255, 0.78);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.santis-booking-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.santis-booking-option {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 11px 15px;
+  background: rgba(255, 255, 255, 0.04);
+  color: currentColor;
+  cursor: pointer;
+  transition:
+    border-color 220ms ease,
+    background 220ms ease,
+    transform 220ms ease;
+}
+
+.santis-booking-option:hover,
+.santis-booking-option.is-active {
+  border-color: rgba(198, 169, 107, 0.65);
+  background: rgba(198, 169, 107, 0.12);
+  transform: translateY(-1px);
+}
+
+.santis-booking-guests {
+  display: inline-flex;
+  align-items: center;
+  gap: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 8px 12px;
+}
+
+.santis-booking-guests button {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(198, 169, 107, 0.16);
+  color: currentColor;
+  cursor: pointer;
+  font-size: 20px;
+}
+
+.santis-booking-summary {
+  display: grid;
+  gap: 8px;
+  margin: 30px 0;
+  padding: 18px;
+  border: 1px solid rgba(198, 169, 107, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.035);
+  color: var(--color-text-muted, #a1a1aa);
+}
+
+.santis-booking-summary strong {
+  color: var(--color-text, #f5f5f7);
+  font-weight: 500;
+}
+
+.santis-booking-submit {
+  width: 100%;
+  border: 0;
+  border-radius: 999px;
+  padding: 16px 22px;
+  background: var(--lux-gold, #c6a96b);
+  color: #111;
+  cursor: pointer;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+  .santis-booking-panel {
+    width: 100%;
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -39,6 +39,7 @@
 @import url('modules/signature-cards.css');
 @import url('santis-soul.css');
 @import url('modules/santis-cinematic.css');
+@import url('modules/santis-booking-funnel.css');
 
 
 /* --- Z-Index Master Map & Variables --- */

--- a/assets/js/modules/santis-booking-funnel.js
+++ b/assets/js/modules/santis-booking-funnel.js
@@ -1,0 +1,220 @@
+(function SantisBookingFunnel() {
+  const WHATSAPP_NUMBER = '905348350169';
+
+  const state = {
+    intent: '',
+    ritual: '',
+    time: '',
+    guests: '1',
+  };
+
+  const copy = {
+    intents: [
+      ['reset', 'Reset / Yenilenme'],
+      ['relaxation', 'Derin Rahatlama'],
+      ['hamam', 'Hamam Ritüeli'],
+      ['couple', 'Çift Deneyimi'],
+      ['skin', 'Cilt Yenilenmesi'],
+    ],
+    rituals: [
+      ['classic', 'Klasik Masaj'],
+      ['bali', 'Bali Masajı'],
+      ['deep-tissue', 'Derin Doku Masajı'],
+      ['hammam', 'Hamam Kese & Köpük'],
+      ['signature', 'Signature Ritual'],
+    ],
+    times: [
+      ['today', 'Bugün'],
+      ['tomorrow', 'Yarın'],
+      ['week', 'Bu hafta'],
+      ['concierge', 'Concierge önerisi'],
+    ],
+  };
+
+  function buildMessage() {
+    return [
+      'Merhaba Santis Concierge,',
+      '',
+      'Santis Club üzerinden bir ritüel talebi oluşturmak istiyorum.',
+      '',
+      `Niyet: ${state.intent || 'Concierge önerisi'}`,
+      `Ritüel: ${state.ritual || 'Concierge önerisi'}`,
+      `Zaman tercihi: ${state.time || 'Concierge önerisi'}`,
+      `Kişi sayısı: ${state.guests || '1'}`,
+      '',
+      'Benim için en uygun saat ve deneyim önerisini paylaşır mısınız?',
+    ].join('\n');
+  }
+
+  function openWhatsApp() {
+    const message = encodeURIComponent(buildMessage());
+    const url = `https://wa.me/${WHATSAPP_NUMBER}?text=${message}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  function optionButton(group, value, label) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'santis-booking-option';
+    btn.textContent = label;
+    btn.dataset.group = group;
+    btn.dataset.value = value;
+
+    btn.addEventListener('click', () => {
+      state[group] = label;
+
+      document
+        .querySelectorAll(`.santis-booking-option[data-group="${group}"]`)
+        .forEach((el) => el.classList.remove('is-active'));
+
+      btn.classList.add('is-active');
+      updateSummary();
+    });
+
+    return btn;
+  }
+
+  function updateSummary() {
+    const summary = document.querySelector('[data-booking-summary]');
+    if (!summary) return;
+
+    summary.innerHTML = `
+      <span>Niyet: <strong>${state.intent || 'Seçilmedi'}</strong></span>
+      <span>Ritüel: <strong>${state.ritual || 'Seçilmedi'}</strong></span>
+      <span>Zaman: <strong>${state.time || 'Seçilmedi'}</strong></span>
+      <span>Kişi: <strong>${state.guests || '1'}</strong></span>
+    `;
+  }
+
+  function createDrawer() {
+    if (document.querySelector('#santis-booking-drawer')) return;
+
+    const drawer = document.createElement('aside');
+    drawer.id = 'santis-booking-drawer';
+    drawer.className = 'santis-booking-drawer';
+    drawer.setAttribute('aria-hidden', 'true');
+
+    drawer.innerHTML = `
+      <div class="santis-booking-backdrop" data-booking-close></div>
+      <div class="santis-booking-panel" role="dialog" aria-modal="true" aria-label="Santis Booking Concierge">
+        <button class="santis-booking-close" type="button" data-booking-close aria-label="Kapat">×</button>
+
+        <p class="santis-booking-kicker">SANTIS CONCIERGE</p>
+        <h2 class="santis-booking-title">Ritüelinizi birlikte kuralım.</h2>
+        <p class="santis-booking-copy">
+          Bir hizmet seçmek zorunda değilsiniz. Sadece ihtiyacınız olan hali seçin;
+          Santis Concierge size en uygun zamanı ve deneyimi önersin.
+        </p>
+
+        <section class="santis-booking-step">
+          <h3>Bugün neye ihtiyacınız var?</h3>
+          <div class="santis-booking-options" data-intent-options></div>
+        </section>
+
+        <section class="santis-booking-step">
+          <h3>Ritüel tercihi</h3>
+          <div class="santis-booking-options" data-ritual-options></div>
+        </section>
+
+        <section class="santis-booking-step">
+          <h3>Zaman tercihi</h3>
+          <div class="santis-booking-options" data-time-options></div>
+        </section>
+
+        <section class="santis-booking-step">
+          <h3>Kişi sayısı</h3>
+          <div class="santis-booking-guests">
+            <button type="button" data-guest-minus>−</button>
+            <strong data-guest-count>1</strong>
+            <button type="button" data-guest-plus>+</button>
+          </div>
+        </section>
+
+        <div class="santis-booking-summary" data-booking-summary></div>
+
+        <button class="santis-booking-submit" type="button" data-booking-submit>
+          WhatsApp Concierge’e Gönder
+        </button>
+      </div>
+    `;
+
+    document.body.appendChild(drawer);
+
+    const intentWrap = drawer.querySelector('[data-intent-options]');
+    const ritualWrap = drawer.querySelector('[data-ritual-options]');
+    const timeWrap = drawer.querySelector('[data-time-options]');
+
+    copy.intents.forEach(([value, label]) => intentWrap.appendChild(optionButton('intent', value, label)));
+    copy.rituals.forEach(([value, label]) => ritualWrap.appendChild(optionButton('ritual', value, label)));
+    copy.times.forEach(([value, label]) => timeWrap.appendChild(optionButton('time', value, label)));
+
+    drawer.querySelector('[data-guest-minus]').addEventListener('click', () => {
+      state.guests = String(Math.max(1, Number(state.guests) - 1));
+      drawer.querySelector('[data-guest-count]').textContent = state.guests;
+      updateSummary();
+    });
+
+    drawer.querySelector('[data-guest-plus]').addEventListener('click', () => {
+      state.guests = String(Math.min(8, Number(state.guests) + 1));
+      drawer.querySelector('[data-guest-count]').textContent = state.guests;
+      updateSummary();
+    });
+
+    drawer.querySelector('[data-booking-submit]').addEventListener('click', openWhatsApp);
+
+    drawer.querySelectorAll('[data-booking-close]').forEach((el) => {
+      el.addEventListener('click', closeDrawer);
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') closeDrawer();
+    });
+
+    updateSummary();
+  }
+
+  function openDrawer(event) {
+    if (event) event.preventDefault();
+
+    createDrawer();
+
+    const drawer = document.querySelector('#santis-booking-drawer');
+    drawer.classList.add('is-open');
+    drawer.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('santis-booking-open');
+  }
+
+  function closeDrawer() {
+    const drawer = document.querySelector('#santis-booking-drawer');
+    if (!drawer) return;
+
+    drawer.classList.remove('is-open');
+    drawer.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('santis-booking-open');
+  }
+
+  function bindTriggers() {
+    const selectors = [
+      '[data-booking-open]',
+      'a[href="/rezervasyon"]',
+      'a[href="/tr/rezervasyon"]',
+      'a[href="/tr/rezervasyon/"]',
+    ];
+
+    document.querySelectorAll(selectors.join(',')).forEach((trigger) => {
+      trigger.addEventListener('click', openDrawer);
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bindTriggers);
+  } else {
+    bindTriggers();
+  }
+
+  window.SantisBookingFunnel = {
+    open: openDrawer,
+    close: closeDrawer,
+    state,
+  };
+})();

--- a/assets/js/modules/santis-booking-funnel.js
+++ b/assets/js/modules/santis-booking-funnel.js
@@ -31,6 +31,64 @@
     ],
   };
 
+  const STORAGE_KEY = 'santis_booking_state_v1';
+
+  function persistState() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+
+  function restoreState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw);
+      Object.assign(state, parsed);
+    } catch (e) {
+      console.warn('State restore failed', e);
+    }
+  }
+
+  function hydrateFromDataset(el) {
+    if (!el || !el.dataset) return;
+
+    if (el.dataset.bookingIntent) {
+      state.intent = el.dataset.bookingIntent;
+    }
+
+    if (el.dataset.bookingRitual) {
+      state.ritual = el.dataset.bookingRitual;
+    }
+
+    if (el.dataset.bookingTime) {
+      state.time = el.dataset.bookingTime;
+    }
+
+    if (el.dataset.bookingGuests) {
+      state.guests = el.dataset.bookingGuests;
+    }
+  }
+
+  function applySelectionsToUI() {
+    document.querySelectorAll('.santis-booking-option').forEach((btn) => {
+      const group = btn.dataset.group;
+      const value = btn.textContent;
+
+      if (state[group] === value) {
+        btn.classList.add('is-active');
+      } else {
+        btn.classList.remove('is-active');
+      }
+    });
+
+    const countEl = document.querySelector('[data-guest-count]');
+    if (countEl) {
+      countEl.textContent = state.guests;
+    }
+
+    updateSummary();
+  }
+
   function buildMessage() {
     return [
       'Merhaba Santis Concierge,',
@@ -84,6 +142,8 @@
       <span>Zaman: <strong>${state.time || 'Seçilmedi'}</strong></span>
       <span>Kişi: <strong>${state.guests || '1'}</strong></span>
     `;
+
+    persistState();
   }
 
   function createDrawer() {
@@ -174,7 +234,12 @@
   }
 
   function openDrawer(event) {
-    if (event) event.preventDefault();
+    restoreState();
+
+    if (event) {
+      event.preventDefault();
+      hydrateFromDataset(event.currentTarget);
+    }
 
     createDrawer();
 
@@ -182,6 +247,8 @@
     drawer.classList.add('is-open');
     drawer.setAttribute('aria-hidden', 'false');
     document.body.classList.add('santis-booking-open');
+
+    applySelectionsToUI();
   }
 
   function closeDrawer() {

--- a/tr/index.html
+++ b/tr/index.html
@@ -126,7 +126,7 @@ html { font-display: optional; }
         <span class="hero-kicker">SANTIS CLUB</span>
         <h2 class="hero-title">The Ritual of Stillness</h2>
         <p class="hero-subtitle">Where water, stone and silence meet.</p>
-        <a class="hero-cta" href="/rezervasyon">Ritüeli Keşfet</a>
+        <a class="hero-cta" href="/rezervasyon" data-booking-open>Ritüeli Keşfet</a>
     </div>
 </section>
 <!-- SECTION 2: SIGNATURE EXPERIENCES (V45 COVER FLOW MULTI-CARD) -->
@@ -587,6 +587,7 @@ html { font-display: optional; }
 <script type="module" src="/assets/js/core/santis-lang.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js" defer></script>
     <script src="/assets/js/app.js" defer></script>
+<script src="/assets/js/modules/santis-booking-funnel.js"></script>
 
 <!-- Phase 42(B): Real-Time Art Director Personalization -->
 <script type="module" src="/assets/js/core/santis-art-director-client.js" defer></script>


### PR DESCRIPTION
## Summary

Adds a zero-friction WhatsApp booking funnel for the Turkish homepage.

## Changes

- Adds Santis Booking Drawer UI
- Adds intent, ritual, time, and guest selectors
- Generates a structured WhatsApp concierge message
- Binds booking drawer to homepage reservation CTA
- Adds dedicated booking funnel CSS module and imports it through the canonical style manifest

## Notes

This is a public/static frontend funnel. It does not require backend services, payment integration, or user accounts.