### PR TITLE
feat: persist Oracle action memory server-side

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -18,6 +18,7 @@ import { registerCoreStateRoute } from "./routes/core-state";
 import { createCoreStateStreamRouter } from "./routes/core-state-stream";
 
 import { boardroomRouter } from "./routes/boardroom";
+import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -130,6 +131,7 @@ async function bootstrap() {
   // --- Otoriter Gümrük Kapısı (COMMAND ROTASI) ---
   app.use("/api/v1", createIngressRouter(bus));
   app.use("/api/v1/boardroom", boardroomRouter);
+  app.use("/api/v1/oracle", oracleActionMemoryRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-action-memory.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-action-memory.contract.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const OracleActionDecisionSchema = z.object({
+  type: z.literal("ORACLE_ACTION_DECISION"),
+  actionId: z.string().min(1),
+  decision: z.enum(["approved", "dismissed", "escalated"]),
+  confidence: z.number().min(0).max(100),
+  riskLevel: z.enum(["low", "medium", "high"]),
+  suggestedAction: z.string().min(1),
+  evidence: z.array(z.string()).default([]),
+  timestamp: z.string().datetime(),
+});
+
+export const OracleActionMemoryRecordSchema = OracleActionDecisionSchema.extend({
+  eventId: z.string().uuid(),
+  recordedAt: z.string().datetime(),
+});
+
+export const OracleActionMemoryResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: z.array(OracleActionMemoryRecordSchema),
+});
+
+export type OracleActionDecision = z.infer<typeof OracleActionDecisionSchema>;
+export type OracleActionMemoryRecord = z.infer<typeof OracleActionMemoryRecordSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-action-memory.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-action-memory.routes.ts
@@ -1,0 +1,51 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { OracleActionDecisionSchema } from "./oracle-action-memory.contract.js";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+
+export const oracleActionMemoryRouter = Router();
+
+oracleActionMemoryRouter.get("/action-memory", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 100);
+  const data = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 100);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});
+
+oracleActionMemoryRouter.post("/action-memory", async (req: Request, res: Response) => {
+  try {
+    const decision = OracleActionDecisionSchema.parse(req.body);
+    const record = await oracleActionMemoryStore.append(decision);
+
+    return res.status(201).json({
+      success: true,
+      timestamp: new Date().toISOString(),
+      data: record,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        success: false,
+        timestamp: new Date().toISOString(),
+        error: {
+          type: "ValidationFailed",
+          issues: error.errors.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+          })),
+        },
+      });
+    }
+
+    console.error("[Oracle Action Memory] Failed to persist decision.", error);
+    return res.status(500).json({
+      success: false,
+      timestamp: new Date().toISOString(),
+      error: { type: "InternalSystemError" },
+    });
+  }
+});

--- a/apps/ingestion-api/src/oracle/oracle-action-memory.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-action-memory.store.ts
@@ -1,0 +1,57 @@
+import { appendFile, mkdir } from "fs/promises";
+import { createReadStream, existsSync } from "fs";
+import * as readline from "readline";
+import * as path from "path";
+import crypto from "crypto";
+import {
+  OracleActionDecision,
+  OracleActionMemoryRecord,
+  OracleActionMemoryRecordSchema,
+} from "./oracle-action-memory.contract.js";
+
+const STORE_DIR = path.join(process.cwd(), ".data");
+const STORE_FILE = path.join(STORE_DIR, "oracle-action-memory.jsonl");
+
+export class OracleActionMemoryStore {
+  async append(decision: OracleActionDecision): Promise<OracleActionMemoryRecord> {
+    if (!existsSync(STORE_DIR)) {
+      await mkdir(STORE_DIR, { recursive: true });
+    }
+
+    const record: OracleActionMemoryRecord = {
+      ...decision,
+      eventId: crypto.randomUUID(),
+      recordedAt: new Date().toISOString(),
+    };
+
+    await appendFile(STORE_FILE, `${JSON.stringify(record)}\n`, "utf-8");
+    return record;
+  }
+
+  async replay(limit: number = 100): Promise<OracleActionMemoryRecord[]> {
+    if (!existsSync(STORE_FILE)) {
+      return [];
+    }
+
+    const recordsByAction = new Map<string, OracleActionMemoryRecord>();
+    const fileStream = createReadStream(STORE_FILE);
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (line.trim() === "") continue;
+
+      try {
+        const parsed = OracleActionMemoryRecordSchema.parse(JSON.parse(line));
+        recordsByAction.set(parsed.actionId, parsed);
+      } catch (error) {
+        console.warn("[Oracle Action Memory] Skipping invalid memory record.", error);
+      }
+    }
+
+    return Array.from(recordsByAction.values())
+      .sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt))
+      .slice(0, limit);
+  }
+}
+
+export const oracleActionMemoryStore = new OracleActionMemoryStore();

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -1,0 +1,43 @@
+/**
+ * santis-oracle-action-memory-client.js
+ * Server-side Oracle action memory transport for the Boardroom.
+ */
+export class SantisOracleActionMemoryClient {
+  constructor({
+    baseUrl = 'http://localhost:3030/api/v1/oracle/action-memory',
+  } = {}) {
+    this.baseUrl = baseUrl;
+  }
+
+  async readAll() {
+    const response = await fetch(this.baseUrl, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle memory read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return Array.isArray(body.data) ? body.data : [];
+  }
+
+  async recordDecision(decisionEvent) {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(decisionEvent),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle memory write failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data;
+  }
+}

--- a/assets/js/modules/santis-oracle-action-memory.js
+++ b/assets/js/modules/santis-oracle-action-memory.js
@@ -2,9 +2,13 @@
  * santis-oracle-action-memory.js
  * Local Boardroom memory for human decisions on Oracle actions.
  */
+import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
+
 export class SantisOracleActionMemory {
-  constructor(storageKey = 'santis_oracle_action_memory_v1') {
+  constructor(storageKey = 'santis_oracle_action_memory_v1', client = new SantisOracleActionMemoryClient()) {
     this.storageKey = storageKey;
+    this.client = client;
+    this.hydrateFromServer();
   }
 
   recordDecision(decisionEvent) {
@@ -31,6 +35,22 @@ export class SantisOracleActionMemory {
       },
     }));
 
+    this.client.recordDecision(decisionEvent)
+      .then((serverRecord) => {
+        if (!serverRecord) return;
+
+        this.upsertLocal(serverRecord);
+        window.dispatchEvent(new CustomEvent('santis:oracle:action-memory:synced', {
+          detail: {
+            record: serverRecord,
+            memory: this.readAll(),
+          },
+        }));
+      })
+      .catch((error) => {
+        console.warn('[Santis Oracle Memory] Server sync failed. Local memory retained.', error);
+      });
+
     return nextRecord;
   }
 
@@ -54,5 +74,47 @@ export class SantisOracleActionMemory {
     } catch (error) {
       console.warn('[Santis Oracle Memory] Could not write action memory.', error);
     }
+  }
+
+  hydrateFromServer() {
+    this.client.readAll()
+      .then((serverMemory) => {
+        if (!Array.isArray(serverMemory)) return;
+
+        this.writeAll(this.mergeMemory(serverMemory, this.readAll()).slice(0, 50));
+        window.dispatchEvent(new CustomEvent('santis:oracle:action-memory:hydrated', {
+          detail: {
+            memory: this.readAll(),
+          },
+        }));
+      })
+      .catch((error) => {
+        console.warn('[Santis Oracle Memory] Server hydration failed. Using local memory.', error);
+      });
+  }
+
+  upsertLocal(record) {
+    const memory = this.readAll();
+    const existingIndex = memory.findIndex((entry) => entry.actionId === record.actionId);
+
+    if (existingIndex >= 0) {
+      memory[existingIndex] = record;
+    } else {
+      memory.unshift(record);
+    }
+
+    this.writeAll(memory.slice(0, 50));
+  }
+
+  mergeMemory(primaryMemory, fallbackMemory) {
+    const merged = new Map();
+
+    [...fallbackMemory, ...primaryMemory].forEach((record) => {
+      if (!record?.actionId) return;
+      merged.set(record.actionId, record);
+    });
+
+    return Array.from(merged.values())
+      .sort((a, b) => Date.parse(b.recordedAt || b.timestamp || 0) - Date.parse(a.recordedAt || a.timestamp || 0));
   }
 }


### PR DESCRIPTION
## Summary

Persists Oracle action memory server-side so HACI decisions become replayable, multi-device, and available beyond localStorage.

## Scope

- Adds ORACLE_ACTION_DECISION Zod contract
- Adds append-only JSONL Oracle action memory store
- Adds GET /api/v1/oracle/action-memory
- Adds POST /api/v1/oracle/action-memory
- Adds frontend Oracle action memory client
- Hydrates local Oracle memory from server
- Syncs human decisions to server while preserving localStorage fallback
- Merges server memory with local unsynced memory without deleting local state

## Validation

- node --check passed for changed frontend JS
- Targeted TypeScript check passed for new ingestion-api Oracle files
- pnpm test:quality:static passed

## Note

Full pnpm --filter @santis/ingestion-api typecheck still fails on pre-existing unrelated package/dependency issues such as drizzle-orm, pg, and excluded route imports.