### PR TITLE
feat: add Oracle multi-node sync foundation

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -19,6 +19,7 @@ import { createCoreStateStreamRouter } from "./routes/core-state-stream";
 
 import { boardroomRouter } from "./routes/boardroom";
 import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
+import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -132,6 +133,7 @@ async function bootstrap() {
   app.use("/api/v1", createIngressRouter(bus));
   app.use("/api/v1/boardroom", boardroomRouter);
   app.use("/api/v1/oracle", oracleActionMemoryRouter);
+  app.use("/api/v1/oracle", oracleNodeSyncRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-action-memory.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-action-memory.contract.ts
@@ -1,4 +1,13 @@
 import { z } from "zod";
+import { OracleNodeContextSchema } from "./oracle-node.contract.js";
+
+export const DefaultOracleNodeContext = {
+  nodeId: "budva-primary",
+  nodeCode: "BUDVA",
+  location: "Budva",
+  region: "Montenegro",
+  role: "primary",
+} as const;
 
 export const OracleActionDecisionSchema = z.object({
   type: z.literal("ORACLE_ACTION_DECISION"),
@@ -9,6 +18,7 @@ export const OracleActionDecisionSchema = z.object({
   suggestedAction: z.string().min(1),
   evidence: z.array(z.string()).default([]),
   timestamp: z.string().datetime(),
+  node: OracleNodeContextSchema.default(DefaultOracleNodeContext),
 });
 
 export const OracleActionMemoryRecordSchema = OracleActionDecisionSchema.extend({

--- a/apps/ingestion-api/src/oracle/oracle-node-sync.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-node-sync.routes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from "express";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+import { oracleNodeSyncStore } from "./oracle-node-sync.store.js";
+
+export const oracleNodeSyncRouter = Router();
+
+oracleNodeSyncRouter.get("/node-sync", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 250);
+  const nodeId = typeof req.query.nodeId === "string" ? req.query.nodeId : undefined;
+  const records = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 250);
+  const filteredRecords = oracleNodeSyncStore.filterByNode(records, nodeId);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data: {
+      nodes: oracleNodeSyncStore.buildSnapshots(records),
+      decisions: filteredRecords,
+    },
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-node-sync.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-node-sync.store.ts
@@ -1,0 +1,54 @@
+import {
+  OracleActionMemoryRecord,
+  DefaultOracleNodeContext,
+} from "./oracle-action-memory.contract.js";
+import {
+  OracleNodeContext,
+  OracleNodeSyncSnapshot,
+} from "./oracle-node.contract.js";
+
+export class OracleNodeSyncStore {
+  buildSnapshots(records: OracleActionMemoryRecord[]): OracleNodeSyncSnapshot[] {
+    const snapshots = new Map<string, OracleNodeSyncSnapshot>();
+
+    records.forEach((record) => {
+      const node = record.node || DefaultOracleNodeContext;
+      const existing = snapshots.get(node.nodeId) || this.createSnapshot(node);
+
+      existing.decisionCount += 1;
+      if (record.decision === "approved") existing.approvedCount += 1;
+      if (record.decision === "dismissed") existing.dismissedCount += 1;
+      if (record.decision === "escalated") existing.escalatedCount += 1;
+
+      const currentLatest = existing.latestDecisionAt ? Date.parse(existing.latestDecisionAt) : 0;
+      const candidateLatest = Date.parse(record.recordedAt || record.timestamp);
+      if (candidateLatest > currentLatest) {
+        existing.latestDecisionAt = record.recordedAt || record.timestamp;
+      }
+
+      snapshots.set(node.nodeId, existing);
+    });
+
+    return Array.from(snapshots.values())
+      .sort((a, b) => Date.parse(b.latestDecisionAt || "0") - Date.parse(a.latestDecisionAt || "0"));
+  }
+
+  filterByNode(records: OracleActionMemoryRecord[], nodeId?: string): OracleActionMemoryRecord[] {
+    if (!nodeId || nodeId === "global") return records;
+
+    return records.filter((record) => (record.node?.nodeId || DefaultOracleNodeContext.nodeId) === nodeId);
+  }
+
+  createSnapshot(node: OracleNodeContext): OracleNodeSyncSnapshot {
+    return {
+      node,
+      decisionCount: 0,
+      approvedCount: 0,
+      dismissedCount: 0,
+      escalatedCount: 0,
+      latestDecisionAt: null,
+    };
+  }
+}
+
+export const oracleNodeSyncStore = new OracleNodeSyncStore();

--- a/apps/ingestion-api/src/oracle/oracle-node.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-node.contract.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const OracleNodeContextSchema = z.object({
+  nodeId: z.string().min(2).max(64),
+  nodeCode: z.string().min(2).max(32),
+  location: z.string().min(2).max(80),
+  region: z.string().min(2).max(32),
+  role: z.enum(["primary", "partner", "future"]).default("primary"),
+});
+
+export const OracleNodeSyncSnapshotSchema = z.object({
+  node: OracleNodeContextSchema,
+  decisionCount: z.number().int().nonnegative(),
+  approvedCount: z.number().int().nonnegative(),
+  dismissedCount: z.number().int().nonnegative(),
+  escalatedCount: z.number().int().nonnegative(),
+  latestDecisionAt: z.string().datetime().nullable(),
+});
+
+export const OracleNodeSyncResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: z.object({
+    nodes: z.array(OracleNodeSyncSnapshotSchema),
+    decisions: z.array(z.unknown()),
+  }),
+});
+
+export type OracleNodeContext = z.infer<typeof OracleNodeContextSchema>;
+export type OracleNodeSyncSnapshot = z.infer<typeof OracleNodeSyncSnapshotSchema>;

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -5,8 +5,10 @@
 export class SantisOracleActionMemoryClient {
   constructor({
     baseUrl = 'http://localhost:3030/api/v1/oracle/action-memory',
+    nodeSyncUrl = 'http://localhost:3030/api/v1/oracle/node-sync',
   } = {}) {
     this.baseUrl = baseUrl;
+    this.nodeSyncUrl = nodeSyncUrl;
   }
 
   async readAll() {
@@ -39,5 +41,23 @@ export class SantisOracleActionMemoryClient {
 
     const body = await response.json();
     return body.data;
+  }
+
+  async readNodeSync({ nodeId = 'global', limit = 250 } = {}) {
+    const url = new URL(this.nodeSyncUrl);
+    url.searchParams.set('nodeId', nodeId);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle node sync read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || { nodes: [], decisions: [] };
   }
 }

--- a/assets/js/modules/santis-oracle-human-approval-loop.js
+++ b/assets/js/modules/santis-oracle-human-approval-loop.js
@@ -3,14 +3,17 @@
  * Captures human decisions for Oracle Action Rail recommendations.
  */
 import { SantisOracleActionMemory } from './santis-oracle-action-memory.js';
+import { SantisOracleNodeContext } from './santis-oracle-node-context.js';
 
 export class SantisOracleHumanApprovalLoop {
   constructor({
     container = document.getElementById('oracle-action-rail-container'),
     memory = new SantisOracleActionMemory(),
+    nodeContext = new SantisOracleNodeContext(),
   } = {}) {
     this.container = container;
     this.memory = memory;
+    this.nodeContext = nodeContext;
     this.actions = new Map();
     this.handleDecisionClick = this.handleDecisionClick.bind(this);
     this.handleActionsRendered = this.handleActionsRendered.bind(this);
@@ -66,6 +69,7 @@ export class SantisOracleHumanApprovalLoop {
       suggestedAction: action.suggestedAction,
       evidence: action.evidenceTrail || [],
       timestamp: new Date().toISOString(),
+      node: this.nodeContext.resolve(),
     };
   }
 

--- a/assets/js/modules/santis-oracle-node-context.js
+++ b/assets/js/modules/santis-oracle-node-context.js
@@ -1,0 +1,51 @@
+/**
+ * santis-oracle-node-context.js
+ * Resolves the local Oracle node identity for multi-node learning sync.
+ */
+export class SantisOracleNodeContext {
+  constructor(storageKey = 'santis_oracle_node_context_v1') {
+    this.storageKey = storageKey;
+    this.defaultNode = {
+      nodeId: 'budva-primary',
+      nodeCode: 'BUDVA',
+      location: 'Budva',
+      region: 'Montenegro',
+      role: 'primary',
+    };
+  }
+
+  resolve() {
+    return {
+      ...this.defaultNode,
+      ...this.readStoredNode(),
+      ...this.readDomNode(),
+    };
+  }
+
+  readStoredNode() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(this.storageKey) || '{}');
+      return this.sanitize(parsed);
+    } catch (error) {
+      console.warn('[Santis Oracle Node] Could not read stored node context.', error);
+      return {};
+    }
+  }
+
+  readDomNode() {
+    const source = document.documentElement.dataset;
+    return this.sanitize({
+      nodeId: source.oracleNodeId,
+      nodeCode: source.oracleNodeCode,
+      location: source.oracleNodeLocation,
+      region: source.oracleNodeRegion,
+      role: source.oracleNodeRole,
+    });
+  }
+
+  sanitize(candidate) {
+    return Object.fromEntries(
+      Object.entries(candidate || {}).filter(([, value]) => typeof value === 'string' && value.trim().length > 0)
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Adds the foundation for Oracle v2 multi-node sync so action memory and learning signals can be scoped and summarized by operating node.

## Scope

- Adds Oracle node context contract
- Adds node sync snapshot contract
- Adds node-based decision summary/filter store
- Adds GET /api/v1/oracle/node-sync
- Adds frontend node identity resolver
- Adds node metadata to ORACLE_ACTION_DECISION
- Uses budva-primary / BUDVA / Budva / Montenegro as default node
- Enables frontend memory client to read node-sync state

## Validation

- node --check passed for changed frontend JS
- Targeted TypeScript check passed for new and touched Oracle API files
- pnpm test:quality:static passed

## Notes

This is the distributed intelligence foundation for future Budva, Dubai, and partner-node Boardroom aggregation.