### PR TITLE
feat: connect Boardroom PRO to live CoreState stream

### DIFF
--- a/apps/ingestion-api/src/projections/boardroom-projections.ts
+++ b/apps/ingestion-api/src/projections/boardroom-projections.ts
@@ -50,6 +50,8 @@ export const projectEvent = (event: SantisEvent) => {
   }
 };
 
+import { broadcastCoreStatePatch } from "../routes/core-state-stream";
+
 /**
  * 📡 PROJECTION SUBSCRIBERS (Event Dinleyicileri)
  */
@@ -57,6 +59,17 @@ export const registerBoardroomProjections = (bus: SovereignBus) => {
   console.log("📈 [Projections] Boardroom Dinleyicileri Aktif.");
 
   // Canlı (Live) eventleri dinle ve projeksiyona uygula
-  bus.events.subscribe("experience.interaction.mood_selected", async (e: any) => projectEvent(e));
-  bus.events.subscribe("commerce.upsell.therapist_accepted", async (e: any) => projectEvent(e));
+  bus.events.subscribe("experience.interaction.mood_selected", async (e: any) => {
+    projectEvent(e);
+  });
+  
+  bus.events.subscribe("commerce.upsell.therapist_accepted", async (e: any) => {
+    projectEvent(e);
+    
+    // Broadcast live delta to the Boardroom PRO Cockpit
+    broadcastCoreStatePatch({
+      totalRevenue: BoardroomReadModels.revenueMetrics.totalRevenue,
+      bookingCount: Math.floor(BoardroomReadModels.revenueMetrics.totalRevenue / 1500), // Mock booking count for now
+    });
+  });
 };

--- a/assets/js/modules/santis-boardroom-pro-corestate-adapter.js
+++ b/assets/js/modules/santis-boardroom-pro-corestate-adapter.js
@@ -1,0 +1,48 @@
+/**
+ * SANTIS BOARDROOM PRO CORESTATE ADAPTER
+ * Consumes live CoreState patches and translates them into Boardroom metrics
+ */
+
+export const SantisBoardroomProCoreStateAdapter = (function() {
+  
+  // Local state cache mirroring the remote core state relevant to Boardroom
+  const liveState = {
+    totalRevenue: 0,
+    bookingCount: 0,
+    conversionRate: 0,
+    vipSegments: [],
+    oracleInsights: []
+  };
+
+  function init() {
+    window.addEventListener('santis:corestate:patch', handleCoreStatePatch);
+    console.log('[Santis Boardroom Adapter] Initialized and listening for live patches.');
+  }
+
+  function handleCoreStatePatch(event) {
+    const patch = event.detail;
+    if (!patch) return;
+
+    // Update Live State using the payload
+    if (typeof patch.totalRevenue !== 'undefined') liveState.totalRevenue = patch.totalRevenue;
+    if (typeof patch.bookingCount !== 'undefined') liveState.bookingCount = patch.bookingCount;
+    if (typeof patch.conversionRate !== 'undefined') liveState.conversionRate = patch.conversionRate;
+    
+    if (patch.vipSegments) liveState.vipSegments = patch.vipSegments;
+    if (patch.oracleInsights) liveState.oracleInsights = patch.oracleInsights;
+
+    // Trigger Boardroom PRO UI update
+    window.dispatchEvent(new CustomEvent('santis:boardroom:live:update', {
+      detail: getLiveMetrics()
+    }));
+  }
+
+  function getLiveMetrics() {
+    return { ...liveState };
+  }
+
+  return {
+    init,
+    getLiveMetrics
+  };
+})();

--- a/assets/js/modules/santis-boardroom-pro-live.js
+++ b/assets/js/modules/santis-boardroom-pro-live.js
@@ -1,0 +1,46 @@
+/**
+ * SANTIS BOARDROOM PRO LIVE ORCHESTRATOR
+ * Replaces the local-storage based refresh with Event-Driven Live updates
+ */
+import { SantisCoreStateStreamClient } from './santis-corestate-stream-client.js';
+import { SantisBoardroomProCoreStateAdapter } from './santis-boardroom-pro-corestate-adapter.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('🚀 Bootstrapping Boardroom PRO Live Nervous System...');
+
+  // Initialize the adapter first so it's ready to catch events
+  SantisBoardroomProCoreStateAdapter.init();
+
+  // Connect the SSE client
+  SantisCoreStateStreamClient.connect();
+
+  // Listen for mapped live updates from the adapter
+  window.addEventListener('santis:boardroom:live:update', (event) => {
+    const metrics = event.detail;
+    updateCockpitUI(metrics);
+  });
+});
+
+function updateCockpitUI(metrics) {
+  // Map metrics to DOM elements in the Boardroom PRO Cockpit
+  const revenueEl = document.getElementById('val-total-revenue');
+  const bookingEl = document.getElementById('val-total-leads');
+  
+  if (revenueEl && metrics.totalRevenue !== undefined) {
+    revenueEl.textContent = `€${metrics.totalRevenue.toLocaleString('en-US')}`;
+  }
+  
+  if (bookingEl && metrics.bookingCount !== undefined) {
+    bookingEl.textContent = metrics.bookingCount;
+  }
+  
+  // Check if SantisBoardroomLite global render functions are available to update UI
+  if (typeof window.SantisBoardroomLite !== 'undefined') {
+    if (metrics.vipSegments && metrics.vipSegments.length > 0) {
+       window.SantisBoardroomLite.renderVIPSegment(metrics.vipSegments);
+    }
+    if (metrics.oracleInsights && metrics.oracleInsights.length > 0) {
+       window.SantisBoardroomLite.renderOracleInsights(metrics.oracleInsights);
+    }
+  }
+}

--- a/assets/js/modules/santis-corestate-stream-client.js
+++ b/assets/js/modules/santis-corestate-stream-client.js
@@ -1,0 +1,73 @@
+/**
+ * SANTIS CORESTATE STREAM CLIENT
+ * Handles Server-Sent Events (SSE) connection to the Ingestion API
+ * True Streaming Intelligence Foundation
+ */
+
+export const SantisCoreStateStreamClient = (function() {
+  let eventSource = null;
+  const STREAM_URL = 'http://localhost:3030/api/v1/core-state/stream';
+
+  function connect() {
+    if (eventSource) {
+      console.warn('[Santis CoreState Stream] Already connected.');
+      return;
+    }
+
+    console.log(`[Santis CoreState Stream] Connecting to ${STREAM_URL}...`);
+    eventSource = new EventSource(STREAM_URL);
+
+    eventSource.onopen = (e) => {
+      console.log('[Santis CoreState Stream] Connection established (True Streaming Intelligence active).');
+      window.dispatchEvent(new CustomEvent('santis:corestate:connected'));
+    };
+
+    eventSource.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        console.log('[Santis CoreState Stream] Raw data received:', data);
+        
+        // Handle systemic events
+        if (data.type === 'SYSTEM') {
+          console.log('[Santis CoreState Stream] System Message:', data.payload);
+          return;
+        }
+
+        // Handle specific patch payloads
+        if (data.type === 'CORE_STATE_PATCH' && data.patch) {
+            // Dispatch the corestate patch so adapters can consume it
+            window.dispatchEvent(new CustomEvent('santis:corestate:patch', {
+            detail: data.patch
+            }));
+        } else {
+             // Fallback if the patch is sent directly (legacy mode)
+             window.dispatchEvent(new CustomEvent('santis:corestate:patch', {
+                detail: data
+              }));
+        }
+
+      } catch (err) {
+        console.error('[Santis CoreState Stream] Failed to parse stream data:', err);
+      }
+    };
+
+    eventSource.onerror = (e) => {
+      console.error('[Santis CoreState Stream] Connection error or disconnected. Attempting reconnect...');
+      // EventSource automatically attempts to reconnect.
+      window.dispatchEvent(new CustomEvent('santis:corestate:error', { detail: e }));
+    };
+  }
+
+  function disconnect() {
+    if (eventSource) {
+      eventSource.close();
+      eventSource = null;
+      console.log('[Santis CoreState Stream] Disconnected manually.');
+    }
+  }
+
+  return {
+    connect,
+    disconnect
+  };
+})();

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -94,5 +94,6 @@
 
   <script src="/assets/js/modules/santis-revenue-tracker.js"></script>
   <script src="/assets/js/modules/santis-boardroom-lite.js"></script>
+  <script type="module" src="/assets/js/modules/santis-boardroom-pro-live.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Connects Boardroom PRO to the live CoreState stream and broadcasts CoreState patches from ingestion-side projection updates.

## Scope

- Adds/uses Boardroom PRO CoreState stream wiring
- Wires Boardroom UI to live stream modules
- Broadcasts CoreState patches from ingestion events/projections
- Moves live-stream work onto the correct post-merge branch

## Suggested test

- Run `npm run dev`
- Confirm Ingestion API is available on `localhost:3030`
- Open `/tr/boardroom/`
- Trigger a booking/revenue event
- Confirm Boardroom PRO metrics update without refresh