### PR TITLE
feat: add scarcity engine to booking funnel

### DIFF
--- a/assets/css/modules/santis-booking-funnel.css
+++ b/assets/css/modules/santis-booking-funnel.css
@@ -224,3 +224,17 @@
   background: var(--lux-gold, #c6a96b);
   color: #111;
 }
+
+.santis-booking-scarcity {
+  margin: 24px 0 16px;
+  color: var(--color-text-muted, #a1a1aa);
+  font-size: 0.72rem;
+  text-align: center;
+  letter-spacing: 0.04em;
+  opacity: 0.8;
+  transition: color 0.4s ease;
+}
+
+.santis-booking-scarcity strong {
+  font-weight: 500;
+}

--- a/assets/js/modules/santis-booking-funnel.js
+++ b/assets/js/modules/santis-booking-funnel.js
@@ -254,7 +254,28 @@
     `;
 
     renderUpsell();
+    updateScarcity();
     persistState();
+  }
+
+  function updateScarcity() {
+    const scarcityEl = document.querySelector('[data-booking-scarcity]');
+    if (!scarcityEl) return;
+
+    if (state.time === 'Bugün' || state.time === 'Yarın') {
+      scarcityEl.innerHTML = 'Yakın zamanlı talepler için <strong>son 2 sessiz saat aralığı</strong> önerilebilir.';
+      scarcityEl.style.color = 'var(--nv-gold, #CFA968)';
+      return;
+    }
+
+    if (state.ritual) {
+      scarcityEl.innerHTML = `${state.ritual} deneyimi için sınırlı concierge kapasitesi bulunmaktadır.`;
+      scarcityEl.style.color = '';
+      return;
+    }
+
+    scarcityEl.innerHTML = 'Talepleriniz için VIP Concierge kapasitesi sınırlı tutulmaktadır.';
+    scarcityEl.style.color = '';
   }
 
   function createDrawer() {
@@ -311,6 +332,8 @@
         </section>
 
         <div class="santis-booking-summary" data-booking-summary></div>
+
+        <div class="santis-booking-scarcity" data-booking-scarcity></div>
 
         <button class="santis-booking-submit" type="button" data-booking-submit>
           WhatsApp Concierge’e Gönder


### PR DESCRIPTION
## Summary

Adds a subtle Quiet Luxury scarcity layer to the Santis booking funnel.

## Changes

- Adds dynamic scarcity copy to the booking drawer
- Shows near-term capacity messaging for Bugün/Yarın selections
- Shows ritual-specific concierge capacity messaging when a ritual is selected
- Adds dedicated low-pressure scarcity styling

## Notes

This is intentionally soft and premium. It does not use aggressive e-commerce scarcity, countdowns, hotel logic, nights, rooms, check-in, or checkout fields.