### PR TITLE
feat: add Oracle global aggregation foundation

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -20,6 +20,7 @@ import { createCoreStateStreamRouter } from "./routes/core-state-stream";
 import { boardroomRouter } from "./routes/boardroom";
 import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
 import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
+import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregation.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -134,6 +135,7 @@ async function bootstrap() {
   app.use("/api/v1/boardroom", boardroomRouter);
   app.use("/api/v1/oracle", oracleActionMemoryRouter);
   app.use("/api/v1/oracle", oracleNodeSyncRouter);
+  app.use("/api/v1/oracle", oracleGlobalAggregationRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-global-aggregation.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-global-aggregation.contract.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { OracleNodeSyncSnapshotSchema } from "./oracle-node.contract.js";
+
+export const OracleGlobalSignalSchema = z.object({
+  signalId: z.string().min(1),
+  title: z.string().min(1),
+  detail: z.string().min(1),
+  confidence: z.number().min(0).max(100),
+  sourceNodeIds: z.array(z.string()),
+  recommendedNodeIds: z.array(z.string()),
+  generatedAt: z.string().datetime(),
+});
+
+export const OracleGlobalAggregationSchema = z.object({
+  nodeCount: z.number().int().nonnegative(),
+  decisionCount: z.number().int().nonnegative(),
+  globalApprovalRate: z.number().min(0).max(100),
+  globalEscalationRate: z.number().min(0).max(100),
+  topApprovalNode: OracleNodeSyncSnapshotSchema.nullable(),
+  leadingAction: z.string().nullable(),
+  crossNodeRecommendation: z.string(),
+  nodes: z.array(OracleNodeSyncSnapshotSchema),
+  signals: z.array(OracleGlobalSignalSchema),
+});
+
+export const OracleGlobalAggregationResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleGlobalAggregationSchema,
+});
+
+export type OracleGlobalSignal = z.infer<typeof OracleGlobalSignalSchema>;
+export type OracleGlobalAggregation = z.infer<typeof OracleGlobalAggregationSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-global-aggregation.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-global-aggregation.routes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from "express";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+import { oracleGlobalAggregationStore } from "./oracle-global-aggregation.store.js";
+
+export const oracleGlobalAggregationRouter = Router();
+
+oracleGlobalAggregationRouter.get("/global-aggregation", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 250);
+  const records = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 250);
+  const data = oracleGlobalAggregationStore.aggregate(records);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-global-aggregation.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-global-aggregation.store.ts
@@ -1,0 +1,198 @@
+import {
+  OracleActionMemoryRecord,
+  DefaultOracleNodeContext,
+} from "./oracle-action-memory.contract.js";
+import { OracleNodeSyncSnapshot } from "./oracle-node.contract.js";
+import {
+  OracleGlobalAggregation,
+  OracleGlobalSignal,
+} from "./oracle-global-aggregation.contract.js";
+import { oracleNodeSyncStore } from "./oracle-node-sync.store.js";
+
+export class OracleGlobalAggregationStore {
+  aggregate(records: OracleActionMemoryRecord[]): OracleGlobalAggregation {
+    const nodes = oracleNodeSyncStore.buildSnapshots(records);
+    const decisionCount = records.length;
+    const approvedCount = records.filter((record) => record.decision === "approved").length;
+    const escalatedCount = records.filter((record) => record.decision === "escalated").length;
+    const globalApprovalRate = this.toPercentage(approvedCount, decisionCount);
+    const globalEscalationRate = this.toPercentage(escalatedCount, decisionCount);
+    const topApprovalNode = this.resolveTopApprovalNode(nodes);
+    const leadingAction = this.resolveLeadingApprovedAction(records);
+    const generatedAt = new Date().toISOString();
+    const signals = this.buildSignals({
+      records,
+      nodes,
+      topApprovalNode,
+      leadingAction,
+      globalApprovalRate,
+      globalEscalationRate,
+      generatedAt,
+    });
+
+    return {
+      nodeCount: nodes.length,
+      decisionCount,
+      globalApprovalRate,
+      globalEscalationRate,
+      topApprovalNode,
+      leadingAction,
+      crossNodeRecommendation: this.buildCrossNodeRecommendation({
+        decisionCount,
+        topApprovalNode,
+        leadingAction,
+        globalApprovalRate,
+        globalEscalationRate,
+      }),
+      nodes,
+      signals,
+    };
+  }
+
+  resolveTopApprovalNode(nodes: OracleNodeSyncSnapshot[]): OracleNodeSyncSnapshot | null {
+    const rankedNodes = nodes
+      .filter((node) => node.decisionCount > 0)
+      .sort((a, b) => {
+        const approvalDelta = this.toPercentage(b.approvedCount, b.decisionCount)
+          - this.toPercentage(a.approvedCount, a.decisionCount);
+
+        if (approvalDelta !== 0) return approvalDelta;
+        return b.decisionCount - a.decisionCount;
+      });
+
+    return rankedNodes[0] || null;
+  }
+
+  resolveLeadingApprovedAction(records: OracleActionMemoryRecord[]): string | null {
+    const counts = new Map<string, number>();
+
+    records
+      .filter((record) => record.decision === "approved")
+      .forEach((record) => {
+        counts.set(record.suggestedAction, (counts.get(record.suggestedAction) || 0) + 1);
+      });
+
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+  }
+
+  buildSignals({
+    records,
+    nodes,
+    topApprovalNode,
+    leadingAction,
+    globalApprovalRate,
+    globalEscalationRate,
+    generatedAt,
+  }: {
+    records: OracleActionMemoryRecord[];
+    nodes: OracleNodeSyncSnapshot[];
+    topApprovalNode: OracleNodeSyncSnapshot | null;
+    leadingAction: string | null;
+    globalApprovalRate: number;
+    globalEscalationRate: number;
+    generatedAt: string;
+  }): OracleGlobalSignal[] {
+    const signals: OracleGlobalSignal[] = [];
+    const recommendedNodeIds = this.resolveRecommendedNodeIds(nodes);
+
+    if (topApprovalNode && leadingAction) {
+      const approvalRate = this.toPercentage(topApprovalNode.approvedCount, topApprovalNode.decisionCount);
+      signals.push({
+        signalId: "global-approval-momentum",
+        title: `${topApprovalNode.node.location} approval momentum`,
+        detail: `${topApprovalNode.node.nodeCode} is leading with ${approvalRate}% approval. Prioritize "${leadingAction}" as a candidate play for launch and partner nodes.`,
+        confidence: Math.min(96, Math.max(62, approvalRate)),
+        sourceNodeIds: [topApprovalNode.node.nodeId],
+        recommendedNodeIds,
+        generatedAt,
+      });
+    }
+
+    if (globalEscalationRate >= 30) {
+      signals.push({
+        signalId: "global-risk-sensitivity",
+        title: "Cross-node risk sensitivity rising",
+        detail: `${globalEscalationRate}% of recent Oracle decisions were escalated. Keep HACI review active before scaling high-risk playbooks.`,
+        confidence: Math.min(94, 60 + globalEscalationRate),
+        sourceNodeIds: this.resolveSourceNodeIds(records),
+        recommendedNodeIds,
+        generatedAt,
+      });
+    }
+
+    if (records.length > 0 && nodes.length <= 1) {
+      const node = nodes[0]?.node || DefaultOracleNodeContext;
+      signals.push({
+        signalId: "single-node-learning-baseline",
+        title: "Single-node learning baseline ready",
+        detail: `${node.location} has ${records.length} replayable Oracle decisions. Future nodes can bootstrap from this memory before local traffic matures.`,
+        confidence: Math.min(90, Math.max(55, globalApprovalRate || 55)),
+        sourceNodeIds: [node.nodeId],
+        recommendedNodeIds,
+        generatedAt,
+      });
+    }
+
+    if (signals.length === 0) {
+      signals.push({
+        signalId: "global-aggregation-standby",
+        title: "Global aggregation standing by",
+        detail: "Oracle memory has no decision density yet. Approvals, dismissals, and escalations will become cross-node learning signals as they arrive.",
+        confidence: 50,
+        sourceNodeIds: [],
+        recommendedNodeIds,
+        generatedAt,
+      });
+    }
+
+    return signals.slice(0, 3);
+  }
+
+  buildCrossNodeRecommendation({
+    decisionCount,
+    topApprovalNode,
+    leadingAction,
+    globalApprovalRate,
+    globalEscalationRate,
+  }: {
+    decisionCount: number;
+    topApprovalNode: OracleNodeSyncSnapshot | null;
+    leadingAction: string | null;
+    globalApprovalRate: number;
+    globalEscalationRate: number;
+  }): string {
+    if (decisionCount === 0) {
+      return "Await more human decisions before promoting network-level strategy.";
+    }
+
+    if (topApprovalNode && leadingAction && globalApprovalRate >= 70) {
+      return `${topApprovalNode.node.location} node is producing strong approval signal; test "${leadingAction}" as a controlled playbook candidate for Dubai and partner launch nodes.`;
+    }
+
+    if (globalEscalationRate >= 30) {
+      return "Escalation density is high; require human review before applying cross-node learning weights.";
+    }
+
+    return "Keep aggregating node-tagged decisions until approval density produces a stronger global playbook signal.";
+  }
+
+  resolveSourceNodeIds(records: OracleActionMemoryRecord[]): string[] {
+    return Array.from(new Set(records.map((record) => record.node?.nodeId || DefaultOracleNodeContext.nodeId)));
+  }
+
+  resolveRecommendedNodeIds(nodes: OracleNodeSyncSnapshot[]): string[] {
+    const recommended = nodes
+      .filter((node) => node.node.role !== "primary")
+      .map((node) => node.node.nodeId);
+
+    return recommended.length > 0 ? recommended : ["dubai-launch", "partner-spa-network"];
+  }
+
+  toPercentage(part: number, total: number): number {
+    if (!total) return 0;
+    return Math.round((part / total) * 100);
+  }
+}
+
+export const oracleGlobalAggregationStore = new OracleGlobalAggregationStore();

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -8,6 +8,7 @@ import { SantisOracleConfidenceEngine } from './santis-oracle-confidence-engine.
 import { SantisOracleActionRail } from './santis-oracle-action-rail.js';
 import { SantisOracleHumanApprovalLoop } from './santis-oracle-human-approval-loop.js';
 import { SantisOracleExecutiveNarrative } from './santis-oracle-executive-narrative.js';
+import { SantisOracleGlobalExecutiveView } from './santis-oracle-global-executive-view.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -17,6 +18,7 @@ class BoardroomOracleV2 {
     this.humanApprovalLoop = new SantisOracleHumanApprovalLoop();
     this.actionRail = new SantisOracleActionRail();
     this.executiveNarrative = new SantisOracleExecutiveNarrative();
+    this.globalExecutiveView = new SantisOracleGlobalExecutiveView();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -24,6 +26,7 @@ class BoardroomOracleV2 {
 
   init() {
     if (!this.container) return;
+    this.globalExecutiveView.init();
     
     // Initial state
     this.container.innerHTML = `

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -6,9 +6,11 @@ export class SantisOracleActionMemoryClient {
   constructor({
     baseUrl = 'http://localhost:3030/api/v1/oracle/action-memory',
     nodeSyncUrl = 'http://localhost:3030/api/v1/oracle/node-sync',
+    globalAggregationUrl = 'http://localhost:3030/api/v1/oracle/global-aggregation',
   } = {}) {
     this.baseUrl = baseUrl;
     this.nodeSyncUrl = nodeSyncUrl;
+    this.globalAggregationUrl = globalAggregationUrl;
   }
 
   async readAll() {
@@ -59,5 +61,22 @@ export class SantisOracleActionMemoryClient {
 
     const body = await response.json();
     return body.data || { nodes: [], decisions: [] };
+  }
+
+  async readGlobalAggregation({ limit = 250 } = {}) {
+    const url = new URL(this.globalAggregationUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle global aggregation read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
   }
 }

--- a/assets/js/modules/santis-oracle-global-context.js
+++ b/assets/js/modules/santis-oracle-global-context.js
@@ -1,0 +1,53 @@
+/**
+ * santis-oracle-global-context.js
+ * Network-level Oracle context for cross-node aggregation.
+ */
+export class SantisOracleGlobalContext {
+  constructor({
+    storageKey = 'santis_oracle_global_context_v1',
+    defaults = {},
+  } = {}) {
+    this.storageKey = storageKey;
+    this.defaults = {
+      networkId: 'santis-global',
+      homeNodeId: 'budva-primary',
+      launchNodeIds: ['dubai-launch', 'partner-spa-network'],
+      ...defaults,
+    };
+  }
+
+  resolve() {
+    return {
+      ...this.defaults,
+      ...this.readDomContext(),
+      ...this.readStoredContext(),
+    };
+  }
+
+  readStoredContext() {
+    try {
+      const raw = window.localStorage?.getItem(this.storageKey);
+      return raw ? JSON.parse(raw) : {};
+    } catch (error) {
+      console.warn('[Oracle Global Context] Failed to read stored context.', error);
+      return {};
+    }
+  }
+
+  readDomContext() {
+    const dataset = document.documentElement?.dataset || {};
+
+    return {
+      ...(dataset.oracleNetworkId ? { networkId: dataset.oracleNetworkId } : {}),
+      ...(dataset.oracleHomeNodeId ? { homeNodeId: dataset.oracleHomeNodeId } : {}),
+      ...(dataset.oracleLaunchNodes ? { launchNodeIds: this.parseNodeList(dataset.oracleLaunchNodes) } : {}),
+    };
+  }
+
+  parseNodeList(value) {
+    return String(value)
+      .split(',')
+      .map((nodeId) => nodeId.trim())
+      .filter(Boolean);
+  }
+}

--- a/assets/js/modules/santis-oracle-global-executive-view.js
+++ b/assets/js/modules/santis-oracle-global-executive-view.js
@@ -1,0 +1,114 @@
+/**
+ * santis-oracle-global-executive-view.js
+ * Read-only Global Oracle aggregation view for the Boardroom.
+ */
+import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
+import { SantisOracleGlobalContext } from './santis-oracle-global-context.js';
+
+export class SantisOracleGlobalExecutiveView {
+  constructor({
+    container = document.getElementById('oracle-global-executive-view-container'),
+    client = new SantisOracleActionMemoryClient(),
+    globalContext = new SantisOracleGlobalContext(),
+    limit = 250,
+  } = {}) {
+    this.container = container;
+    this.client = client;
+    this.globalContext = globalContext;
+    this.limit = limit;
+    this.refresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.refresh();
+    window.addEventListener('santis:oracle:action-memory:synced', this.refresh);
+    window.addEventListener('santis:oracle:action-memory:hydrated', this.refresh);
+  }
+
+  async refresh() {
+    if (!this.container) return;
+
+    try {
+      const data = await this.client.readGlobalAggregation({ limit: this.limit });
+      this.render(data);
+    } catch (error) {
+      console.warn('[Oracle Global Executive View] Failed to read global aggregation.', error);
+      this.renderUnavailable();
+    }
+  }
+
+  render(data) {
+    const context = this.globalContext.resolve();
+    const signals = Array.isArray(data?.signals) ? data.signals.slice(0, 3) : [];
+
+    this.container.innerHTML = `
+      <div class="oracle-executive-brief">
+        <div class="oracle-executive-kicker">Global aggregation - ${this.escapeHtml(context.networkId)}</div>
+        <p>${this.escapeHtml(this.resolveNarrative(data, context))}</p>
+      </div>
+      <div class="oracle-executive-grid">
+        <div class="oracle-executive-panel">
+          <h3>Network Signals</h3>
+          ${signals.map((signal) => this.renderSignal(signal)).join('')}
+        </div>
+        <div class="oracle-executive-panel">
+          <h3>Cross-node Readiness</h3>
+          ${this.renderMetricCard('Nodes', data?.nodeCount ?? 0, 'Tagged Oracle memory sources')}
+          ${this.renderMetricCard('Global Approval', `${data?.globalApprovalRate ?? 0}%`, 'Approved decision density')}
+          ${this.renderMetricCard('Escalation', `${data?.globalEscalationRate ?? 0}%`, 'Human risk review pressure')}
+        </div>
+      </div>
+    `;
+  }
+
+  resolveNarrative(data, context) {
+    if (!data || !data.decisionCount) {
+      return 'Global Oracle aggregation is standing by. Human decisions will become cross-node learning signals as node-tagged memory grows.';
+    }
+
+    if (data.topApprovalNode && data.leadingAction) {
+      const node = data.topApprovalNode.node;
+      return `${node.location} node is leading network approval momentum at ${data.globalApprovalRate}%. Prioritize "${data.leadingAction}" as a controlled candidate for ${context.launchNodeIds.join(', ')}.`;
+    }
+
+    return data.crossNodeRecommendation || 'Keep collecting node-scoped decisions before promoting global strategy.';
+  }
+
+  renderSignal(signal) {
+    return `
+      <div class="oracle-strategic-alert">
+        <strong>${this.escapeHtml(signal.title)}</strong>
+        <p>${this.escapeHtml(signal.detail)}</p>
+        <span>${Number(signal.confidence || 0)}% global confidence</span>
+      </div>
+    `;
+  }
+
+  renderMetricCard(label, value, detail) {
+    return `
+      <div class="oracle-playbook-card">
+        <strong>${this.escapeHtml(label)} - ${this.escapeHtml(String(value))}</strong>
+        <p>${this.escapeHtml(detail)}</p>
+      </div>
+    `;
+  }
+
+  renderUnavailable() {
+    this.container.innerHTML = `
+      <div class="oracle-executive-empty">
+        Global Oracle aggregation is unavailable. Local HACI memory remains active.
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -55,6 +55,16 @@
         </div>
       </section>
 
+      <section class="santis-boardroom-executive-mode">
+        <div class="log-header">
+          <h2>Global Intelligence</h2>
+          <span class="ai-badge">Network</span>
+        </div>
+        <div class="oracle-executive-mode" id="oracle-global-executive-view-container">
+          <div class="oracle-executive-empty">Awaiting global Oracle aggregation.</div>
+        </div>
+      </section>
+
       <div class="santis-boardroom-pro-grid">
         <section class="santis-boardroom-oracle">
           <div class="log-header">


### PR DESCRIPTION
## Summary

Adds Oracle global aggregation foundation for cross-node intelligence and global executive visibility.

## Scope

- Adds server-side global aggregation contract, store, and routes
- Adds GET /api/v1/oracle/global-aggregation
- Adds Boardroom Global Intelligence panel
- Adds global context and global executive view frontend modules
- Adds global aggregation read support to the action memory client

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- git diff --check passed

## Notes

This moves Santis OS from node-scoped Oracle intelligence toward network-level aggregation across Budva, Dubai, and future partner nodes.