### PR TITLE
feat: add Oracle cross-node learning foundation

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -21,6 +21,7 @@ import { boardroomRouter } from "./routes/boardroom";
 import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
 import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
 import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregation.routes";
+import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learning.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -136,6 +137,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleActionMemoryRouter);
   app.use("/api/v1/oracle", oracleNodeSyncRouter);
   app.use("/api/v1/oracle", oracleGlobalAggregationRouter);
+  app.use("/api/v1/oracle", oracleCrossNodeLearningRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-cross-node-learning.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-cross-node-learning.contract.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const OracleCrossNodePatternSchema = z.object({
+  patternId: z.string().min(1),
+  sourceNodeId: z.string().min(1),
+  sourceNodeCode: z.string().min(1),
+  suggestedAction: z.string().min(1),
+  approvalRate: z.number().min(0).max(100),
+  sampleSize: z.number().int().nonnegative(),
+  evidence: z.array(z.string()),
+});
+
+export const OracleLearningTransferSchema = z.object({
+  transferId: z.string().min(1),
+  patternId: z.string().min(1),
+  targetNodeId: z.string().min(1),
+  targetNodeRole: z.enum(["primary", "partner", "future"]),
+  contextFit: z.number().min(0).max(100),
+  baseConfidence: z.number().min(0).max(100),
+  adjustedConfidence: z.number().min(0).max(100),
+  riskBoundary: z.enum(["low", "medium", "high"]),
+  recommendation: z.string().min(1),
+});
+
+export const OracleCrossNodeLearningSchema = z.object({
+  patternCount: z.number().int().nonnegative(),
+  transferCount: z.number().int().nonnegative(),
+  globalCalibration: z.object({
+    approvalRate: z.number().min(0).max(100),
+    escalationRate: z.number().min(0).max(100),
+    confidenceFloor: z.number().min(0).max(100),
+    confidenceCeiling: z.number().min(0).max(100),
+  }),
+  patterns: z.array(OracleCrossNodePatternSchema),
+  transfers: z.array(OracleLearningTransferSchema),
+  networkStrategy: z.string().min(1),
+});
+
+export const OracleCrossNodeLearningResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleCrossNodeLearningSchema,
+});
+
+export type OracleCrossNodePattern = z.infer<typeof OracleCrossNodePatternSchema>;
+export type OracleLearningTransfer = z.infer<typeof OracleLearningTransferSchema>;
+export type OracleCrossNodeLearning = z.infer<typeof OracleCrossNodeLearningSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-cross-node-learning.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-cross-node-learning.routes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from "express";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+import { oracleCrossNodeLearningStore } from "./oracle-cross-node-learning.store.js";
+
+export const oracleCrossNodeLearningRouter = Router();
+
+oracleCrossNodeLearningRouter.get("/cross-node-learning", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 250);
+  const records = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 250);
+  const data = oracleCrossNodeLearningStore.evaluate(records);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-cross-node-learning.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-cross-node-learning.store.ts
@@ -1,0 +1,209 @@
+import {
+  DefaultOracleNodeContext,
+} from "./oracle-action-memory.contract.js";
+import { oracleGlobalAggregationStore } from "./oracle-global-aggregation.store.js";
+import type { OracleActionMemoryRecord } from "./oracle-action-memory.contract.js";
+import type { OracleNodeContext } from "./oracle-node.contract.js";
+import type {
+  OracleCrossNodeLearning,
+  OracleCrossNodePattern,
+  OracleLearningTransfer,
+} from "./oracle-cross-node-learning.contract.js";
+
+type PatternBucket = {
+  sourceNode: OracleNodeContext;
+  suggestedAction: string;
+  records: OracleActionMemoryRecord[];
+  approvedCount: number;
+};
+
+export class OracleCrossNodeLearningStore {
+  evaluate(records: OracleActionMemoryRecord[]): OracleCrossNodeLearning {
+    const aggregation = oracleGlobalAggregationStore.aggregate(records);
+    const patterns = this.detectPatterns(records);
+    const targetNodes = this.resolveTargetNodes(records);
+    const transfers = patterns.flatMap((pattern) =>
+      targetNodes
+        .filter((targetNode) => targetNode.nodeId !== pattern.sourceNodeId)
+        .map((targetNode) => this.createTransfer(pattern, targetNode, aggregation.globalEscalationRate))
+    );
+
+    return {
+      patternCount: patterns.length,
+      transferCount: transfers.length,
+      globalCalibration: {
+        approvalRate: aggregation.globalApprovalRate,
+        escalationRate: aggregation.globalEscalationRate,
+        confidenceFloor: aggregation.globalEscalationRate >= 30 ? 45 : 55,
+        confidenceCeiling: aggregation.globalEscalationRate >= 30 ? 82 : 92,
+      },
+      patterns,
+      transfers: transfers.slice(0, 6),
+      networkStrategy: this.buildNetworkStrategy(patterns, transfers, aggregation.globalEscalationRate),
+    };
+  }
+
+  detectPatterns(records: OracleActionMemoryRecord[]): OracleCrossNodePattern[] {
+    const buckets = new Map<string, PatternBucket>();
+
+    records.forEach((record) => {
+      const node = record.node || DefaultOracleNodeContext;
+      const key = `${node.nodeId}:${record.suggestedAction}`;
+      const bucket = buckets.get(key) || {
+        sourceNode: node,
+        suggestedAction: record.suggestedAction,
+        records: [],
+        approvedCount: 0,
+      };
+
+      bucket.records.push(record);
+      if (record.decision === "approved") bucket.approvedCount += 1;
+      buckets.set(key, bucket);
+    });
+
+    return Array.from(buckets.values())
+      .map((bucket) => {
+        const approvalRate = this.toPercentage(bucket.approvedCount, bucket.records.length);
+
+        return {
+          patternId: this.createPatternId(bucket.sourceNode.nodeId, bucket.suggestedAction),
+          sourceNodeId: bucket.sourceNode.nodeId,
+          sourceNodeCode: bucket.sourceNode.nodeCode,
+          suggestedAction: bucket.suggestedAction,
+          approvalRate,
+          sampleSize: bucket.records.length,
+          evidence: this.resolveEvidence(bucket.records),
+        };
+      })
+      .filter((pattern) => pattern.approvalRate >= 50 && pattern.sampleSize >= 1)
+      .sort((a, b) => b.approvalRate - a.approvalRate || b.sampleSize - a.sampleSize)
+      .slice(0, 5);
+  }
+
+  createTransfer(
+    pattern: OracleCrossNodePattern,
+    targetNode: OracleNodeContext,
+    globalEscalationRate: number,
+  ): OracleLearningTransfer {
+    const contextFit = this.resolveContextFit(targetNode, pattern);
+    const riskBoundary = this.resolveRiskBoundary(globalEscalationRate, contextFit);
+    const riskPenalty = riskBoundary === "high" ? 18 : riskBoundary === "medium" ? 10 : 4;
+    const adjustedConfidence = this.clamp(
+      Math.round((pattern.approvalRate * contextFit) / 100 - riskPenalty),
+      globalEscalationRate >= 30 ? 45 : 55,
+      globalEscalationRate >= 30 ? 82 : 92,
+    );
+
+    return {
+      transferId: `${pattern.patternId}->${targetNode.nodeId}`,
+      patternId: pattern.patternId,
+      targetNodeId: targetNode.nodeId,
+      targetNodeRole: targetNode.role,
+      contextFit,
+      baseConfidence: pattern.approvalRate,
+      adjustedConfidence,
+      riskBoundary,
+      recommendation: this.buildTransferRecommendation(pattern, targetNode, adjustedConfidence, riskBoundary),
+    };
+  }
+
+  resolveTargetNodes(records: OracleActionMemoryRecord[]): OracleNodeContext[] {
+    const nodes = new Map<string, OracleNodeContext>();
+    records.forEach((record) => {
+      const node = record.node || DefaultOracleNodeContext;
+      nodes.set(node.nodeId, node);
+    });
+
+    if (!nodes.has("dubai-launch")) {
+      nodes.set("dubai-launch", {
+        nodeId: "dubai-launch",
+        nodeCode: "DXB",
+        location: "Dubai",
+        region: "UAE",
+        role: "future",
+      });
+    }
+
+    if (!nodes.has("partner-spa-network")) {
+      nodes.set("partner-spa-network", {
+        nodeId: "partner-spa-network",
+        nodeCode: "PARTNER",
+        location: "Partner Spa Network",
+        region: "Global",
+        role: "partner",
+      });
+    }
+
+    return Array.from(nodes.values());
+  }
+
+  resolveContextFit(targetNode: OracleNodeContext, pattern: OracleCrossNodePattern): number {
+    let fit = targetNode.role === "future" ? 74 : 82;
+    if (targetNode.role === "partner") fit -= 6;
+    if (pattern.suggestedAction.toLowerCase().includes("concierge")) fit += 8;
+    if (pattern.suggestedAction.toLowerCase().includes("sovereign")) fit += 6;
+    return this.clamp(fit, 45, 95);
+  }
+
+  resolveRiskBoundary(globalEscalationRate: number, contextFit: number): "low" | "medium" | "high" {
+    if (globalEscalationRate >= 35 || contextFit < 58) return "high";
+    if (globalEscalationRate >= 18 || contextFit < 72) return "medium";
+    return "low";
+  }
+
+  buildTransferRecommendation(
+    pattern: OracleCrossNodePattern,
+    targetNode: OracleNodeContext,
+    adjustedConfidence: number,
+    riskBoundary: "low" | "medium" | "high",
+  ): string {
+    if (riskBoundary === "high") {
+      return `Do not auto-transfer "${pattern.suggestedAction}" to ${targetNode.location}; require local validation and HACI approval.`;
+    }
+
+    return `Transfer "${pattern.suggestedAction}" to ${targetNode.location} as a monitored recommendation with ${adjustedConfidence}% adjusted confidence.`;
+  }
+
+  buildNetworkStrategy(
+    patterns: OracleCrossNodePattern[],
+    transfers: OracleLearningTransfer[],
+    globalEscalationRate: number,
+  ): string {
+    if (patterns.length === 0) {
+      return "No cross-node pattern is strong enough yet. Continue collecting human decisions before transferring learning.";
+    }
+
+    const strongestTransfer = [...transfers].sort((a, b) => b.adjustedConfidence - a.adjustedConfidence)[0];
+    if (!strongestTransfer) {
+      return "Patterns exist, but no target node is available for contextual transfer.";
+    }
+
+    if (globalEscalationRate >= 30) {
+      return "Network learning is active, but escalation pressure requires conservative confidence ceilings and human approval gates.";
+    }
+
+    return `Use ${strongestTransfer.patternId} as the lead network learning candidate; apply context fit before node-specific strategy activation.`;
+  }
+
+  resolveEvidence(records: OracleActionMemoryRecord[]): string[] {
+    return Array.from(new Set(records.flatMap((record) => record.evidence || []))).slice(0, 3);
+  }
+
+  createPatternId(nodeId: string, suggestedAction: string): string {
+    return `${nodeId}-${suggestedAction}`
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+
+  clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+  }
+
+  toPercentage(part: number, total: number): number {
+    if (!total) return 0;
+    return Math.round((part / total) * 100);
+  }
+}
+
+export const oracleCrossNodeLearningStore = new OracleCrossNodeLearningStore();

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -7,10 +7,12 @@ export class SantisOracleActionMemoryClient {
     baseUrl = 'http://localhost:3030/api/v1/oracle/action-memory',
     nodeSyncUrl = 'http://localhost:3030/api/v1/oracle/node-sync',
     globalAggregationUrl = 'http://localhost:3030/api/v1/oracle/global-aggregation',
+    crossNodeLearningUrl = 'http://localhost:3030/api/v1/oracle/cross-node-learning',
   } = {}) {
     this.baseUrl = baseUrl;
     this.nodeSyncUrl = nodeSyncUrl;
     this.globalAggregationUrl = globalAggregationUrl;
+    this.crossNodeLearningUrl = crossNodeLearningUrl;
   }
 
   async readAll() {
@@ -74,6 +76,23 @@ export class SantisOracleActionMemoryClient {
 
     if (!response.ok) {
       throw new Error(`Oracle global aggregation read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
+  }
+
+  async readCrossNodeLearning({ limit = 250 } = {}) {
+    const url = new URL(this.crossNodeLearningUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle cross-node learning read failed: ${response.status}`);
     }
 
     const body = await response.json();

--- a/assets/js/modules/santis-oracle-cross-node-learning.js
+++ b/assets/js/modules/santis-oracle-cross-node-learning.js
@@ -1,0 +1,19 @@
+/**
+ * santis-oracle-cross-node-learning.js
+ * Read-only client wrapper for Oracle cross-node learning.
+ */
+import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
+
+export class SantisOracleCrossNodeLearning {
+  constructor({
+    client = new SantisOracleActionMemoryClient(),
+    limit = 250,
+  } = {}) {
+    this.client = client;
+    this.limit = limit;
+  }
+
+  async read() {
+    return this.client.readCrossNodeLearning({ limit: this.limit });
+  }
+}

--- a/assets/js/modules/santis-oracle-global-executive-view.js
+++ b/assets/js/modules/santis-oracle-global-executive-view.js
@@ -4,6 +4,8 @@
  */
 import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
 import { SantisOracleGlobalContext } from './santis-oracle-global-context.js';
+import { SantisOracleCrossNodeLearning } from './santis-oracle-cross-node-learning.js';
+import { SantisOracleNetworkStrategy } from './santis-oracle-network-strategy.js';
 
 export class SantisOracleGlobalExecutiveView {
   constructor({
@@ -11,10 +13,14 @@ export class SantisOracleGlobalExecutiveView {
     client = new SantisOracleActionMemoryClient(),
     globalContext = new SantisOracleGlobalContext(),
     limit = 250,
+    crossNodeLearning = new SantisOracleCrossNodeLearning({ client, limit }),
+    networkStrategy = new SantisOracleNetworkStrategy(),
   } = {}) {
     this.container = container;
     this.client = client;
     this.globalContext = globalContext;
+    this.crossNodeLearning = crossNodeLearning;
+    this.networkStrategy = networkStrategy;
     this.limit = limit;
     this.refresh = this.refresh.bind(this);
   }
@@ -31,15 +37,18 @@ export class SantisOracleGlobalExecutiveView {
     if (!this.container) return;
 
     try {
-      const data = await this.client.readGlobalAggregation({ limit: this.limit });
-      this.render(data);
+      const [data, learning] = await Promise.all([
+        this.client.readGlobalAggregation({ limit: this.limit }),
+        this.crossNodeLearning.read(),
+      ]);
+      this.render(data, learning);
     } catch (error) {
       console.warn('[Oracle Global Executive View] Failed to read global aggregation.', error);
       this.renderUnavailable();
     }
   }
 
-  render(data) {
+  render(data, learning = null) {
     const context = this.globalContext.resolve();
     const signals = Array.isArray(data?.signals) ? data.signals.slice(0, 3) : [];
 
@@ -58,6 +67,10 @@ export class SantisOracleGlobalExecutiveView {
           ${this.renderMetricCard('Nodes', data?.nodeCount ?? 0, 'Tagged Oracle memory sources')}
           ${this.renderMetricCard('Global Approval', `${data?.globalApprovalRate ?? 0}%`, 'Approved decision density')}
           ${this.renderMetricCard('Escalation', `${data?.globalEscalationRate ?? 0}%`, 'Human risk review pressure')}
+        </div>
+        <div class="oracle-executive-panel">
+          <h3>Cross-node Learning</h3>
+          ${this.renderLearningSummary(learning)}
         </div>
       </div>
     `;
@@ -91,6 +104,29 @@ export class SantisOracleGlobalExecutiveView {
       <div class="oracle-playbook-card">
         <strong>${this.escapeHtml(label)} - ${this.escapeHtml(String(value))}</strong>
         <p>${this.escapeHtml(detail)}</p>
+      </div>
+    `;
+  }
+
+  renderLearningSummary(learning) {
+    const transfers = Array.isArray(learning?.transfers) ? learning.transfers.slice(0, 3) : [];
+    const summary = this.networkStrategy.summarize(learning);
+
+    return `
+      <div class="oracle-playbook-card">
+        <strong>Network Strategy</strong>
+        <p>${this.escapeHtml(summary)}</p>
+      </div>
+      ${transfers.map((transfer) => this.renderTransfer(transfer)).join('')}
+    `;
+  }
+
+  renderTransfer(transfer) {
+    return `
+      <div class="oracle-playbook-card">
+        <strong>${this.escapeHtml(transfer.targetNodeId)} - ${Number(transfer.adjustedConfidence || 0)}%</strong>
+        <p>${this.escapeHtml(transfer.recommendation)}</p>
+        <span>${this.escapeHtml(transfer.riskBoundary)} boundary - ${Number(transfer.contextFit || 0)}% context fit</span>
       </div>
     `;
   }

--- a/assets/js/modules/santis-oracle-network-strategy.js
+++ b/assets/js/modules/santis-oracle-network-strategy.js
@@ -1,0 +1,23 @@
+/**
+ * santis-oracle-network-strategy.js
+ * Formats cross-node learning into network-level strategy copy.
+ */
+export class SantisOracleNetworkStrategy {
+  summarize(learning) {
+    if (!learning || !learning.patternCount) {
+      return 'Cross-node learning is collecting pattern density. No node-specific transfer is recommended yet.';
+    }
+
+    const transfer = this.resolveStrongestTransfer(learning);
+    if (!transfer) {
+      return learning.networkStrategy || 'Patterns exist, but no contextual transfer target is ready.';
+    }
+
+    return `${transfer.targetNodeId} can receive a context-adjusted learning transfer at ${transfer.adjustedConfidence}% confidence with ${transfer.riskBoundary} risk boundary.`;
+  }
+
+  resolveStrongestTransfer(learning) {
+    const transfers = Array.isArray(learning?.transfers) ? learning.transfers : [];
+    return [...transfers].sort((a, b) => (b.adjustedConfidence || 0) - (a.adjustedConfidence || 0))[0] || null;
+  }
+}


### PR DESCRIPTION
## Summary

Adds Oracle v2 cross-node learning foundation so global aggregation can produce transferable learning signals across operating nodes while preserving node-specific context boundaries.

## Scope

- Adds GET /api/v1/oracle/cross-node-learning
- Adds cross-node pattern detection
- Adds node-specific learning transfer
- Adds context fit, adjusted confidence, and risk boundary modeling
- Adds Cross-node Learning panel to Boardroom Global Intelligence
- Adds network strategy formatter

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- Scoped git diff --check passed

## Notes

Working tree contained unrelated local changes that were intentionally not included:

- assets/js/santis-data-bridge.js
- assets/js/sovereign-cart-ui.js