### PR TITLE
feat: add Oracle v2 executive mode

### DIFF
--- a/assets/css/modules/santis-oracle-executive-mode.css
+++ b/assets/css/modules/santis-oracle-executive-mode.css
@@ -1,0 +1,118 @@
+/*
+  Santis Oracle Executive Mode
+  CEO cockpit narrative, strategic alerts, and revenue playbook.
+*/
+
+.santis-boardroom-executive-mode {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-executive-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.oracle-executive-brief {
+  padding: 18px;
+  border-left: 2px solid var(--boardroom-accent);
+  border-radius: 4px;
+  background: rgba(212, 175, 55, 0.055);
+}
+
+.oracle-executive-kicker {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--boardroom-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oracle-executive-brief p {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.65;
+}
+
+.oracle-executive-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.oracle-executive-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.oracle-executive-panel h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-strategic-alert,
+.oracle-playbook-card {
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.oracle-strategic-alert {
+  border-left: 2px solid #8b7355;
+}
+
+.oracle-strategic-alert.oracle-alert-high {
+  border-left-color: var(--boardroom-accent);
+}
+
+.oracle-strategic-alert strong,
+.oracle-playbook-card strong {
+  display: block;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.oracle-strategic-alert p,
+.oracle-playbook-card p {
+  margin: 8px 0 0;
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.oracle-playbook-card span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--boardroom-accent);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.oracle-executive-empty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  color: var(--boardroom-text-muted);
+  font-size: 13px;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .oracle-executive-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -7,6 +7,7 @@ import { VipBehaviorInference } from './santis-vip-behavior-inference.js';
 import { SantisOracleConfidenceEngine } from './santis-oracle-confidence-engine.js';
 import { SantisOracleActionRail } from './santis-oracle-action-rail.js';
 import { SantisOracleHumanApprovalLoop } from './santis-oracle-human-approval-loop.js';
+import { SantisOracleExecutiveNarrative } from './santis-oracle-executive-narrative.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -15,6 +16,7 @@ class BoardroomOracleV2 {
     this.confidenceEngine = new SantisOracleConfidenceEngine();
     this.humanApprovalLoop = new SantisOracleHumanApprovalLoop();
     this.actionRail = new SantisOracleActionRail();
+    this.executiveNarrative = new SantisOracleExecutiveNarrative();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -71,6 +73,7 @@ class BoardroomOracleV2 {
     if (allInsights.length > 0) {
       this.renderInsights(allInsights);
       this.actionRail.render(allInsights);
+      this.executiveNarrative.render(allInsights, boardroomMetrics);
     }
   }
 

--- a/assets/js/modules/santis-oracle-executive-narrative.js
+++ b/assets/js/modules/santis-oracle-executive-narrative.js
@@ -1,0 +1,105 @@
+/**
+ * santis-oracle-executive-narrative.js
+ * Renders the CEO cockpit narrative for Boardroom Oracle v2.
+ */
+import { SantisOracleStrategicAlerts } from './santis-oracle-strategic-alerts.js';
+import { SantisOracleRevenuePlaybook } from './santis-oracle-revenue-playbook.js';
+
+export class SantisOracleExecutiveNarrative {
+  constructor({
+    container = document.getElementById('oracle-executive-mode-container'),
+    strategicAlerts = new SantisOracleStrategicAlerts(),
+    revenuePlaybook = new SantisOracleRevenuePlaybook(),
+  } = {}) {
+    this.container = container;
+    this.strategicAlerts = strategicAlerts;
+    this.revenuePlaybook = revenuePlaybook;
+  }
+
+  render(insights = [], metrics = {}) {
+    if (!this.container) return;
+
+    const alerts = this.strategicAlerts.generate(insights, metrics);
+    const playbook = this.revenuePlaybook.generate(insights, metrics);
+    const narrative = this.buildNarrative(insights, metrics, alerts, playbook);
+
+    this.container.innerHTML = `
+      <div class="oracle-executive-brief">
+        <span class="oracle-executive-kicker">Executive narrative</span>
+        <p>${this.escapeHtml(narrative)}</p>
+      </div>
+      <div class="oracle-executive-grid">
+        <div class="oracle-executive-panel">
+          <h3>Strategic Alerts</h3>
+          ${this.renderAlerts(alerts)}
+        </div>
+        <div class="oracle-executive-panel">
+          <h3>Revenue Playbook</h3>
+          ${this.renderPlaybook(playbook)}
+        </div>
+      </div>
+    `;
+  }
+
+  buildNarrative(insights, metrics, alerts, playbook) {
+    const vipLeads = Number(metrics.vipLeads || this.getVipSegmentCount(metrics) || 0);
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+    const averageLeadValue = Number(metrics.averageLeadValue || 0);
+    const topInsight = [...insights].sort((a, b) => Number(b.confidenceScore || 0) - Number(a.confidenceScore || 0))[0];
+    const topPlay = playbook[0]?.title || 'Keep Boardroom review active until the next confirming signal lands';
+
+    if (!topInsight) {
+      return 'Oracle is monitoring the live stream. Executive strategy will activate when a decision-grade signal appears.';
+    }
+
+    if (vipLeads > 0 && bookings > 0 && vipLeads / bookings >= 0.5) {
+      return `VIP intent quality is rising faster than booking volume. A low-volume, high-value Sovereign window is forming with €${Math.round(averageLeadValue).toLocaleString('en-US')} average lead value. Recommended strategy: ${topPlay}.`;
+    }
+
+    if (alerts.some((alert) => alert.level === 'high')) {
+      return `Oracle sees a high-priority strategic condition with ${topInsight.confidenceScore}% confidence. Keep human approval active, validate capacity, and run the next move through the revenue playbook.`;
+    }
+
+    return `Oracle has a calibrated ${topInsight.confidenceScore}% confidence signal. The current executive move is to ${topPlay.toLowerCase()} while the learning loop continues to tune future recommendations.`;
+  }
+
+  renderAlerts(alerts) {
+    if (alerts.length === 0) {
+      return '<div class="oracle-executive-empty">No strategic alerts above threshold.</div>';
+    }
+
+    return alerts.map((alert) => `
+      <article class="oracle-strategic-alert oracle-alert-${this.escapeHtml(alert.level)}">
+        <strong>${this.escapeHtml(alert.title)}</strong>
+        <p>${this.escapeHtml(alert.detail)}</p>
+      </article>
+    `).join('');
+  }
+
+  renderPlaybook(playbook) {
+    if (playbook.length === 0) {
+      return '<div class="oracle-executive-empty">No revenue playbook suggestion yet.</div>';
+    }
+
+    return playbook.map((play) => `
+      <article class="oracle-playbook-card">
+        <span>${this.escapeHtml(play.cadence)}</span>
+        <strong>${this.escapeHtml(play.title)}</strong>
+        <p>${this.escapeHtml(play.action)}</p>
+      </article>
+    `).join('');
+  }
+
+  getVipSegmentCount(metrics) {
+    return Array.isArray(metrics.vipSegments) ? metrics.vipSegments.length : 0;
+  }
+
+  escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+}

--- a/assets/js/modules/santis-oracle-revenue-playbook.js
+++ b/assets/js/modules/santis-oracle-revenue-playbook.js
@@ -1,0 +1,49 @@
+/**
+ * santis-oracle-revenue-playbook.js
+ * Generates executive playbook suggestions from Oracle insights.
+ */
+export class SantisOracleRevenuePlaybook {
+  generate(insights = [], metrics = {}) {
+    const plays = [];
+    const hasVipMomentum = insights.some((insight) => (
+      insight.type === 'opportunity' && String(insight.message || '').toLowerCase().includes('vip')
+    ));
+    const hasRevenueSpike = insights.some((insight) => insight.type === 'anomaly');
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+    const averageLeadValue = Number(metrics.averageLeadValue || 0);
+
+    if (hasVipMomentum) {
+      plays.push({
+        title: 'Activate Sovereign Concierge follow-up',
+        cadence: 'Within 2 hours',
+        action: 'Route approved VIP actions to concierge follow-up and foreground Sovereign Couple rituals.',
+      });
+    }
+
+    if (averageLeadValue >= 1000) {
+      plays.push({
+        title: 'Protect premium package focus',
+        cadence: 'Today',
+        action: 'Reduce low-value upsell exposure and keep premium ritual bundles visible in follow-up messaging.',
+      });
+    }
+
+    if (hasRevenueSpike) {
+      plays.push({
+        title: 'Validate spike source before scaling',
+        cadence: 'Before next campaign push',
+        action: 'Check attribution, staffing capacity, and inventory constraints before increasing acquisition pressure.',
+      });
+    }
+
+    if (bookings <= 2 && averageLeadValue > 0) {
+      plays.push({
+        title: 'Prioritize precision over reach',
+        cadence: 'Next operating block',
+        action: 'Focus on qualified follow-up quality instead of expanding broad funnel traffic.',
+      });
+    }
+
+    return plays.slice(0, 3);
+  }
+}

--- a/assets/js/modules/santis-oracle-strategic-alerts.js
+++ b/assets/js/modules/santis-oracle-strategic-alerts.js
@@ -1,0 +1,56 @@
+/**
+ * santis-oracle-strategic-alerts.js
+ * Converts calibrated Oracle signals into strategic Boardroom alerts.
+ */
+export class SantisOracleStrategicAlerts {
+  generate(insights = [], metrics = {}) {
+    const alerts = [];
+    const vipLeads = Number(metrics.vipLeads || this.getVipSegmentCount(metrics) || 0);
+    const bookings = Number(metrics.bookings || metrics.bookingCount || 0);
+    const averageLeadValue = Number(metrics.averageLeadValue || 0);
+    const highConfidenceOpportunity = insights.find((insight) => (
+      insight.type === 'opportunity' && Number(insight.confidenceScore || 0) >= 80
+    ));
+    const highRiskAnomaly = insights.find((insight) => (
+      insight.type === 'anomaly' && insight.riskLevel === 'high'
+    ));
+
+    if (vipLeads > 0 && bookings > 0 && vipLeads / bookings >= 0.5) {
+      alerts.push({
+        level: 'high',
+        title: 'VIP intent is outpacing volume',
+        detail: 'Premium demand quality is stronger than raw booking count. Treat this as a high-value conversion window.',
+      });
+    }
+
+    if (highConfidenceOpportunity) {
+      alerts.push({
+        level: 'medium',
+        title: 'Concierge window is active',
+        detail: `${highConfidenceOpportunity.confidenceScore}% confidence on a premium opportunity. Keep human approval in the loop before execution.`,
+      });
+    }
+
+    if (highRiskAnomaly) {
+      alerts.push({
+        level: 'high',
+        title: 'Revenue pattern needs executive review',
+        detail: 'A high-risk anomaly is present. Validate campaign source, team capacity, and premium inventory before scaling exposure.',
+      });
+    }
+
+    if (averageLeadValue >= 1200 && bookings <= 2 && bookings > 0) {
+      alerts.push({
+        level: 'medium',
+        title: 'Low-volume high-value window',
+        detail: 'A small number of leads is carrying outsized value. Prioritize precision follow-up over broad upsell exposure.',
+      });
+    }
+
+    return alerts.slice(0, 3);
+  }
+
+  getVipSegmentCount(metrics) {
+    return Array.isArray(metrics.vipSegments) ? metrics.vipSegments.length : 0;
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -11,6 +11,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-action-rail.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-human-approval-loop.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-learning-loop.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-executive-mode.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -41,6 +42,16 @@
         <div class="metric-card">
           <span class="metric-label">Avg. Value per Lead</span>
           <strong class="metric-value" id="val-avg-revenue">€0</strong>
+        </div>
+      </section>
+
+      <section class="santis-boardroom-executive-mode">
+        <div class="log-header">
+          <h2>Executive Mode</h2>
+          <span class="ai-badge">Strategy</span>
+        </div>
+        <div class="oracle-executive-mode" id="oracle-executive-mode-container">
+          <div class="oracle-executive-empty">Awaiting decision-grade Oracle signal.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds Oracle v2 Executive Mode, converting calibrated Oracle insights into executive narrative, strategic alerts, and revenue playbook suggestions for the Boardroom CEO cockpit.

## Scope

- Adds executive narrative generation
- Adds strategic alert generation from calibrated insights
- Adds revenue playbook suggestions
- Adds Executive Mode UI styling
- Wires the Boardroom page to render executive strategy output

## Validation

- `node --check` passed for new and changed JS modules
- `pnpm test:quality:static` passed

## Governance

Executive Mode remains advisory. It translates learned signals into strategy recommendations without auto-apply behavior.