### PR TITLE
fix: harden sovereign bus error handling

### DIFF
--- a/assets/js/sovereign-bus.js
+++ b/assets/js/sovereign-bus.js
@@ -144,7 +144,22 @@
                 this._scheduleReconnect();
             };
 
-            this._ws.onerror = () => {};
+            this._ws.onerror = (event) => {
+                this._handleSocketError(event);
+            };
+        },
+
+        _handleSocketError(event) {
+            const payload = {
+                type: 'bus:error',
+                readyState: this._ws ? this._ws.readyState : null,
+                reconnectAttempts: this._reconnectAttempts,
+                timestamp: new Date().toISOString()
+            };
+
+            console.warn('[Sovereign Bus] WebSocket error detected.', payload, event);
+            this._dispatch(payload);
+            window.dispatchEvent(new CustomEvent('santis:sovereign-bus:error', { detail: payload }));
         },
 
         /** Tip bazlı mesaj dağıtımı */


### PR DESCRIPTION
## Summary

Hardens Sovereign Bus WebSocket error handling so runtime connection failures are observable instead of being silently swallowed.

## Scope

- Replaces empty WebSocket `onerror` handler
- Emits a visible `console.warn` diagnostic
- Dispatches an internal `bus:error` event
- Publishes a window-level `santis:sovereign-bus:error` event for UI/runtime observers

## Validation

- `node --check assets/js/sovereign-bus.js`
- `pnpm test:quality:static`
- `git diff --check`