### PR TITLE
feat: add guarded Oracle execution planning

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -23,6 +23,7 @@ import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
 import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregation.routes";
 import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learning.routes";
 import { oracleStrategySimulationRouter } from "./oracle/oracle-strategy-simulation.routes";
+import { oracleExecutionGuardRouter } from "./oracle/oracle-execution-guard.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -140,6 +141,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleGlobalAggregationRouter);
   app.use("/api/v1/oracle", oracleCrossNodeLearningRouter);
   app.use("/api/v1/oracle", oracleStrategySimulationRouter);
+  app.use("/api/v1/oracle", oracleExecutionGuardRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-execution-guard.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-guard.contract.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+
+export const OracleExecutionGuardrailSchema = z.object({
+  key: z.string().min(1),
+  label: z.string().min(1),
+  passed: z.boolean(),
+  actual: z.union([z.string(), z.number(), z.boolean()]),
+  threshold: z.union([z.string(), z.number(), z.boolean()]),
+  severity: z.enum(["info", "warning", "blocking"]),
+});
+
+export const OracleExecutionStepSchema = z.object({
+  stepId: z.string().min(1),
+  label: z.string().min(1),
+  detail: z.string().min(1),
+  status: z.literal("proposed"),
+});
+
+export const OracleExecutionPlanSchema = z.object({
+  planId: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  source: z.literal("strategy-simulation"),
+  status: z.enum(["awaiting_signal", "not_recommended", "human_approval_required"]),
+  executable: z.boolean(),
+  scenarioId: z.string().nullable(),
+  targetNodeId: z.string().nullable(),
+  rationale: z.string().min(1),
+  guardrails: z.array(OracleExecutionGuardrailSchema),
+  steps: z.array(OracleExecutionStepSchema),
+});
+
+export const OracleExecutionGuardResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleExecutionPlanSchema,
+});
+
+export type OracleExecutionGuardrail = z.infer<typeof OracleExecutionGuardrailSchema>;
+export type OracleExecutionStep = z.infer<typeof OracleExecutionStepSchema>;
+export type OracleExecutionPlan = z.infer<typeof OracleExecutionPlanSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-execution-guard.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-guard.routes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from "express";
+import { oracleActionMemoryStore } from "./oracle-action-memory.store.js";
+import { oracleExecutionGuardStore } from "./oracle-execution-guard.store.js";
+
+export const oracleExecutionGuardRouter = Router();
+
+oracleExecutionGuardRouter.get("/execution-guard", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 250);
+  const records = await oracleActionMemoryStore.replay(Number.isFinite(limit) ? limit : 250);
+  const data = oracleExecutionGuardStore.evaluate(records);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-execution-guard.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-guard.store.ts
@@ -1,0 +1,137 @@
+import { oracleStrategySimulationStore } from "./oracle-strategy-simulation.store.js";
+import type { OracleActionMemoryRecord } from "./oracle-action-memory.contract.js";
+import type { OracleStrategyScenario } from "./oracle-strategy-simulation.contract.js";
+import type {
+  OracleExecutionGuardrail,
+  OracleExecutionPlan,
+  OracleExecutionStep,
+} from "./oracle-execution-guard.contract.js";
+
+export class OracleExecutionGuardStore {
+  evaluate(records: OracleActionMemoryRecord[]): OracleExecutionPlan {
+    const simulation = oracleStrategySimulationStore.simulate(records);
+    const scenario = this.resolveRecommendedScenario(simulation.scenarios, simulation.recommendedScenarioId);
+    const generatedAt = new Date().toISOString();
+
+    if (!scenario) {
+      return {
+        planId: `oracle-execution-plan-${Date.parse(generatedAt)}`,
+        generatedAt,
+        source: "strategy-simulation",
+        status: "awaiting_signal",
+        executable: false,
+        scenarioId: null,
+        targetNodeId: null,
+        rationale: "No strategy scenario is strong enough for guarded execution planning yet.",
+        guardrails: [],
+        steps: [],
+      };
+    }
+
+    const guardrails = this.buildGuardrails(scenario);
+    const executable = guardrails.every((guardrail) => guardrail.passed || guardrail.severity !== "blocking");
+
+    return {
+      planId: `oracle-execution-plan-${Date.parse(generatedAt)}`,
+      generatedAt,
+      source: "strategy-simulation",
+      status: executable ? "human_approval_required" : "not_recommended",
+      executable,
+      scenarioId: scenario.scenarioId,
+      targetNodeId: scenario.targetNodeId,
+      rationale: this.buildRationale(scenario, executable),
+      guardrails,
+      steps: executable ? this.buildSteps(scenario) : [],
+    };
+  }
+
+  resolveRecommendedScenario(
+    scenarios: OracleStrategyScenario[],
+    recommendedScenarioId: string | null,
+  ): OracleStrategyScenario | null {
+    return scenarios.find((scenario) => scenario.scenarioId === recommendedScenarioId)
+      || [...scenarios].sort((a, b) => b.riskAdjustedConfidence - a.riskAdjustedConfidence)[0]
+      || null;
+  }
+
+  buildGuardrails(scenario: OracleStrategyScenario): OracleExecutionGuardrail[] {
+    const vipThresholdPassed = this.hasVipIntentSignal(scenario);
+
+    return [
+      {
+        key: "confidence",
+        label: "Risk-adjusted confidence",
+        passed: scenario.riskAdjustedConfidence >= 85,
+        actual: scenario.riskAdjustedConfidence,
+        threshold: 85,
+        severity: "blocking",
+      },
+      {
+        key: "risk",
+        label: "Risk boundary",
+        passed: scenario.riskLevel === "low" || scenario.riskLevel === "medium",
+        actual: scenario.riskLevel,
+        threshold: "low_or_medium",
+        severity: "blocking",
+      },
+      {
+        key: "revenue",
+        label: "Forecast direction",
+        passed: scenario.projectedRevenueLift > 0,
+        actual: scenario.projectedRevenueLift,
+        threshold: "> 0",
+        severity: "blocking",
+      },
+      {
+        key: "vip_threshold",
+        label: "VIP or high-intent threshold",
+        passed: vipThresholdPassed,
+        actual: vipThresholdPassed,
+        threshold: true,
+        severity: "blocking",
+      },
+    ];
+  }
+
+  buildSteps(scenario: OracleStrategyScenario): OracleExecutionStep[] {
+    return [
+      {
+        stepId: "sovereign-concierge-follow-up",
+        label: "Start Sovereign Concierge follow-up",
+        detail: `Route ${scenario.targetNodeId} high-intent leads to human Concierge review before outreach.`,
+        status: "proposed",
+      },
+      {
+        stepId: "promote-high-value-ritual",
+        label: "Promote high-value ritual card",
+        detail: "Prioritize the strongest Sovereign or VIP ritual in the next Boardroom-approved content window.",
+        status: "proposed",
+      },
+      {
+        stepId: "reduce-low-value-upsell",
+        label: "Reduce low-value upsell exposure",
+        detail: "De-emphasize low-value upsell prompts while the high-confidence strategy window is active.",
+        status: "proposed",
+      },
+    ];
+  }
+
+  buildRationale(scenario: OracleStrategyScenario, executable: boolean): string {
+    if (!executable) {
+      return `Scenario ${scenario.label} is not ready for execution planning. Guardrails require confidence >= 85, low/medium risk, positive forecast, and VIP or high-intent signal.`;
+    }
+
+    return `Scenario ${scenario.label} passed guarded planning with ${scenario.riskAdjustedConfidence}% confidence and ${scenario.projectedRevenueLift}% projected revenue lift. Human approval is required before any operational action.`;
+  }
+
+  hasVipIntentSignal(scenario: OracleStrategyScenario): boolean {
+    const signalText = `${scenario.strategy} ${scenario.decisionPath.join(" ")}`.toLowerCase();
+    return scenario.projectedApprovalRate >= 70
+      || signalText.includes("vip")
+      || signalText.includes("sovereign")
+      || signalText.includes("concierge")
+      || signalText.includes("high-intent");
+  }
+}
+
+export const oracleExecutionGuardStore = new OracleExecutionGuardStore();

--- a/assets/css/modules/santis-oracle-execution-plan-panel.css
+++ b/assets/css/modules/santis-oracle-execution-plan-panel.css
@@ -1,0 +1,126 @@
+/*
+  Santis Oracle Execution Plan Panel
+  Guarded, read-only execution planning. Human approval remains mandatory.
+*/
+
+.santis-boardroom-execution-plan {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-execution-plan {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.oracle-execution-brief {
+  padding: 18px;
+  border-left: 2px solid var(--boardroom-accent);
+  border-radius: 4px;
+  background: rgba(212, 175, 55, 0.055);
+}
+
+.oracle-execution-brief span,
+.oracle-execution-human-gate {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--boardroom-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oracle-execution-brief p,
+.oracle-guardrail p,
+.oracle-execution-steps p,
+.oracle-execution-empty {
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.oracle-execution-brief p {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.oracle-execution-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.oracle-execution-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.oracle-execution-panel h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-guardrail,
+.oracle-execution-steps li {
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 2px solid #8b7355;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.oracle-guardrail-pass {
+  border-left-color: #7fbc8c;
+}
+
+.oracle-guardrail-block {
+  border-left-color: #c57f7f;
+}
+
+.oracle-guardrail strong,
+.oracle-execution-steps strong {
+  color: #fff;
+  font-size: 13px;
+}
+
+.oracle-guardrail p,
+.oracle-execution-steps p {
+  margin: 8px 0 0;
+}
+
+.oracle-execution-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style-position: inside;
+}
+
+.oracle-execution-human-gate {
+  margin: 4px 0 0;
+}
+
+.oracle-execution-empty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .oracle-execution-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -10,6 +10,7 @@ import { SantisOracleHumanApprovalLoop } from './santis-oracle-human-approval-lo
 import { SantisOracleExecutiveNarrative } from './santis-oracle-executive-narrative.js';
 import { SantisOracleGlobalExecutiveView } from './santis-oracle-global-executive-view.js';
 import { SantisOracleSimulationPanel } from './santis-oracle-simulation-panel.js';
+import { SantisOracleExecutionPlanPanel } from './santis-oracle-execution-plan-panel.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -21,6 +22,7 @@ class BoardroomOracleV2 {
     this.executiveNarrative = new SantisOracleExecutiveNarrative();
     this.globalExecutiveView = new SantisOracleGlobalExecutiveView();
     this.simulationPanel = new SantisOracleSimulationPanel();
+    this.executionPlanPanel = new SantisOracleExecutionPlanPanel();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -30,6 +32,7 @@ class BoardroomOracleV2 {
     if (!this.container) return;
     this.globalExecutiveView.init();
     this.simulationPanel.init();
+    this.executionPlanPanel.init();
     
     // Initial state
     this.container.innerHTML = `

--- a/assets/js/modules/santis-oracle-action-memory-client.js
+++ b/assets/js/modules/santis-oracle-action-memory-client.js
@@ -9,12 +9,14 @@ export class SantisOracleActionMemoryClient {
     globalAggregationUrl = 'http://localhost:3030/api/v1/oracle/global-aggregation',
     crossNodeLearningUrl = 'http://localhost:3030/api/v1/oracle/cross-node-learning',
     strategySimulationUrl = 'http://localhost:3030/api/v1/oracle/strategy-simulation',
+    executionGuardUrl = 'http://localhost:3030/api/v1/oracle/execution-guard',
   } = {}) {
     this.baseUrl = baseUrl;
     this.nodeSyncUrl = nodeSyncUrl;
     this.globalAggregationUrl = globalAggregationUrl;
     this.crossNodeLearningUrl = crossNodeLearningUrl;
     this.strategySimulationUrl = strategySimulationUrl;
+    this.executionGuardUrl = executionGuardUrl;
   }
 
   async readAll() {
@@ -112,6 +114,23 @@ export class SantisOracleActionMemoryClient {
 
     if (!response.ok) {
       throw new Error(`Oracle strategy simulation read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
+  }
+
+  async readExecutionGuard({ limit = 250 } = {}) {
+    const url = new URL(this.executionGuardUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle execution guard read failed: ${response.status}`);
     }
 
     const body = await response.json();

--- a/assets/js/modules/santis-oracle-execution-guard.js
+++ b/assets/js/modules/santis-oracle-execution-guard.js
@@ -1,0 +1,19 @@
+/**
+ * santis-oracle-execution-guard.js
+ * Read-only client wrapper for guarded Oracle execution planning.
+ */
+import { SantisOracleActionMemoryClient } from './santis-oracle-action-memory-client.js';
+
+export class SantisOracleExecutionGuard {
+  constructor({
+    client = new SantisOracleActionMemoryClient(),
+    limit = 250,
+  } = {}) {
+    this.client = client;
+    this.limit = limit;
+  }
+
+  async read() {
+    return this.client.readExecutionGuard({ limit: this.limit });
+  }
+}

--- a/assets/js/modules/santis-oracle-execution-plan-panel.js
+++ b/assets/js/modules/santis-oracle-execution-plan-panel.js
@@ -1,0 +1,115 @@
+/**
+ * santis-oracle-execution-plan-panel.js
+ * Human-gated execution planning panel. It never applies actions.
+ */
+import { SantisOracleExecutionGuard } from './santis-oracle-execution-guard.js';
+
+export class SantisOracleExecutionPlanPanel {
+  constructor({
+    container = document.getElementById('oracle-execution-plan-container'),
+    guard = new SantisOracleExecutionGuard(),
+  } = {}) {
+    this.container = container;
+    this.guard = guard;
+    this.refresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.refresh();
+    window.addEventListener('santis:oracle:action-memory:synced', this.refresh);
+    window.addEventListener('santis:oracle:action-memory:hydrated', this.refresh);
+  }
+
+  async refresh() {
+    if (!this.container) return;
+
+    try {
+      const plan = await this.guard.read();
+      this.render(plan);
+    } catch (error) {
+      console.warn('[Oracle Execution Plan] Failed to read execution guard.', error);
+      this.renderUnavailable();
+    }
+  }
+
+  render(plan) {
+    this.container.innerHTML = `
+      <div class="oracle-execution-brief">
+        <span>${this.escapeHtml(this.resolveStatusLabel(plan?.status))}</span>
+        <p>${this.escapeHtml(plan?.rationale || 'Execution guard is standing by. No operational plan is active.')}</p>
+      </div>
+      <div class="oracle-execution-grid">
+        <div class="oracle-execution-panel">
+          <h3>Guardrails</h3>
+          ${this.renderGuardrails(plan?.guardrails || [])}
+        </div>
+        <div class="oracle-execution-panel">
+          <h3>Suggested Execution Plan</h3>
+          ${this.renderSteps(plan?.steps || [])}
+        </div>
+      </div>
+    `;
+  }
+
+  renderGuardrails(guardrails) {
+    if (!guardrails.length) {
+      return '<div class="oracle-execution-empty">No guardrails are active yet.</div>';
+    }
+
+    return guardrails.map((guardrail) => `
+      <div class="oracle-guardrail ${guardrail.passed ? 'oracle-guardrail-pass' : 'oracle-guardrail-block'}">
+        <strong>${this.escapeHtml(guardrail.label)}</strong>
+        <p>${this.escapeHtml(String(guardrail.actual))} / ${this.escapeHtml(String(guardrail.threshold))}</p>
+      </div>
+    `).join('');
+  }
+
+  renderSteps(steps) {
+    if (!steps.length) {
+      return '<div class="oracle-execution-empty">No execution plan is recommended. Human approval remains required.</div>';
+    }
+
+    return `
+      <ol class="oracle-execution-steps">
+        ${steps.map((step) => `
+          <li>
+            <strong>${this.escapeHtml(step.label)}</strong>
+            <p>${this.escapeHtml(step.detail)}</p>
+          </li>
+        `).join('')}
+      </ol>
+      <div class="oracle-execution-human-gate">Human approval required. No auto-apply.</div>
+    `;
+  }
+
+  resolveStatusLabel(status) {
+    switch (status) {
+      case 'human_approval_required':
+        return 'Human approval required';
+      case 'not_recommended':
+        return 'Not recommended';
+      case 'awaiting_signal':
+      default:
+        return 'Awaiting guarded signal';
+    }
+  }
+
+  renderUnavailable() {
+    this.container.innerHTML = `
+      <div class="oracle-execution-empty">
+        Execution guard is unavailable. Auto-apply remains disabled.
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-learning-loop.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-executive-mode.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-simulation-panel.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-execution-plan-panel.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -73,6 +74,16 @@
         </div>
         <div class="oracle-simulation-panel" id="oracle-strategy-simulation-container">
           <div class="oracle-simulation-empty">Awaiting cross-node strategy simulation.</div>
+        </div>
+      </section>
+
+      <section class="santis-boardroom-execution-plan">
+        <div class="log-header">
+          <h2>Guarded Execution Plan</h2>
+          <span class="ai-badge">Human Gate</span>
+        </div>
+        <div class="oracle-execution-plan" id="oracle-execution-plan-container">
+          <div class="oracle-execution-empty">Awaiting guarded Oracle execution plan.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds guarded Oracle execution planning so high-confidence simulated strategies can be translated into human-gated execution plans.

## Scope

- Adds GET /api/v1/oracle/execution-guard
- Adds confidence, risk, revenue, and VIP guardrail evaluation
- Adds execution plan states: human_approval_required, not_recommended, and awaiting_signal
- Adds suggested execution plan steps
- Adds Boardroom Guarded Execution Plan panel and styling
- Preserves no-auto-apply governance

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- git diff --check passed

## Governance

No auto-apply behavior is introduced. Execution planning is advisory and remains human-gated.