### PR TITLE
feat: add Oracle v2 human approval loop

### DIFF
--- a/assets/css/modules/santis-oracle-human-approval-loop.css
+++ b/assets/css/modules/santis-oracle-human-approval-loop.css
@@ -1,0 +1,78 @@
+/*
+  Santis Oracle Human Approval Loop
+  HACI controls for Oracle Action Rail decisions.
+*/
+
+.oracle-human-controls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.oracle-human-decision-btn {
+  min-height: 34px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #f5f5f5;
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+.oracle-human-decision-btn:hover:not(:disabled),
+.oracle-human-decision-btn:focus-visible:not(:disabled) {
+  border-color: rgba(212, 175, 55, 0.55);
+  background: rgba(212, 175, 55, 0.12);
+  color: #fff;
+  outline: none;
+}
+
+.oracle-human-decision-btn:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.oracle-human-decision-btn[data-oracle-decision="approved"] {
+  color: #79e6a1;
+}
+
+.oracle-human-decision-btn[data-oracle-decision="dismissed"] {
+  color: #b9b9b9;
+}
+
+.oracle-human-decision-btn[data-oracle-decision="escalated"] {
+  color: #d4af37;
+}
+
+.oracle-human-decision-status {
+  min-height: 18px;
+  color: var(--boardroom-text-muted);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.oracle-action-card-decided {
+  border-color: rgba(212, 175, 55, 0.24);
+}
+
+.oracle-action-card[data-oracle-decision-state="approved"] .oracle-human-decision-status {
+  color: #79e6a1;
+}
+
+.oracle-action-card[data-oracle-decision-state="dismissed"] .oracle-human-decision-status {
+  color: #b9b9b9;
+}
+
+.oracle-action-card[data-oracle-decision-state="escalated"] .oracle-human-decision-status {
+  color: #d4af37;
+}
+
+@media (max-width: 560px) {
+  .oracle-human-controls {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -6,12 +6,14 @@ import { RevenueAnomalyDetector } from './santis-revenue-anomaly-detector.js';
 import { VipBehaviorInference } from './santis-vip-behavior-inference.js';
 import { SantisOracleConfidenceEngine } from './santis-oracle-confidence-engine.js';
 import { SantisOracleActionRail } from './santis-oracle-action-rail.js';
+import { SantisOracleHumanApprovalLoop } from './santis-oracle-human-approval-loop.js';
 
 class BoardroomOracleV2 {
   constructor() {
     this.anomalyDetector = new RevenueAnomalyDetector();
     this.vipInference = new VipBehaviorInference();
     this.confidenceEngine = new SantisOracleConfidenceEngine();
+    this.humanApprovalLoop = new SantisOracleHumanApprovalLoop();
     this.actionRail = new SantisOracleActionRail();
     this.container = document.getElementById('oracle-insights-container');
     

--- a/assets/js/modules/santis-oracle-action-memory.js
+++ b/assets/js/modules/santis-oracle-action-memory.js
@@ -1,0 +1,58 @@
+/**
+ * santis-oracle-action-memory.js
+ * Local Boardroom memory for human decisions on Oracle actions.
+ */
+export class SantisOracleActionMemory {
+  constructor(storageKey = 'santis_oracle_action_memory_v1') {
+    this.storageKey = storageKey;
+  }
+
+  recordDecision(decisionEvent) {
+    const memory = this.readAll();
+    const nextRecord = {
+      ...decisionEvent,
+      recordedAt: new Date().toISOString(),
+    };
+
+    const existingIndex = memory.findIndex((entry) => entry.actionId === nextRecord.actionId);
+
+    if (existingIndex >= 0) {
+      memory[existingIndex] = nextRecord;
+    } else {
+      memory.unshift(nextRecord);
+    }
+
+    this.writeAll(memory.slice(0, 50));
+
+    window.dispatchEvent(new CustomEvent('santis:oracle:action-memory:updated', {
+      detail: {
+        record: nextRecord,
+        memory: this.readAll(),
+      },
+    }));
+
+    return nextRecord;
+  }
+
+  getDecision(actionId) {
+    return this.readAll().find((entry) => entry.actionId === actionId) || null;
+  }
+
+  readAll() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(this.storageKey) || '[]');
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (error) {
+      console.warn('[Santis Oracle Memory] Could not read action memory.', error);
+      return [];
+    }
+  }
+
+  writeAll(memory) {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(memory));
+    } catch (error) {
+      console.warn('[Santis Oracle Memory] Could not write action memory.', error);
+    }
+  }
+}

--- a/assets/js/modules/santis-oracle-action-rail.js
+++ b/assets/js/modules/santis-oracle-action-rail.js
@@ -25,6 +25,9 @@ export class SantisOracleActionRail {
     }
 
     this.container.innerHTML = actions.map((action) => this.renderAction(action)).join('');
+    window.dispatchEvent(new CustomEvent('santis:oracle:actions:rendered', {
+      detail: { actions },
+    }));
   }
 
   toAction(insight) {
@@ -66,7 +69,10 @@ export class SantisOracleActionRail {
       .join('');
 
     return `
-      <article class="oracle-action-card oracle-risk-${this.escapeHtml(action.riskLevel)}">
+      <article
+        class="oracle-action-card oracle-risk-${this.escapeHtml(action.riskLevel)}"
+        data-oracle-action-id="${this.escapeHtml(action.id)}"
+      >
         <div class="oracle-action-meta">
           <span class="oracle-risk-label">${this.escapeHtml(action.riskLevel)} risk</span>
           <strong>${Number(action.confidenceScore || 0)}%</strong>
@@ -74,6 +80,12 @@ export class SantisOracleActionRail {
         <h3>${this.escapeHtml(action.title)}</h3>
         <p>${this.escapeHtml(action.suggestedAction)}</p>
         <ul>${evidence}</ul>
+        <div class="oracle-human-controls" aria-label="Oracle human decision controls">
+          <button class="oracle-human-decision-btn" type="button" data-oracle-decision="approved">Approve</button>
+          <button class="oracle-human-decision-btn" type="button" data-oracle-decision="dismissed">Dismiss</button>
+          <button class="oracle-human-decision-btn" type="button" data-oracle-decision="escalated">Escalate</button>
+        </div>
+        <div class="oracle-human-decision-status" data-oracle-decision-status>Awaiting human decision</div>
       </article>
     `;
   }

--- a/assets/js/modules/santis-oracle-confidence-engine.js
+++ b/assets/js/modules/santis-oracle-confidence-engine.js
@@ -131,6 +131,13 @@ export class SantisOracleConfidenceEngine {
   }
 
   createInsightId(insight) {
-    return `${insight.type || 'signal'}:${insight.severity || 'low'}:${insight.message}`;
+    const source = `${insight.type || 'signal'}:${insight.severity || 'low'}:${insight.message}`;
+    let hash = 0;
+
+    for (let index = 0; index < source.length; index += 1) {
+      hash = ((hash << 5) - hash + source.charCodeAt(index)) | 0;
+    }
+
+    return `oracle-action-${Math.abs(hash).toString(36)}`;
   }
 }

--- a/assets/js/modules/santis-oracle-human-approval-loop.js
+++ b/assets/js/modules/santis-oracle-human-approval-loop.js
@@ -1,0 +1,114 @@
+/**
+ * santis-oracle-human-approval-loop.js
+ * Captures human decisions for Oracle Action Rail recommendations.
+ */
+import { SantisOracleActionMemory } from './santis-oracle-action-memory.js';
+
+export class SantisOracleHumanApprovalLoop {
+  constructor({
+    container = document.getElementById('oracle-action-rail-container'),
+    memory = new SantisOracleActionMemory(),
+  } = {}) {
+    this.container = container;
+    this.memory = memory;
+    this.actions = new Map();
+    this.handleDecisionClick = this.handleDecisionClick.bind(this);
+    this.handleActionsRendered = this.handleActionsRendered.bind(this);
+
+    this.init();
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.container.addEventListener('click', this.handleDecisionClick);
+    window.addEventListener('santis:oracle:actions:rendered', this.handleActionsRendered);
+  }
+
+  handleActionsRendered(event) {
+    const actions = event.detail?.actions || [];
+
+    actions.forEach((action) => {
+      this.actions.set(action.id, action);
+    });
+
+    this.applyStoredDecisionStates();
+  }
+
+  handleDecisionClick(event) {
+    const button = event.target.closest('[data-oracle-decision]');
+    if (!button || !this.container.contains(button)) return;
+
+    const card = button.closest('[data-oracle-action-id]');
+    const actionId = card?.dataset.oracleActionId;
+    const action = this.actions.get(actionId);
+    const decision = button.dataset.oracleDecision;
+
+    if (!action || !this.isValidDecision(decision)) return;
+
+    const decisionEvent = this.createDecisionEvent(action, decision);
+    const record = this.memory.recordDecision(decisionEvent);
+
+    window.dispatchEvent(new CustomEvent('santis:oracle:action:decision', {
+      detail: record,
+    }));
+
+    this.markCardDecision(card, record);
+  }
+
+  createDecisionEvent(action, decision) {
+    return {
+      type: 'ORACLE_ACTION_DECISION',
+      actionId: action.id,
+      decision,
+      confidence: Number(action.confidenceScore || 0),
+      riskLevel: action.riskLevel,
+      suggestedAction: action.suggestedAction,
+      evidence: action.evidenceTrail || [],
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  applyStoredDecisionStates() {
+    if (!this.container) return;
+
+    this.container.querySelectorAll('[data-oracle-action-id]').forEach((card) => {
+      const record = this.memory.getDecision(card.dataset.oracleActionId);
+      if (record) this.markCardDecision(card, record);
+    });
+  }
+
+  markCardDecision(card, record) {
+    if (!card) return;
+
+    card.classList.add('oracle-action-card-decided');
+    card.dataset.oracleDecisionState = record.decision;
+
+    const status = card.querySelector('[data-oracle-decision-status]');
+    if (status) {
+      status.textContent = this.resolveStatusLabel(record);
+    }
+
+    card.querySelectorAll('[data-oracle-decision]').forEach((button) => {
+      button.disabled = true;
+      button.setAttribute('aria-disabled', 'true');
+    });
+  }
+
+  resolveStatusLabel(record) {
+    const label = {
+      approved: 'Approved by human operator',
+      dismissed: 'Dismissed by human operator',
+      escalated: 'Escalated to Boardroom review',
+    }[record.decision] || 'Decision recorded';
+
+    return `${label} at ${new Date(record.timestamp).toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`;
+  }
+
+  isValidDecision(decision) {
+    return ['approved', 'dismissed', 'escalated'].includes(decision);
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-lite.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-oracle-v2.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-action-rail.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-human-approval-loop.css" />
 </head>
 <body>
   <div class="santis-boardroom">


### PR DESCRIPTION
## Summary

Adds the HACI human approval loop for Boardroom Oracle v2 so recommended actions require explicit human decisions before any operational effect.

## Scope

- Adds Approve / Dismiss / Escalate controls to Oracle Action Rail cards
- Adds stable `oracle-action-*` action identifiers
- Emits `ORACLE_ACTION_DECISION` events for human decisions
- Persists decisions into local Boardroom memory
- Adds HACI control UI styling

## Validation

- `node --check` passed for new and changed JS modules
- `pnpm test:quality:static` passed

## Governance

No auto-apply behavior is introduced. Oracle recommends, the human decides, and the system records the decision.