### PR TITLE
fix: add Boardroom file protocol runtime guard

### DIFF
--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -5,6 +5,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Santis Boardroom Lite</title>
   <meta name="robots" content="noindex, nofollow" />
+  <script>
+    (function () {
+      if (window.location.protocol !== 'file:') return;
+
+      var recommendedUrl = 'http://127.0.0.1:8080/tr/boardroom/';
+
+      document.documentElement.style.background = '#08090b';
+      document.addEventListener('DOMContentLoaded', function () {
+        document.body.innerHTML = ''
+          + '<main style="min-height:100vh;display:flex;align-items:center;justify-content:center;padding:32px;background:#08090b;color:#f1f1f1;font-family:Inter,Arial,sans-serif;">'
+          + '<section style="max-width:680px;border:1px solid rgba(212,175,55,.35);border-radius:8px;padding:28px;background:#111318;box-shadow:0 18px 60px rgba(0,0,0,.35);">'
+          + '<p style="margin:0 0 10px;color:#d4af37;font-size:11px;letter-spacing:.14em;text-transform:uppercase;">Boardroom Runtime Guard</p>'
+          + '<h1 style="margin:0 0 14px;font-size:28px;line-height:1.15;font-weight:500;">Boardroom cannot run from file://</h1>'
+          + '<p style="margin:0 0 18px;color:#b9bdc7;font-size:14px;line-height:1.6;">CSS root paths and ES module scripts require an HTTP origin. Start the local static server from the repository root, then open the Boardroom URL below.</p>'
+          + '<pre style="white-space:pre-wrap;margin:0 0 18px;padding:14px;border-radius:6px;background:#050608;color:#d7dbe5;font-size:13px;">python -m http.server 8080 --bind 127.0.0.1</pre>'
+          + '<a href="' + recommendedUrl + '" style="display:inline-block;color:#08090b;background:#d4af37;border-radius:4px;padding:12px 16px;text-decoration:none;font-size:13px;font-weight:700;">Open ' + recommendedUrl + '</a>'
+          + '</section>'
+          + '</main>';
+      });
+    })();
+  </script>
   <link rel="stylesheet" href="/assets/css/fonts.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-lite.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-oracle-v2.css" />


### PR DESCRIPTION
## Summary

Adds a runtime guard for the Boardroom page when it is opened directly via file://, preventing confusing missing CSS/JS and CORS errors.

## Scope

- Detects file:// protocol on tr/boardroom/index.html
- Shows a clear runtime warning instead of a broken Boardroom experience
- Provides the correct local server command: python -m http.server 8080 --bind 127.0.0.1
- Provides the correct URL: http://127.0.0.1:8080/tr/boardroom/

## Validation

- git diff --check passed
- pnpm test:quality:static passed