### PR TITLE
feat: add Oracle execution outcome feedback

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -24,6 +24,7 @@ import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregatio
 import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learning.routes";
 import { oracleStrategySimulationRouter } from "./oracle/oracle-strategy-simulation.routes";
 import { oracleExecutionGuardRouter } from "./oracle/oracle-execution-guard.routes";
+import { oracleExecutionOutcomeRouter } from "./oracle/oracle-execution-outcome.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -142,6 +143,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleCrossNodeLearningRouter);
   app.use("/api/v1/oracle", oracleStrategySimulationRouter);
   app.use("/api/v1/oracle", oracleExecutionGuardRouter);
+  app.use("/api/v1/oracle", oracleExecutionOutcomeRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-execution-outcome.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-outcome.contract.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const OracleExecutionOutcomeSchema = z.object({
+  type: z.literal("ORACLE_EXECUTION_OUTCOME").default("ORACLE_EXECUTION_OUTCOME"),
+  planId: z.string().min(1),
+  scenarioId: z.string().nullable(),
+  targetNodeId: z.string().nullable(),
+  executionStatus: z.enum(["implemented", "partially_implemented", "not_implemented"]),
+  forecastRevenueLift: z.number(),
+  actualRevenueLift: z.number(),
+  forecastConfidence: z.number().min(0).max(100),
+  actualConfidence: z.number().min(0).max(100),
+  notes: z.string().default(""),
+  timestamp: z.string().datetime(),
+});
+
+export const OracleExecutionOutcomeRecordSchema = OracleExecutionOutcomeSchema.extend({
+  outcomeId: z.string().uuid(),
+  recordedAt: z.string().datetime(),
+});
+
+export const OracleExecutionOutcomeSummarySchema = z.object({
+  outcomeCount: z.number().int().nonnegative(),
+  averageRevenueDelta: z.number(),
+  averageConfidenceDelta: z.number(),
+  calibrationSignal: z.enum(["awaiting_outcomes", "over_forecast", "under_forecast", "aligned"]),
+  latestOutcome: OracleExecutionOutcomeRecordSchema.nullable(),
+  outcomes: z.array(OracleExecutionOutcomeRecordSchema),
+});
+
+export const OracleExecutionOutcomeResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleExecutionOutcomeSummarySchema,
+});
+
+export type OracleExecutionOutcome = z.infer<typeof OracleExecutionOutcomeSchema>;
+export type OracleExecutionOutcomeRecord = z.infer<typeof OracleExecutionOutcomeRecordSchema>;
+export type OracleExecutionOutcomeSummary = z.infer<typeof OracleExecutionOutcomeSummarySchema>;

--- a/apps/ingestion-api/src/oracle/oracle-execution-outcome.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-outcome.routes.ts
@@ -1,0 +1,38 @@
+import { Router, Request, Response } from "express";
+import {
+  OracleExecutionOutcomeSchema,
+} from "./oracle-execution-outcome.contract.js";
+import { oracleExecutionOutcomeStore } from "./oracle-execution-outcome.store.js";
+
+export const oracleExecutionOutcomeRouter = Router();
+
+oracleExecutionOutcomeRouter.get("/execution-outcomes", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 50);
+  const data = await oracleExecutionOutcomeStore.summarize(Number.isFinite(limit) ? limit : 50);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});
+
+oracleExecutionOutcomeRouter.post("/execution-outcomes", async (req: Request, res: Response) => {
+  const parsed = OracleExecutionOutcomeSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    return res.status(400).json({
+      success: false,
+      timestamp: new Date().toISOString(),
+      error: parsed.error.flatten(),
+    });
+  }
+
+  const record = await oracleExecutionOutcomeStore.append(parsed.data);
+
+  return res.status(201).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data: record,
+  });
+});

--- a/apps/ingestion-api/src/oracle/oracle-execution-outcome.store.ts
+++ b/apps/ingestion-api/src/oracle/oracle-execution-outcome.store.ts
@@ -1,0 +1,93 @@
+import { appendFile, mkdir } from "fs/promises";
+import { createReadStream, existsSync } from "fs";
+import * as readline from "readline";
+import * as path from "path";
+import crypto from "crypto";
+import {
+  OracleExecutionOutcome,
+  OracleExecutionOutcomeRecord,
+  OracleExecutionOutcomeRecordSchema,
+  OracleExecutionOutcomeSummary,
+} from "./oracle-execution-outcome.contract.js";
+
+const STORE_DIR = path.join(process.cwd(), ".data");
+const STORE_FILE = path.join(STORE_DIR, "oracle-execution-outcomes.jsonl");
+
+export class OracleExecutionOutcomeStore {
+  async append(outcome: OracleExecutionOutcome): Promise<OracleExecutionOutcomeRecord> {
+    if (!existsSync(STORE_DIR)) {
+      await mkdir(STORE_DIR, { recursive: true });
+    }
+
+    const record: OracleExecutionOutcomeRecord = {
+      ...outcome,
+      outcomeId: crypto.randomUUID(),
+      recordedAt: new Date().toISOString(),
+    };
+
+    await appendFile(STORE_FILE, `${JSON.stringify(record)}\n`, "utf-8");
+    return record;
+  }
+
+  async summarize(limit: number = 50): Promise<OracleExecutionOutcomeSummary> {
+    const outcomes = await this.replay(limit);
+    const averageRevenueDelta = this.average(outcomes.map((outcome) =>
+      outcome.actualRevenueLift - outcome.forecastRevenueLift
+    ));
+    const averageConfidenceDelta = this.average(outcomes.map((outcome) =>
+      outcome.actualConfidence - outcome.forecastConfidence
+    ));
+
+    return {
+      outcomeCount: outcomes.length,
+      averageRevenueDelta,
+      averageConfidenceDelta,
+      calibrationSignal: this.resolveCalibrationSignal(outcomes.length, averageRevenueDelta, averageConfidenceDelta),
+      latestOutcome: outcomes[0] || null,
+      outcomes,
+    };
+  }
+
+  async replay(limit: number = 50): Promise<OracleExecutionOutcomeRecord[]> {
+    if (!existsSync(STORE_FILE)) {
+      return [];
+    }
+
+    const records: OracleExecutionOutcomeRecord[] = [];
+    const fileStream = createReadStream(STORE_FILE);
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (line.trim() === "") continue;
+
+      try {
+        records.push(OracleExecutionOutcomeRecordSchema.parse(JSON.parse(line)));
+      } catch (error) {
+        console.warn("[Oracle Execution Outcome] Skipping invalid outcome record.", error);
+      }
+    }
+
+    return records
+      .sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt))
+      .slice(0, limit);
+  }
+
+  resolveCalibrationSignal(
+    outcomeCount: number,
+    averageRevenueDelta: number,
+    averageConfidenceDelta: number,
+  ): OracleExecutionOutcomeSummary["calibrationSignal"] {
+    if (outcomeCount === 0) return "awaiting_outcomes";
+    if (averageRevenueDelta <= -5 || averageConfidenceDelta <= -8) return "over_forecast";
+    if (averageRevenueDelta >= 5 || averageConfidenceDelta >= 8) return "under_forecast";
+    return "aligned";
+  }
+
+  average(values: number[]): number {
+    if (!values.length) return 0;
+    const total = values.reduce((sum, value) => sum + value, 0);
+    return Math.round(total / values.length);
+  }
+}
+
+export const oracleExecutionOutcomeStore = new OracleExecutionOutcomeStore();

--- a/assets/css/modules/santis-oracle-outcome-feedback-panel.css
+++ b/assets/css/modules/santis-oracle-outcome-feedback-panel.css
@@ -1,0 +1,104 @@
+/*
+  Santis Oracle Outcome Feedback Panel
+  Forecast vs reality tracking for approved execution outcomes.
+*/
+
+.santis-boardroom-outcome-feedback {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-outcome-feedback {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.oracle-outcome-brief {
+  padding: 18px;
+  border-left: 2px solid var(--boardroom-accent);
+  border-radius: 4px;
+  background: rgba(212, 175, 55, 0.055);
+}
+
+.oracle-outcome-brief span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--boardroom-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oracle-outcome-brief p {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.oracle-outcome-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.oracle-outcome-metric,
+.oracle-outcome-card {
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.oracle-outcome-metric span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--boardroom-text-muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-outcome-metric strong,
+.oracle-outcome-card strong {
+  color: #fff;
+  font-size: 14px;
+}
+
+.oracle-outcome-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.oracle-outcome-card {
+  border-left: 2px solid #8b7355;
+}
+
+.oracle-outcome-card p,
+.oracle-outcome-empty {
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.oracle-outcome-card p {
+  margin: 8px 0 0;
+}
+
+.oracle-outcome-empty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .oracle-outcome-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -11,6 +11,7 @@ import { SantisOracleExecutiveNarrative } from './santis-oracle-executive-narrat
 import { SantisOracleGlobalExecutiveView } from './santis-oracle-global-executive-view.js';
 import { SantisOracleSimulationPanel } from './santis-oracle-simulation-panel.js';
 import { SantisOracleExecutionPlanPanel } from './santis-oracle-execution-plan-panel.js';
+import { SantisOracleOutcomeFeedbackPanel } from './santis-oracle-outcome-feedback-panel.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -23,6 +24,7 @@ class BoardroomOracleV2 {
     this.globalExecutiveView = new SantisOracleGlobalExecutiveView();
     this.simulationPanel = new SantisOracleSimulationPanel();
     this.executionPlanPanel = new SantisOracleExecutionPlanPanel();
+    this.outcomeFeedbackPanel = new SantisOracleOutcomeFeedbackPanel();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -33,6 +35,7 @@ class BoardroomOracleV2 {
     this.globalExecutiveView.init();
     this.simulationPanel.init();
     this.executionPlanPanel.init();
+    this.outcomeFeedbackPanel.init();
     
     // Initial state
     this.container.innerHTML = `

--- a/assets/js/modules/santis-oracle-execution-outcome-client.js
+++ b/assets/js/modules/santis-oracle-execution-outcome-client.js
@@ -1,0 +1,46 @@
+/**
+ * santis-oracle-execution-outcome-client.js
+ * Transport for Oracle execution outcome feedback.
+ */
+export class SantisOracleExecutionOutcomeClient {
+  constructor({
+    baseUrl = 'http://localhost:3030/api/v1/oracle/execution-outcomes',
+  } = {}) {
+    this.baseUrl = baseUrl;
+  }
+
+  async readSummary({ limit = 50 } = {}) {
+    const url = new URL(this.baseUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle outcome summary read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
+  }
+
+  async record(outcome) {
+    const response = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(outcome),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle outcome write failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data;
+  }
+}

--- a/assets/js/modules/santis-oracle-outcome-feedback-panel.js
+++ b/assets/js/modules/santis-oracle-outcome-feedback-panel.js
@@ -1,0 +1,122 @@
+/**
+ * santis-oracle-outcome-feedback-panel.js
+ * Displays forecast vs reality feedback for guarded execution outcomes.
+ */
+import { SantisOracleExecutionOutcomeClient } from './santis-oracle-execution-outcome-client.js';
+
+export class SantisOracleOutcomeFeedbackPanel {
+  constructor({
+    container = document.getElementById('oracle-outcome-feedback-container'),
+    client = new SantisOracleExecutionOutcomeClient(),
+  } = {}) {
+    this.container = container;
+    this.client = client;
+    this.refresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.refresh();
+    window.addEventListener('santis:oracle:outcome-feedback:recorded', this.refresh);
+  }
+
+  async refresh() {
+    if (!this.container) return;
+
+    try {
+      const summary = await this.client.readSummary();
+      this.render(summary);
+    } catch (error) {
+      console.warn('[Oracle Outcome Feedback] Failed to read outcome summary.', error);
+      this.renderUnavailable();
+    }
+  }
+
+  render(summary) {
+    const outcomes = Array.isArray(summary?.outcomes) ? summary.outcomes.slice(0, 3) : [];
+
+    this.container.innerHTML = `
+      <div class="oracle-outcome-brief">
+        <span>${this.escapeHtml(this.resolveSignalLabel(summary?.calibrationSignal))}</span>
+        <p>${this.escapeHtml(this.resolveNarrative(summary))}</p>
+      </div>
+      <div class="oracle-outcome-grid">
+        ${this.renderMetric('Outcomes', summary?.outcomeCount ?? 0)}
+        ${this.renderMetric('Revenue delta', `${Number(summary?.averageRevenueDelta || 0)}%`)}
+        ${this.renderMetric('Confidence delta', `${Number(summary?.averageConfidenceDelta || 0)}%`)}
+      </div>
+      <div class="oracle-outcome-list">
+        ${outcomes.length ? outcomes.map((outcome) => this.renderOutcome(outcome)).join('') : '<div class="oracle-outcome-empty">No execution outcomes recorded yet.</div>'}
+      </div>
+    `;
+  }
+
+  resolveNarrative(summary) {
+    if (!summary || !summary.outcomeCount) {
+      return 'Outcome feedback is standing by. Approved plans can be measured once real-world execution results are recorded.';
+    }
+
+    if (summary.calibrationSignal === 'over_forecast') {
+      return 'Reality is trailing forecast. Future Oracle confidence should be calibrated downward for similar execution plans.';
+    }
+
+    if (summary.calibrationSignal === 'under_forecast') {
+      return 'Reality is outperforming forecast. Similar future scenarios can receive cautious confidence lift.';
+    }
+
+    return 'Forecast and reality are aligned. Current confidence calibration is holding within expected bounds.';
+  }
+
+  resolveSignalLabel(signal) {
+    switch (signal) {
+      case 'over_forecast':
+        return 'Calibration - over forecast';
+      case 'under_forecast':
+        return 'Calibration - under forecast';
+      case 'aligned':
+        return 'Calibration - aligned';
+      case 'awaiting_outcomes':
+      default:
+        return 'Awaiting execution outcomes';
+    }
+  }
+
+  renderMetric(label, value) {
+    return `
+      <div class="oracle-outcome-metric">
+        <span>${this.escapeHtml(label)}</span>
+        <strong>${this.escapeHtml(String(value))}</strong>
+      </div>
+    `;
+  }
+
+  renderOutcome(outcome) {
+    const revenueDelta = Number(outcome.actualRevenueLift || 0) - Number(outcome.forecastRevenueLift || 0);
+    const confidenceDelta = Number(outcome.actualConfidence || 0) - Number(outcome.forecastConfidence || 0);
+
+    return `
+      <article class="oracle-outcome-card">
+        <strong>${this.escapeHtml(outcome.executionStatus)}</strong>
+        <p>${this.escapeHtml(outcome.targetNodeId || 'global')} - revenue delta ${revenueDelta}%, confidence delta ${confidenceDelta}%</p>
+      </article>
+    `;
+  }
+
+  renderUnavailable() {
+    this.container.innerHTML = `
+      <div class="oracle-outcome-empty">
+        Outcome feedback is unavailable. Forecasting remains read-only.
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-executive-mode.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-simulation-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-execution-plan-panel.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-outcome-feedback-panel.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -84,6 +85,16 @@
         </div>
         <div class="oracle-execution-plan" id="oracle-execution-plan-container">
           <div class="oracle-execution-empty">Awaiting guarded Oracle execution plan.</div>
+        </div>
+      </section>
+
+      <section class="santis-boardroom-outcome-feedback">
+        <div class="log-header">
+          <h2>Outcome Feedback</h2>
+          <span class="ai-badge">Reality Check</span>
+        </div>
+        <div class="oracle-outcome-feedback" id="oracle-outcome-feedback-container">
+          <div class="oracle-outcome-empty">Awaiting execution outcome feedback.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds Oracle v2 execution outcome feedback so approved execution plans can be compared against real outcomes and fed back into future calibration.

## Scope

- Adds GET/POST support for /api/v1/oracle/execution-outcomes
- Adds append-only outcome records
- Adds forecast vs reality summary
- Adds revenue delta and confidence delta tracking
- Adds calibration signals: awaiting_outcomes, over_forecast, under_forecast, aligned
- Adds Boardroom Outcome Feedback panel, client, and CSS

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- git diff --check passed

## Governance

Outcome feedback is measurement and calibration only. It does not introduce auto-apply behavior.