### PR TITLE
feat: add Boardroom dev health overlay

### DIFF
--- a/assets/css/modules/santis-boardroom-dev-health-overlay.css
+++ b/assets/css/modules/santis-boardroom-dev-health-overlay.css
@@ -1,0 +1,133 @@
+/*
+  Boardroom Dev Health Overlay
+  Lightweight runtime cockpit for local development diagnostics.
+*/
+
+.boardroom-dev-health {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 9999;
+  font-family: Inter, Arial, sans-serif;
+}
+
+.dev-health-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(212, 175, 55, 0.38);
+  border-radius: 999px;
+  background: rgba(10, 11, 14, 0.94);
+  color: #f1f1f1;
+  cursor: pointer;
+  font-size: 12px;
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.28);
+}
+
+.dev-health-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #d4af37;
+}
+
+.dev-health-dot[data-status="ok"] {
+  background: #7fbc8c;
+}
+
+.dev-health-dot[data-status="warn"] {
+  background: #d4af37;
+}
+
+.dev-health-dot[data-status="error"] {
+  background: #c57f7f;
+}
+
+.dev-health-panel {
+  position: absolute;
+  right: 0;
+  bottom: 48px;
+  width: min(420px, calc(100vw - 36px));
+  padding: 16px;
+  border: 1px solid rgba(212, 175, 55, 0.28);
+  border-radius: 8px;
+  background: rgba(13, 15, 20, 0.98);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.4);
+}
+
+.dev-health-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.dev-health-header strong {
+  color: #fff;
+  font-size: 13px;
+}
+
+.dev-health-header span {
+  color: #d4af37;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.dev-health-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.dev-health-item {
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 2px solid #8b7355;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.dev-health-item[data-status="ok"] {
+  border-left-color: #7fbc8c;
+}
+
+.dev-health-item[data-status="warn"],
+.dev-health-item[data-status="checking"] {
+  border-left-color: #d4af37;
+}
+
+.dev-health-item[data-status="error"] {
+  border-left-color: #c57f7f;
+}
+
+.dev-health-item span {
+  display: block;
+  color: #f1f1f1;
+  font-size: 12px;
+}
+
+.dev-health-item strong {
+  display: block;
+  margin: 4px 0;
+  color: #d4af37;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dev-health-item p {
+  margin: 0;
+  color: #aeb4c0;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+  .boardroom-dev-health {
+    right: 12px;
+    bottom: 12px;
+  }
+}

--- a/assets/js/modules/santis-boardroom-dev-health-overlay.js
+++ b/assets/js/modules/santis-boardroom-dev-health-overlay.js
@@ -1,0 +1,220 @@
+/**
+ * santis-boardroom-dev-health-overlay.js
+ * Runtime health cockpit for Boardroom development.
+ */
+class SantisBoardroomDevHealthOverlay {
+  constructor({
+    root = document.getElementById('boardroom-dev-health-overlay'),
+    pollInterval = 15000,
+  } = {}) {
+    this.root = root;
+    this.pollInterval = pollInterval;
+    this.state = {
+      assets: 'checking',
+      ingestionApi: 'checking',
+      coreState: 'checking',
+      oracle: 'checking',
+      sovereignBus: 'idle',
+      lastError: 'none',
+    };
+    this.details = {
+      assets: 'Scanning linked CSS and scripts',
+      ingestionApi: 'Checking http://localhost:3030',
+      coreState: 'Waiting for stream event',
+      oracle: 'Checking Oracle endpoints',
+      sovereignBus: 'No bus error observed',
+      lastError: 'No runtime error observed',
+    };
+    this.boundRefresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.root) return;
+
+    this.renderShell();
+    this.bindEvents();
+    this.refresh();
+    window.setInterval(this.boundRefresh, this.pollInterval);
+  }
+
+  bindEvents() {
+    window.addEventListener('error', (event) => {
+      this.state.lastError = 'error';
+      this.details.lastError = event.message || 'Runtime error captured';
+      this.render();
+    });
+
+    window.addEventListener('unhandledrejection', (event) => {
+      this.state.lastError = 'error';
+      this.details.lastError = event.reason?.message || String(event.reason || 'Unhandled promise rejection');
+      this.render();
+    });
+
+    window.addEventListener('santis:corestate:connected', () => {
+      this.state.coreState = 'ok';
+      this.details.coreState = 'CoreState stream connected';
+      this.render();
+    });
+
+    window.addEventListener('santis:corestate:error', () => {
+      this.state.coreState = 'warn';
+      this.details.coreState = 'CoreState stream error or reconnecting';
+      this.render();
+    });
+
+    window.addEventListener('santis:sovereign-bus:error', (event) => {
+      this.state.sovereignBus = 'warn';
+      this.details.sovereignBus = `Bus error at ${event.detail?.timestamp || 'unknown time'}`;
+      this.render();
+    });
+  }
+
+  renderShell() {
+    this.root.innerHTML = `
+      <button class="dev-health-toggle" type="button" aria-expanded="false">
+        <span class="dev-health-dot"></span>
+        Dev Health
+      </button>
+      <section class="dev-health-panel" hidden>
+        <div class="dev-health-header">
+          <strong>Boardroom Dev Health</strong>
+          <span data-health-summary>Checking...</span>
+        </div>
+        <div class="dev-health-grid" data-health-grid></div>
+      </section>
+    `;
+
+    this.root.querySelector('.dev-health-toggle')?.addEventListener('click', () => {
+      const panel = this.root.querySelector('.dev-health-panel');
+      const button = this.root.querySelector('.dev-health-toggle');
+      const isHidden = panel.hasAttribute('hidden');
+      panel.toggleAttribute('hidden', !isHidden);
+      button.setAttribute('aria-expanded', String(isHidden));
+    });
+  }
+
+  async refresh() {
+    this.checkAssets();
+    await Promise.all([
+      this.checkIngestionApi(),
+      this.checkOracleEndpoints(),
+    ]);
+    this.render();
+  }
+
+  checkAssets() {
+    const stylesheets = Array.from(document.styleSheets || []);
+    const expectedLinks = Array.from(document.querySelectorAll('link[rel="stylesheet"]')).length;
+    const loadedStylesheets = stylesheets.filter((sheet) => sheet.href).length;
+    const moduleScripts = Array.from(document.querySelectorAll('script[type="module"]'));
+
+    if (loadedStylesheets >= expectedLinks && moduleScripts.length > 0) {
+      this.state.assets = 'ok';
+      this.details.assets = `${loadedStylesheets}/${expectedLinks} stylesheets loaded; ${moduleScripts.length} module scripts declared`;
+      return;
+    }
+
+    this.state.assets = 'warn';
+    this.details.assets = `${loadedStylesheets}/${expectedLinks} stylesheets visible; verify server root if assets are missing`;
+  }
+
+  async checkIngestionApi() {
+    try {
+      const response = await fetch('http://localhost:3030/api/v1/analytics/god/health', {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+      });
+      this.state.ingestionApi = response.ok ? 'ok' : 'warn';
+      this.details.ingestionApi = response.ok ? 'Ingestion API reachable' : `Health returned ${response.status}`;
+    } catch (error) {
+      this.state.ingestionApi = 'error';
+      this.details.ingestionApi = 'Ingestion API not reachable on localhost:3030';
+    }
+  }
+
+  async checkOracleEndpoints() {
+    const endpoints = [
+      'action-memory',
+      'node-sync',
+      'global-aggregation',
+      'cross-node-learning',
+      'strategy-simulation',
+      'execution-guard',
+      'execution-outcomes',
+    ];
+
+    try {
+      const results = await Promise.all(endpoints.map((endpoint) =>
+        fetch(`http://localhost:3030/api/v1/oracle/${endpoint}`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        }).then((response) => response.ok)
+      ));
+      const okCount = results.filter(Boolean).length;
+      this.state.oracle = okCount === endpoints.length ? 'ok' : 'warn';
+      this.details.oracle = `${okCount}/${endpoints.length} Oracle endpoints reachable`;
+    } catch (error) {
+      this.state.oracle = 'error';
+      this.details.oracle = 'Oracle endpoints not reachable on localhost:3030';
+    }
+  }
+
+  render() {
+    if (!this.root) return;
+
+    const healthKeys = ['assets', 'ingestionApi', 'coreState', 'oracle', 'sovereignBus', 'lastError'];
+    const worst = this.resolveWorstStatus(healthKeys.map((key) => this.state[key]));
+    const grid = this.root.querySelector('[data-health-grid]');
+    const summary = this.root.querySelector('[data-health-summary]');
+    const dot = this.root.querySelector('.dev-health-dot');
+
+    summary.textContent = this.resolveSummary(worst);
+    dot.dataset.status = worst;
+    grid.innerHTML = healthKeys.map((key) => this.renderItem(key)).join('');
+  }
+
+  renderItem(key) {
+    return `
+      <article class="dev-health-item" data-status="${this.escapeHtml(this.state[key])}">
+        <span>${this.escapeHtml(this.labelFor(key))}</span>
+        <strong>${this.escapeHtml(this.state[key])}</strong>
+        <p>${this.escapeHtml(this.details[key])}</p>
+      </article>
+    `;
+  }
+
+  resolveWorstStatus(statuses) {
+    if (statuses.includes('error')) return 'error';
+    if (statuses.includes('warn') || statuses.includes('checking')) return 'warn';
+    return 'ok';
+  }
+
+  resolveSummary(status) {
+    if (status === 'error') return 'Action needed';
+    if (status === 'warn') return 'Degraded';
+    return 'Healthy';
+  }
+
+  labelFor(key) {
+    return {
+      assets: 'Static assets',
+      ingestionApi: 'Ingestion API',
+      coreState: 'CoreState stream',
+      oracle: 'Oracle endpoints',
+      sovereignBus: 'Sovereign Bus',
+      lastError: 'Last runtime error',
+    }[key] || key;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}
+
+const overlay = new SantisBoardroomDevHealthOverlay();
+overlay.init();

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -36,6 +36,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-simulation-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-execution-plan-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-outcome-feedback-panel.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-dev-health-overlay.css" />
 </head>
 <body>
   <div class="santis-boardroom">
@@ -182,10 +183,12 @@
       </section>
     </main>
   </div>
+  <div class="boardroom-dev-health" id="boardroom-dev-health-overlay"></div>
 
   <script src="/assets/js/modules/santis-revenue-tracker.js"></script>
   <script src="/assets/js/modules/santis-boardroom-lite.js"></script>
   <script type="module" src="/assets/js/modules/santis-boardroom-pro-live.js"></script>
   <script type="module" src="/assets/js/modules/santis-boardroom-oracle-v2.js"></script>
+  <script type="module" src="/assets/js/modules/santis-boardroom-dev-health-overlay.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a Boardroom Dev Health Overlay so runtime health can be inspected directly from the Boardroom without relying on DevTools.

## Scope

- Adds assets/js/modules/santis-boardroom-dev-health-overlay.js
- Adds assets/css/modules/santis-boardroom-dev-health-overlay.css
- Wires the overlay into the Boardroom HTML
- Shows static asset status
- Shows ingestion API health
- Shows CoreState stream status
- Shows Oracle endpoint reachability
- Shows Sovereign Bus error events
- Shows last runtime error or unhandled rejection

## Validation

- node --check assets/js/modules/santis-boardroom-dev-health-overlay.js
- git diff --check
- pnpm test:quality:static