### PR TITLE
feat: add Oracle v2 confidence scoring and action rail

### DIFF
--- a/assets/css/modules/santis-boardroom-oracle-v2.css
+++ b/assets/css/modules/santis-boardroom-oracle-v2.css
@@ -47,6 +47,33 @@
   letter-spacing: 0.01em;
 }
 
+.oracle-decision-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.oracle-decision-row span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 0.55rem;
+  border: 1px solid rgba(212, 175, 55, 0.22);
+  border-radius: 4px;
+  color: #d4af37;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-suggested-action {
+  margin-top: 0.75rem;
+  color: #f1f1f1;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
 .pulse-animation {
   animation: subtlePulse 1s ease-out;
 }

--- a/assets/css/modules/santis-oracle-action-rail.css
+++ b/assets/css/modules/santis-oracle-action-rail.css
@@ -1,0 +1,112 @@
+/*
+  Santis Oracle Action Rail
+  Executive recommendation queue for Boardroom Oracle v2.
+*/
+
+.santis-boardroom-action-rail {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-action-rail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.oracle-action-card {
+  min-height: 190px;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 2px solid #8b7355;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.oracle-action-card.oracle-risk-high {
+  border-left-color: var(--boardroom-accent);
+  background: linear-gradient(145deg, rgba(212, 175, 55, 0.08), rgba(255, 255, 255, 0.02));
+}
+
+.oracle-action-card.oracle-risk-medium {
+  border-left-color: #b89062;
+}
+
+.oracle-action-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--boardroom-accent);
+  font-size: 13px;
+}
+
+.oracle-risk-label {
+  color: var(--boardroom-text-muted);
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.oracle-action-card h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.oracle-action-card p {
+  margin: 0;
+  color: #ddd;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.oracle-action-card ul {
+  margin: auto 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.oracle-action-card li {
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.oracle-action-card li::before {
+  content: '';
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: var(--boardroom-accent);
+  vertical-align: 1px;
+}
+
+.oracle-action-empty {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 96px;
+  color: var(--boardroom-text-muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .santis-boardroom-action-rail {
+    padding: 20px;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -4,11 +4,15 @@
  */
 import { RevenueAnomalyDetector } from './santis-revenue-anomaly-detector.js';
 import { VipBehaviorInference } from './santis-vip-behavior-inference.js';
+import { SantisOracleConfidenceEngine } from './santis-oracle-confidence-engine.js';
+import { SantisOracleActionRail } from './santis-oracle-action-rail.js';
 
 class BoardroomOracleV2 {
   constructor() {
     this.anomalyDetector = new RevenueAnomalyDetector();
     this.vipInference = new VipBehaviorInference();
+    this.confidenceEngine = new SantisOracleConfidenceEngine();
+    this.actionRail = new SantisOracleActionRail();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -26,8 +30,29 @@ class BoardroomOracleV2 {
 
     // Listen to the system-wide patch event from the CoreState stream
     window.addEventListener('santis:corestate:patch', (e) => {
-      this.evaluateState(e.detail.patch.boardroom);
+      this.evaluateState(this.resolveBoardroomMetrics(e.detail));
     });
+  }
+
+  resolveBoardroomMetrics(payload) {
+    if (!payload) return null;
+    if (payload.patch?.boardroom) return payload.patch.boardroom;
+    if (payload.boardroom) return payload.boardroom;
+
+    return {
+      ...payload,
+      revenue: payload.revenue ?? payload.totalRevenue,
+      bookings: payload.bookings ?? payload.bookingCount,
+      vipLeads: payload.vipLeads ?? (Array.isArray(payload.vipSegments) ? payload.vipSegments.length : 0),
+      averageLeadValue: payload.averageLeadValue ?? this.resolveAverageLeadValue(payload),
+    };
+  }
+
+  resolveAverageLeadValue(metrics) {
+    const revenue = Number(metrics.revenue ?? metrics.totalRevenue ?? 0);
+    const bookings = Number(metrics.bookings ?? metrics.bookingCount ?? 0);
+
+    return bookings > 0 ? revenue / bookings : 0;
   }
 
   evaluateState(boardroomMetrics) {
@@ -36,10 +61,14 @@ class BoardroomOracleV2 {
     const anomalyInsights = this.anomalyDetector.analyze(boardroomMetrics);
     const vipInsights = this.vipInference.analyze(boardroomMetrics);
 
-    const allInsights = [...anomalyInsights, ...vipInsights];
+    const allInsights = this.confidenceEngine.enrich(
+      [...anomalyInsights, ...vipInsights],
+      boardroomMetrics
+    );
     
     if (allInsights.length > 0) {
       this.renderInsights(allInsights);
+      this.actionRail.render(allInsights);
     }
   }
 
@@ -71,6 +100,11 @@ class BoardroomOracleV2 {
         <div class="oracle-insight-icon">${this.getIconForType(insight.type)}</div>
         <div class="oracle-insight-content">
           <p>${insight.message}</p>
+          <div class="oracle-decision-row">
+            <span>${insight.confidenceScore}% confidence</span>
+            <span>${insight.riskLevel} risk</span>
+          </div>
+          <div class="oracle-suggested-action">${insight.suggestedAction}</div>
         </div>
       `;
       

--- a/assets/js/modules/santis-oracle-action-rail.js
+++ b/assets/js/modules/santis-oracle-action-rail.js
@@ -1,0 +1,97 @@
+/**
+ * santis-oracle-action-rail.js
+ * Renders Oracle recommendations as an executive action queue.
+ */
+export class SantisOracleActionRail {
+  constructor(container = document.getElementById('oracle-action-rail-container')) {
+    this.container = container;
+    this.actions = new Map();
+  }
+
+  render(insights) {
+    if (!this.container) return;
+
+    insights.forEach((insight) => {
+      this.actions.set(insight.id, this.toAction(insight));
+    });
+
+    const actions = Array.from(this.actions.values())
+      .sort((a, b) => b.priority - a.priority)
+      .slice(0, 3);
+
+    if (actions.length === 0) {
+      this.renderEmpty();
+      return;
+    }
+
+    this.container.innerHTML = actions.map((action) => this.renderAction(action)).join('');
+  }
+
+  toAction(insight) {
+    return {
+      id: insight.id,
+      title: this.resolveTitle(insight),
+      priority: this.resolvePriority(insight),
+      confidenceScore: insight.confidenceScore,
+      riskLevel: insight.riskLevel,
+      suggestedAction: insight.suggestedAction,
+      evidenceTrail: insight.evidenceTrail || [],
+    };
+  }
+
+  resolveTitle(insight) {
+    if (insight.type === 'opportunity' && insight.riskLevel === 'high') {
+      return 'VIP Momentum Follow-up';
+    }
+
+    if (insight.type === 'opportunity') {
+      return 'Premium Intent Capture';
+    }
+
+    if (insight.type === 'anomaly') {
+      return 'Revenue Spike Review';
+    }
+
+    return 'Boardroom Signal Review';
+  }
+
+  resolvePriority(insight) {
+    const riskWeight = { high: 300, medium: 200, low: 100 }[insight.riskLevel] || 100;
+    return riskWeight + Number(insight.confidenceScore || 0);
+  }
+
+  renderAction(action) {
+    const evidence = action.evidenceTrail
+      .map((item) => `<li>${this.escapeHtml(item)}</li>`)
+      .join('');
+
+    return `
+      <article class="oracle-action-card oracle-risk-${this.escapeHtml(action.riskLevel)}">
+        <div class="oracle-action-meta">
+          <span class="oracle-risk-label">${this.escapeHtml(action.riskLevel)} risk</span>
+          <strong>${Number(action.confidenceScore || 0)}%</strong>
+        </div>
+        <h3>${this.escapeHtml(action.title)}</h3>
+        <p>${this.escapeHtml(action.suggestedAction)}</p>
+        <ul>${evidence}</ul>
+      </article>
+    `;
+  }
+
+  renderEmpty() {
+    this.container.innerHTML = `
+      <div class="oracle-action-empty">
+        <span class="pulse-dot"></span> Action Rail armed. Awaiting decision-grade signal...
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}

--- a/assets/js/modules/santis-oracle-confidence-engine.js
+++ b/assets/js/modules/santis-oracle-confidence-engine.js
@@ -1,0 +1,136 @@
+/**
+ * santis-oracle-confidence-engine.js
+ * Converts raw Oracle insights into decision-grade recommendations.
+ */
+export class SantisOracleConfidenceEngine {
+  constructor() {
+    this.severityWeight = {
+      high: 24,
+      medium: 14,
+      low: 7,
+    };
+  }
+
+  enrich(insights, metrics = {}) {
+    return insights.map((insight) => {
+      const evidenceTrail = this.buildEvidenceTrail(insight, metrics);
+      const confidenceScore = this.calculateConfidence(insight, metrics, evidenceTrail);
+      const riskLevel = this.resolveRiskLevel(insight, confidenceScore, metrics);
+      const suggestedAction = this.resolveSuggestedAction(insight, riskLevel, confidenceScore);
+
+      return {
+        ...insight,
+        id: this.createInsightId(insight),
+        confidenceScore,
+        evidenceTrail,
+        riskLevel,
+        suggestedAction,
+      };
+    });
+  }
+
+  calculateConfidence(insight, metrics, evidenceTrail) {
+    const severityScore = this.severityWeight[insight.severity] || this.severityWeight.low;
+    const signalScore = Math.min(evidenceTrail.length * 12, 36);
+    const volumeScore = this.getVolumeScore(metrics);
+    const typeScore = insight.type === 'opportunity' ? 10 : 6;
+    const score = 34 + severityScore + signalScore + volumeScore + typeScore;
+
+    return Math.max(52, Math.min(96, score));
+  }
+
+  getVolumeScore(metrics) {
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+    const revenue = Number(metrics.revenue || metrics.totalRevenue || 0);
+
+    if (bookings >= 5 || revenue >= 5000) return 14;
+    if (bookings >= 2 || revenue >= 1500) return 8;
+    if (bookings > 0 || revenue > 0) return 4;
+
+    return 0;
+  }
+
+  buildEvidenceTrail(insight, metrics) {
+    const evidence = [];
+    const revenue = Number(metrics.revenue || metrics.totalRevenue || 0);
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+    const vipLeads = Number(metrics.vipLeads || this.getVipSegmentCount(metrics) || 0);
+    const averageLeadValue = Number(metrics.averageLeadValue || this.resolveAverageLeadValue(metrics));
+
+    if (averageLeadValue > 0) {
+      evidence.push(`Avg lead value: €${Math.round(averageLeadValue).toLocaleString('en-US')}`);
+    }
+
+    if (vipLeads > 0) {
+      evidence.push(`VIP signal: ${vipLeads} premium lead${vipLeads === 1 ? '' : 's'}`);
+    }
+
+    if (bookings > 0) {
+      evidence.push(`Booking velocity: ${bookings} active handoff${bookings === 1 ? '' : 's'}`);
+    }
+
+    if (revenue > 0) {
+      evidence.push(`Pipeline value: €${Math.round(revenue).toLocaleString('en-US')}`);
+    }
+
+    if (insight.type === 'anomaly') {
+      evidence.push('Signal class: revenue anomaly');
+    }
+
+    if (insight.type === 'opportunity') {
+      evidence.push('Signal class: conversion opportunity');
+    }
+
+    return evidence.slice(0, 4);
+  }
+
+  resolveRiskLevel(insight, confidenceScore, metrics) {
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+
+    if (insight.severity === 'high' && confidenceScore >= 84) return 'high';
+    if (insight.type === 'anomaly' && confidenceScore >= 78) return 'high';
+    if (bookings <= 1 && insight.type === 'opportunity') return 'medium';
+    if (confidenceScore >= 70) return 'medium';
+
+    return 'low';
+  }
+
+  resolveSuggestedAction(insight, riskLevel, confidenceScore) {
+    if (insight.type === 'opportunity' && riskLevel === 'high') {
+      return 'Start Sovereign Concierge follow-up within 10 minutes.';
+    }
+
+    if (insight.type === 'opportunity') {
+      return 'Prepare premium follow-up and keep VIP inventory visible.';
+    }
+
+    if (insight.type === 'anomaly' && riskLevel === 'high') {
+      return 'Verify campaign source and reserve capacity for high-value demand.';
+    }
+
+    if (insight.type === 'anomaly') {
+      return 'Monitor the next handoff before changing pricing or capacity.';
+    }
+
+    if (confidenceScore >= 82) {
+      return 'Escalate to Boardroom review and assign an owner.';
+    }
+
+    return 'Keep the signal on watch and wait for one more confirming event.';
+  }
+
+  resolveAverageLeadValue(metrics) {
+    const revenue = Number(metrics.revenue || metrics.totalRevenue || 0);
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+
+    return bookings > 0 ? revenue / bookings : 0;
+  }
+
+  getVipSegmentCount(metrics) {
+    return Array.isArray(metrics.vipSegments) ? metrics.vipSegments.length : 0;
+  }
+
+  createInsightId(insight) {
+    return `${insight.type || 'signal'}:${insight.severity || 'low'}:${insight.message}`;
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-lite.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-oracle-v2.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-action-rail.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -62,6 +63,18 @@
           </div>
         </section>
       </div>
+
+      <section class="santis-boardroom-action-rail">
+        <div class="log-header">
+          <h2>Boardroom Action Rail</h2>
+          <span class="ai-badge">Decision</span>
+        </div>
+        <div class="oracle-action-rail" id="oracle-action-rail-container">
+          <div class="oracle-action-empty">
+            <span class="pulse-dot"></span> Action Rail armed. Awaiting decision-grade signal...
+          </div>
+        </div>
+      </section>
 
       <section class="santis-boardroom-log">
         <div class="log-header">


### PR DESCRIPTION
Summary

Hardens Boardroom Oracle v2 by adding confidence scoring, evidence trails, risk levels, suggested actions, and a Boardroom Action Rail.

Scope

- Adds confidence scoring for Oracle insights
- Adds evidence trails and risk levels
- Adds suggested action generation
- Adds Boardroom Action Rail UI
- Improves Oracle v2 compatibility with nested and flat CoreState patch formats

Validation

- node --check passed for new and changed JS modules
- pnpm test:quality:static passed

Suggested test

- Run npm run dev
- Open /tr/boardroom/
- Trigger live revenue and booking events
- Confirm Oracle insights include confidence, evidence, risk level, and suggested actions in the Action Rail