### PR TITLE
feat: add Oracle strategy simulation foundation

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -22,6 +22,7 @@ import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
 import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
 import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregation.routes";
 import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learning.routes";
+import { oracleStrategySimulationRouter } from "./oracle/oracle-strategy-simulation.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -138,6 +139,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleNodeSyncRouter);
   app.use("/api/v1/oracle", oracleGlobalAggregationRouter);
   app.use("/api/v1/oracle", oracleCrossNodeLearningRouter);
+  app.use("/api/v1/oracle", oracleStrategySimulationRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-strategy-simulation.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-strategy-simulation.contract.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const OracleStrategyScenarioSchema = z.object({
+  scenarioId: z.string().min(1),
+  label: z.string().min(1),
+  strategy: z.string().min(1),
+  targetNodeId: z.string().min(1),
+  projectedRevenueLift: z.number(),
+  projectedApprovalRate: z.number().min(0).max(100),
+  riskAdjustedConfidence: z.number().min(0).max(100),
+  riskLevel: z.enum(["low", "medium", "high"]),
+  decisionPath: z.array(z.string()),
+});
+
+export const OracleStrategySimulationSchema = z.object({
+  simulationId: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  source: z.literal("cross-node-learning"),
+  scenarioCount: z.number().int().nonnegative(),
+  recommendedScenarioId: z.string().nullable(),
+  executivePreview: z.string().min(1),
+  scenarios: z.array(OracleStrategyScenarioSchema),
+});
+
+export const OracleStrategySimulationResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleStrategySimulationSchema,
+});
+
+export type OracleStrategyScenario = z.infer<typeof OracleStrategyScenarioSchema>;
+export type OracleStrategySimulation = z.infer<typeof OracleStrategySimulationSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-strategy-simulation.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-strategy-simulation.routes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from "express";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+import { oracleStrategySimulationStore } from "./oracle-strategy-simulation.store.js";
+
+export const oracleStrategySimulationRouter = Router();
+
+oracleStrategySimulationRouter.get("/strategy-simulation", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 250);
+  const records = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 250);
+  const data = oracleStrategySimulationStore.simulate(records);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-strategy-simulation.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-strategy-simulation.store.ts
@@ -1,0 +1,136 @@
+import { oracleCrossNodeLearningStore } from "./oracle-cross-node-learning.store.js";
+import type { OracleActionMemoryRecord } from "./oracle-action-memory.contract.js";
+import type { OracleLearningTransfer } from "./oracle-cross-node-learning.contract.js";
+import type {
+  OracleStrategyScenario,
+  OracleStrategySimulation,
+} from "./oracle-strategy-simulation.contract.js";
+
+export class OracleStrategySimulationStore {
+  simulate(records: OracleActionMemoryRecord[]): OracleStrategySimulation {
+    const learning = oracleCrossNodeLearningStore.evaluate(records);
+    const bestTransfer = this.resolveBestTransfer(learning.transfers);
+    const generatedAt = new Date().toISOString();
+    const scenarios = bestTransfer ? this.buildScenarios(bestTransfer) : [];
+    const recommendedScenario = this.resolveRecommendedScenario(scenarios);
+
+    return {
+      simulationId: `oracle-simulation-${Date.parse(generatedAt)}`,
+      generatedAt,
+      source: "cross-node-learning",
+      scenarioCount: scenarios.length,
+      recommendedScenarioId: recommendedScenario?.scenarioId || null,
+      executivePreview: this.buildExecutivePreview(bestTransfer, recommendedScenario),
+      scenarios,
+    };
+  }
+
+  buildScenarios(transfer: OracleLearningTransfer): OracleStrategyScenario[] {
+    return [
+      this.createScenario({
+        mode: "conservative",
+        label: "Scenario A - Conservative transfer",
+        transfer,
+        confidenceMultiplier: 0.86,
+        revenueMultiplier: 0.7,
+        path: [
+          "Keep HACI approval as execution gate",
+          "Run one target-node validation window",
+          "Apply learning only to matching high-intent signals",
+        ],
+      }),
+      this.createScenario({
+        mode: "accelerated",
+        label: "Scenario B - Accelerated rollout",
+        transfer,
+        confidenceMultiplier: 1,
+        revenueMultiplier: 1.15,
+        path: [
+          "Surface the strategy in Executive Mode",
+          "Prioritize qualified VIP and Sovereign signals",
+          "Review escalations before any operational activation",
+        ],
+      }),
+    ];
+  }
+
+  createScenario({
+    mode,
+    label,
+    transfer,
+    confidenceMultiplier,
+    revenueMultiplier,
+    path,
+  }: {
+    mode: "conservative" | "accelerated";
+    label: string;
+    transfer: OracleLearningTransfer;
+    confidenceMultiplier: number;
+    revenueMultiplier: number;
+    path: string[];
+  }): OracleStrategyScenario {
+    const riskLevel = this.resolveRiskLevel(transfer, mode);
+    const riskPenalty = riskLevel === "high" ? 18 : riskLevel === "medium" ? 9 : 3;
+    const riskAdjustedConfidence = this.clamp(
+      Math.round(transfer.adjustedConfidence * confidenceMultiplier - riskPenalty),
+      0,
+      100,
+    );
+    const projectedApprovalRate = this.clamp(
+      Math.round((transfer.baseConfidence + riskAdjustedConfidence) / 2),
+      0,
+      100,
+    );
+
+    return {
+      scenarioId: `${transfer.transferId}-${mode}`,
+      label,
+      strategy: transfer.recommendation,
+      targetNodeId: transfer.targetNodeId,
+      projectedRevenueLift: this.resolveRevenueLift(riskAdjustedConfidence, revenueMultiplier),
+      projectedApprovalRate,
+      riskAdjustedConfidence,
+      riskLevel,
+      decisionPath: path,
+    };
+  }
+
+  resolveBestTransfer(transfers: OracleLearningTransfer[]): OracleLearningTransfer | null {
+    return [...transfers]
+      .sort((a, b) => b.adjustedConfidence - a.adjustedConfidence || b.contextFit - a.contextFit)[0] || null;
+  }
+
+  resolveRecommendedScenario(scenarios: OracleStrategyScenario[]): OracleStrategyScenario | null {
+    return [...scenarios]
+      .filter((scenario) => scenario.riskLevel !== "high")
+      .sort((a, b) => b.riskAdjustedConfidence - a.riskAdjustedConfidence)[0] || null;
+  }
+
+  resolveRiskLevel(transfer: OracleLearningTransfer, mode: "conservative" | "accelerated"): "low" | "medium" | "high" {
+    if (transfer.riskBoundary === "high") return "high";
+    if (mode === "accelerated" && transfer.riskBoundary === "medium") return "high";
+    if (mode === "accelerated") return "medium";
+    return transfer.riskBoundary;
+  }
+
+  resolveRevenueLift(riskAdjustedConfidence: number, multiplier: number): number {
+    return Math.round((riskAdjustedConfidence / 100) * 18 * multiplier);
+  }
+
+  buildExecutivePreview(
+    transfer: OracleLearningTransfer | null,
+    recommendedScenario: OracleStrategyScenario | null,
+  ): string {
+    if (!transfer || !recommendedScenario) {
+      return "No strategy simulation is ready yet. Cross-node learning needs a transferable pattern before scenario projection.";
+    }
+
+    return `${recommendedScenario.label} is the recommended preview for ${transfer.targetNodeId}: ${recommendedScenario.projectedRevenueLift}% projected revenue lift at ${recommendedScenario.riskAdjustedConfidence}% risk-adjusted confidence. Human approval remains required before action.`;
+  }
+
+  clamp(value: number, min: number, max: number): number {
+    return Math.min(max, Math.max(min, value));
+  }
+}
+
+export const oracleStrategySimulationStore = new OracleStrategySimulationStore();

--- a/assets/css/modules/santis-oracle-simulation-panel.css
+++ b/assets/css/modules/santis-oracle-simulation-panel.css
@@ -1,0 +1,130 @@
+/*
+  Santis Oracle Strategy Simulation Panel
+  Read-only executive preview for scenario outcome projection.
+*/
+
+.santis-boardroom-simulation {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-simulation-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.oracle-simulation-brief {
+  padding: 18px;
+  border-left: 2px solid var(--boardroom-accent);
+  border-radius: 4px;
+  background: rgba(212, 175, 55, 0.055);
+}
+
+.oracle-simulation-brief span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--boardroom-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oracle-simulation-brief p {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.oracle-simulation-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.oracle-simulation-card {
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.oracle-simulation-card-recommended {
+  border-color: rgba(212, 175, 55, 0.42);
+}
+
+.oracle-simulation-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.oracle-simulation-card-header strong {
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.oracle-simulation-card-header span {
+  color: var(--boardroom-accent);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-simulation-card p,
+.oracle-simulation-card li,
+.oracle-simulation-empty {
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.oracle-simulation-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.oracle-simulation-metrics div {
+  padding: 10px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.oracle-simulation-metrics span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--boardroom-text-muted);
+  font-size: 10px;
+}
+
+.oracle-simulation-metrics strong {
+  color: #fff;
+  font-size: 14px;
+}
+
+.oracle-simulation-card ol {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.oracle-simulation-empty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .oracle-simulation-grid,
+  .oracle-simulation-metrics {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -9,6 +9,7 @@ import { SantisOracleActionRail } from './santis-oracle-action-rail.js';
 import { SantisOracleHumanApprovalLoop } from './santis-oracle-human-approval-loop.js';
 import { SantisOracleExecutiveNarrative } from './santis-oracle-executive-narrative.js';
 import { SantisOracleGlobalExecutiveView } from './santis-oracle-global-executive-view.js';
+import { SantisOracleSimulationPanel } from './santis-oracle-simulation-panel.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -19,6 +20,7 @@ class BoardroomOracleV2 {
     this.actionRail = new SantisOracleActionRail();
     this.executiveNarrative = new SantisOracleExecutiveNarrative();
     this.globalExecutiveView = new SantisOracleGlobalExecutiveView();
+    this.simulationPanel = new SantisOracleSimulationPanel();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -27,6 +29,7 @@ class BoardroomOracleV2 {
   init() {
     if (!this.container) return;
     this.globalExecutiveView.init();
+    this.simulationPanel.init();
     
     // Initial state
     this.container.innerHTML = `

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -8,11 +8,13 @@ export class SantisOracleActionMemoryClient {
     nodeSyncUrl = 'http://localhost:3030/api/v1/oracle/node-sync',
     globalAggregationUrl = 'http://localhost:3030/api/v1/oracle/global-aggregation',
     crossNodeLearningUrl = 'http://localhost:3030/api/v1/oracle/cross-node-learning',
+    strategySimulationUrl = 'http://localhost:3030/api/v1/oracle/strategy-simulation',
   } = {}) {
     this.baseUrl = baseUrl;
     this.nodeSyncUrl = nodeSyncUrl;
     this.globalAggregationUrl = globalAggregationUrl;
     this.crossNodeLearningUrl = crossNodeLearningUrl;
+    this.strategySimulationUrl = strategySimulationUrl;
   }
 
   async readAll() {
@@ -93,6 +95,23 @@ export class SantisOracleActionMemoryClient {
 
     if (!response.ok) {
       throw new Error(`Oracle cross-node learning read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
+  }
+
+  async readStrategySimulation({ limit = 250 } = {}) {
+    const url = new URL(this.strategySimulationUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle strategy simulation read failed: ${response.status}`);
     }
 
     const body = await response.json();

--- a/assets/js/modules/santis-oracle-simulation-panel.js
+++ b/assets/js/modules/santis-oracle-simulation-panel.js
@@ -1,0 +1,106 @@
+/**
+ * santis-oracle-simulation-panel.js
+ * Executive decision preview for risk-adjusted Oracle strategy simulations.
+ */
+import { SantisOracleStrategySimulator } from './santis-oracle-strategy-simulator.js';
+
+export class SantisOracleSimulationPanel {
+  constructor({
+    container = document.getElementById('oracle-strategy-simulation-container'),
+    simulator = new SantisOracleStrategySimulator(),
+  } = {}) {
+    this.container = container;
+    this.simulator = simulator;
+    this.refresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.refresh();
+    window.addEventListener('santis:oracle:action-memory:synced', this.refresh);
+    window.addEventListener('santis:oracle:action-memory:hydrated', this.refresh);
+  }
+
+  async refresh() {
+    if (!this.container) return;
+
+    try {
+      const simulation = await this.simulator.read();
+      this.render(simulation);
+    } catch (error) {
+      console.warn('[Oracle Simulation Panel] Failed to read strategy simulation.', error);
+      this.renderUnavailable();
+    }
+  }
+
+  render(simulation) {
+    const scenarios = Array.isArray(simulation?.scenarios) ? simulation.scenarios.slice(0, 2) : [];
+
+    this.container.innerHTML = `
+      <div class="oracle-simulation-brief">
+        <span>Executive Decision Preview</span>
+        <p>${this.escapeHtml(this.resolvePreview(simulation))}</p>
+      </div>
+      <div class="oracle-simulation-grid">
+        ${scenarios.map((scenario) => this.renderScenario(scenario, simulation?.recommendedScenarioId)).join('')}
+      </div>
+    `;
+  }
+
+  resolvePreview(simulation) {
+    if (!simulation || !simulation.scenarioCount) {
+      return 'Strategy simulation is standing by. Cross-node learning needs a transferable pattern before outcome projection.';
+    }
+
+    return simulation.executivePreview;
+  }
+
+  renderScenario(scenario, recommendedScenarioId) {
+    const isRecommended = scenario.scenarioId === recommendedScenarioId;
+
+    return `
+      <article class="oracle-simulation-card ${isRecommended ? 'oracle-simulation-card-recommended' : ''}">
+        <div class="oracle-simulation-card-header">
+          <strong>${this.escapeHtml(scenario.label)}</strong>
+          <span>${isRecommended ? 'Recommended' : this.escapeHtml(scenario.riskLevel)}</span>
+        </div>
+        <p>${this.escapeHtml(scenario.strategy)}</p>
+        <div class="oracle-simulation-metrics">
+          ${this.renderMetric('Revenue lift', `${Number(scenario.projectedRevenueLift || 0)}%`)}
+          ${this.renderMetric('Approval', `${Number(scenario.projectedApprovalRate || 0)}%`)}
+          ${this.renderMetric('Risk confidence', `${Number(scenario.riskAdjustedConfidence || 0)}%`)}
+        </div>
+        <ol>
+          ${(scenario.decisionPath || []).map((step) => `<li>${this.escapeHtml(step)}</li>`).join('')}
+        </ol>
+      </article>
+    `;
+  }
+
+  renderMetric(label, value) {
+    return `
+      <div>
+        <span>${this.escapeHtml(label)}</span>
+        <strong>${this.escapeHtml(value)}</strong>
+      </div>
+    `;
+  }
+
+  renderUnavailable() {
+    this.container.innerHTML = `
+      <div class="oracle-simulation-empty">
+        Strategy simulation is unavailable. Human approval gates remain active.
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/assets/js/modules/santis-oracle-strategy-simulator.js
+++ b/assets/js/modules/santis-oracle-strategy-simulator.js
@@ -1,0 +1,19 @@
+/**
+ * santis-oracle-strategy-simulator.js
+ * Read-only client wrapper for Oracle strategy simulation.
+ */
+import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
+
+export class SantisOracleStrategySimulator {
+  constructor({
+    client = new SantisOracleActionMemoryClient(),
+    limit = 250,
+  } = {}) {
+    this.client = client;
+    this.limit = limit;
+  }
+
+  async read() {
+    return this.client.readStrategySimulation({ limit: this.limit });
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-human-approval-loop.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-learning-loop.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-executive-mode.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-simulation-panel.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -62,6 +63,16 @@
         </div>
         <div class="oracle-executive-mode" id="oracle-global-executive-view-container">
           <div class="oracle-executive-empty">Awaiting global Oracle aggregation.</div>
+        </div>
+      </section>
+
+      <section class="santis-boardroom-simulation">
+        <div class="log-header">
+          <h2>Strategy Simulation</h2>
+          <span class="ai-badge">Preview</span>
+        </div>
+        <div class="oracle-simulation-panel" id="oracle-strategy-simulation-container">
+          <div class="oracle-simulation-empty">Awaiting cross-node strategy simulation.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds Oracle v2 strategy simulation foundation so executive recommendations can be compared through scenario projections before human approval.

## Scope

- Adds GET /api/v1/oracle/strategy-simulation
- Adds cross-node-learning-based Scenario A/B projection
- Adds revenue lift forecast
- Adds risk-adjusted confidence
- Adds executive decision preview
- Adds Boardroom Strategy Simulation panel and styling

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- git diff --check passed

## Governance

Simulation is advisory only. No auto-apply behavior is introduced; human approval remains the decision gate.