### PR TITLE
feat: add Oracle v2 learning loop

### DIFF
--- a/assets/css/modules/santis-oracle-learning-loop.css
+++ b/assets/css/modules/santis-oracle-learning-loop.css
@@ -1,0 +1,37 @@
+/*
+  Santis Oracle Learning Loop
+  Displays confidence calibration evidence without auto-applying actions.
+*/
+
+.oracle-learning-summary {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: #b8b8b8;
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.oracle-learning-summary::before {
+  content: 'Learning loop';
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--boardroom-accent);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.oracle-learning-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  margin-top: 0.5rem;
+  padding: 0 0.5rem;
+  border: 1px solid rgba(212, 175, 55, 0.2);
+  border-radius: 4px;
+  color: #d4af37;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -107,6 +107,7 @@ class BoardroomOracleV2 {
             <span>${insight.riskLevel} risk</span>
           </div>
           <div class="oracle-suggested-action">${insight.suggestedAction}</div>
+          ${this.renderLearningSummary(insight)}
         </div>
       `;
       
@@ -128,6 +129,12 @@ class BoardroomOracleV2 {
       case 'warning': return '📉';
       default: return '💡';
     }
+  }
+
+  renderLearningSummary(insight) {
+    if (!insight.learningSummary) return '';
+
+    return `<div class="oracle-learning-summary">${insight.learningSummary}</div>`;
   }
 }
 

--- a/assets/js/modules/santis-oracle-action-rail.js
+++ b/assets/js/modules/santis-oracle-action-rail.js
@@ -39,6 +39,8 @@ export class SantisOracleActionRail {
       riskLevel: insight.riskLevel,
       suggestedAction: insight.suggestedAction,
       evidenceTrail: insight.evidenceTrail || [],
+      learningSummary: insight.learningSummary || '',
+      learningFeedback: insight.learningFeedback || null,
     };
   }
 
@@ -80,6 +82,7 @@ export class SantisOracleActionRail {
         <h3>${this.escapeHtml(action.title)}</h3>
         <p>${this.escapeHtml(action.suggestedAction)}</p>
         <ul>${evidence}</ul>
+        ${this.renderLearningSummary(action)}
         <div class="oracle-human-controls" aria-label="Oracle human decision controls">
           <button class="oracle-human-decision-btn" type="button" data-oracle-decision="approved">Approve</button>
           <button class="oracle-human-decision-btn" type="button" data-oracle-decision="dismissed">Dismiss</button>
@@ -87,6 +90,20 @@ export class SantisOracleActionRail {
         </div>
         <div class="oracle-human-decision-status" data-oracle-decision-status>Awaiting human decision</div>
       </article>
+    `;
+  }
+
+  renderLearningSummary(action) {
+    if (!action.learningSummary) return '';
+
+    const delta = Number(action.learningFeedback?.confidenceDelta || 0);
+    const deltaLabel = delta === 0 ? 'neutral' : `${delta > 0 ? '+' : ''}${delta}%`;
+
+    return `
+      <div class="oracle-learning-summary">
+        ${this.escapeHtml(action.learningSummary)}
+        <span class="oracle-learning-chip">Calibration ${this.escapeHtml(deltaLabel)}</span>
+      </div>
     `;
   }
 

--- a/assets/js/modules/santis-oracle-confidence-engine.js
+++ b/assets/js/modules/santis-oracle-confidence-engine.js
@@ -2,8 +2,11 @@
  * santis-oracle-confidence-engine.js
  * Converts raw Oracle insights into decision-grade recommendations.
  */
+import { SantisOracleLearningLoop } from './santis-oracle-learning-loop.js';
+
 export class SantisOracleConfidenceEngine {
-  constructor() {
+  constructor({ learningLoop = new SantisOracleLearningLoop() } = {}) {
+    this.learningLoop = learningLoop;
     this.severityWeight = {
       high: 24,
       medium: 14,
@@ -17,14 +20,23 @@ export class SantisOracleConfidenceEngine {
       const confidenceScore = this.calculateConfidence(insight, metrics, evidenceTrail);
       const riskLevel = this.resolveRiskLevel(insight, confidenceScore, metrics);
       const suggestedAction = this.resolveSuggestedAction(insight, riskLevel, confidenceScore);
+      const id = this.createInsightId(insight);
+      const learning = this.learningLoop.calibrate(id, {
+        confidenceScore,
+        riskLevel,
+        suggestedAction,
+        evidenceTrail,
+      });
 
       return {
         ...insight,
-        id: this.createInsightId(insight),
-        confidenceScore,
+        id,
+        confidenceScore: learning.confidenceScore,
         evidenceTrail,
-        riskLevel,
+        riskLevel: learning.riskLevel,
         suggestedAction,
+        learningSummary: learning.learningSummary,
+        learningFeedback: learning.learningFeedback,
       };
     });
   }

--- a/assets/js/modules/santis-oracle-feedback-weighting.js
+++ b/assets/js/modules/santis-oracle-feedback-weighting.js
@@ -1,0 +1,102 @@
+/**
+ * santis-oracle-feedback-weighting.js
+ * Scores historical human decisions against a future Oracle action candidate.
+ */
+export class SantisOracleFeedbackWeighting {
+  calculate(actionId, candidate, memory = []) {
+    const relevantRecords = memory
+      .map((record) => ({
+        record,
+        similarity: this.calculateSimilarity(actionId, candidate, record),
+      }))
+      .filter((entry) => entry.similarity > 0.35);
+
+    if (relevantRecords.length === 0) {
+      return {
+        confidenceDelta: 0,
+        riskDelta: 0,
+        approvalRate: null,
+        similarDecisionCount: 0,
+        rationale: '',
+      };
+    }
+
+    const weighted = relevantRecords.reduce((summary, entry) => {
+      const impact = this.resolveDecisionImpact(entry.record.decision);
+      const weight = entry.similarity;
+
+      summary.totalWeight += weight;
+      summary.approvalWeight += entry.record.decision === 'approved' ? weight : 0;
+      summary.confidenceDelta += impact.confidence * weight;
+      summary.riskDelta += impact.risk * weight;
+
+      return summary;
+    }, {
+      totalWeight: 0,
+      approvalWeight: 0,
+      confidenceDelta: 0,
+      riskDelta: 0,
+    });
+
+    const approvalRate = weighted.totalWeight > 0
+      ? Math.round((weighted.approvalWeight / weighted.totalWeight) * 100)
+      : null;
+
+    return {
+      confidenceDelta: Math.round(weighted.confidenceDelta),
+      riskDelta: Math.round(weighted.riskDelta),
+      approvalRate,
+      similarDecisionCount: relevantRecords.length,
+      rationale: this.buildRationale(approvalRate, relevantRecords.length),
+    };
+  }
+
+  calculateSimilarity(actionId, candidate, record) {
+    if (record.actionId === actionId) return 1;
+
+    const suggestedActionScore = record.suggestedAction === candidate.suggestedAction ? 0.35 : 0;
+    const riskScore = record.riskLevel === candidate.riskLevel ? 0.2 : 0;
+    const evidenceScore = this.calculateEvidenceOverlap(candidate.evidenceTrail || [], record.evidence || []);
+
+    return Math.min(0.95, suggestedActionScore + riskScore + evidenceScore);
+  }
+
+  calculateEvidenceOverlap(candidateEvidence, memoryEvidence) {
+    const candidateTokens = this.tokenize(candidateEvidence.join(' '));
+    const memoryTokens = this.tokenize(memoryEvidence.join(' '));
+
+    if (candidateTokens.size === 0 || memoryTokens.size === 0) return 0;
+
+    const intersection = Array.from(candidateTokens).filter((token) => memoryTokens.has(token));
+    return Math.min(0.4, intersection.length / Math.max(candidateTokens.size, memoryTokens.size));
+  }
+
+  resolveDecisionImpact(decision) {
+    switch (decision) {
+      case 'approved':
+        return { confidence: 6, risk: 0 };
+      case 'dismissed':
+        return { confidence: -7, risk: -1 };
+      case 'escalated':
+        return { confidence: 3, risk: 1 };
+      default:
+        return { confidence: 0, risk: 0 };
+    }
+  }
+
+  buildRationale(approvalRate, similarDecisionCount) {
+    if (approvalRate === null) return '';
+
+    return `Similar Oracle actions were approved ${approvalRate}% of the time across ${similarDecisionCount} human decision${similarDecisionCount === 1 ? '' : 's'}.`;
+  }
+
+  tokenize(value) {
+    return new Set(
+      String(value)
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, ' ')
+        .split(/\s+/)
+        .filter((token) => token.length > 3)
+    );
+  }
+}

--- a/assets/js/modules/santis-oracle-learning-loop.js
+++ b/assets/js/modules/santis-oracle-learning-loop.js
@@ -1,0 +1,67 @@
+/**
+ * santis-oracle-learning-loop.js
+ * Calibrates future Oracle confidence using human decision memory.
+ */
+import { SantisOracleActionMemory } from './santis-oracle-action-memory.js';
+import { SantisOracleFeedbackWeighting } from './santis-oracle-feedback-weighting.js';
+
+export class SantisOracleLearningLoop {
+  constructor({
+    memory = new SantisOracleActionMemory(),
+    feedbackWeighting = new SantisOracleFeedbackWeighting(),
+  } = {}) {
+    this.memory = memory;
+    this.feedbackWeighting = feedbackWeighting;
+  }
+
+  calibrate(actionId, candidate) {
+    const memory = this.memory.readAll();
+    const feedback = this.feedbackWeighting.calculate(actionId, candidate, memory);
+
+    const calibratedConfidence = this.clamp(
+      Number(candidate.confidenceScore || 0) + feedback.confidenceDelta,
+      45,
+      98
+    );
+
+    const calibratedRiskLevel = this.calibrateRisk(candidate.riskLevel, feedback.riskDelta);
+    const learningSummary = this.buildLearningSummary(feedback);
+
+    return {
+      confidenceScore: calibratedConfidence,
+      riskLevel: calibratedRiskLevel,
+      learningSummary,
+      learningFeedback: feedback,
+    };
+  }
+
+  calibrateRisk(currentRiskLevel, riskDelta) {
+    const levels = ['low', 'medium', 'high'];
+    const currentIndex = Math.max(0, levels.indexOf(currentRiskLevel));
+    const nextIndex = this.clamp(currentIndex + riskDelta, 0, levels.length - 1);
+
+    return levels[nextIndex];
+  }
+
+  buildLearningSummary(feedback) {
+    if (!feedback.rationale) return '';
+
+    if (feedback.confidenceDelta > 0) {
+      return `${feedback.rationale} Confidence calibrated upward.`;
+    }
+
+    if (feedback.confidenceDelta < 0) {
+      return `${feedback.rationale} Confidence calibrated downward.`;
+    }
+
+    if (feedback.riskDelta > 0) {
+      return `${feedback.rationale} Risk sensitivity increased.`;
+    }
+
+    return feedback.rationale;
+  }
+
+  clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-oracle-v2.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-action-rail.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-human-approval-loop.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-learning-loop.css" />
 </head>
 <body>
   <div class="santis-boardroom">


### PR DESCRIPTION
## Summary

Adds the Oracle v2 Learning Loop so human approval decisions calibrate future confidence and risk scoring without introducing auto-apply behavior.

## Scope

- Adds learning loop calibration from human decision memory
- Adds feedback weighting for approved, dismissed, and escalated actions
- Adds learning summary UI styling
- Updates confidence/risk generation to include learning-informed calibration
- Shows learning summaries in Action Rail and insight cards

## Validation

- `node --check` passed for new and changed JS modules
- `pnpm test:quality:static` passed

## Governance

No auto-apply behavior is introduced. The learning loop only calibrates future confidence and risk recommendations.