### PR TITLE
feat: add Oracle statistical forecast baseline

### DIFF
--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -25,6 +25,7 @@ import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learni
 import { oracleStrategySimulationRouter } from "./oracle/oracle-strategy-simulation.routes";
 import { oracleExecutionGuardRouter } from "./oracle/oracle-execution-guard.routes";
 import { oracleExecutionOutcomeRouter } from "./oracle/oracle-execution-outcome.routes";
+import { oracleStatisticalForecastRouter } from "./oracle/oracle-statistical-forecast.routes";
 import { registerBoardroomProjections } from "./projections/boardroom-projections";
 
 import { EventStore } from "./infrastructure/event-store";
@@ -144,6 +145,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleStrategySimulationRouter);
   app.use("/api/v1/oracle", oracleExecutionGuardRouter);
   app.use("/api/v1/oracle", oracleExecutionOutcomeRouter);
+  app.use("/api/v1/oracle", oracleStatisticalForecastRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
   

--- a/apps/ingestion-api/src/oracle/oracle-statistical-forecast.contract.ts
+++ b/apps/ingestion-api/src/oracle/oracle-statistical-forecast.contract.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const OracleStatisticalForecastSchema = z.object({
+  baselineForecast: z.number(),
+  sevenOutcomeAverage: z.number(),
+  thirtyOutcomeAverage: z.number(),
+  weightedTrend: z.number(),
+  trend: z.enum(["up", "down", "flat", "insufficient_data"]),
+  variance: z.number().min(0),
+  confidence: z.number().min(0).max(1),
+  heuristicComparison: z.enum(["aligned", "overconfidence_flag", "missed_opportunity", "insufficient_data"]),
+  hybridConfidence: z.number().min(0).max(1),
+  sampleSize: z.number().int().nonnegative(),
+  generatedAt: z.string().datetime(),
+});
+
+export const OracleStatisticalForecastResponseSchema = z.object({
+  success: z.boolean(),
+  timestamp: z.string().datetime(),
+  data: OracleStatisticalForecastSchema,
+});
+
+export type OracleStatisticalForecast = z.infer<typeof OracleStatisticalForecastSchema>;

--- a/apps/ingestion-api/src/oracle/oracle-statistical-forecast.engine.ts
+++ b/apps/ingestion-api/src/oracle/oracle-statistical-forecast.engine.ts
@@ -1,0 +1,95 @@
+import type { OracleExecutionOutcomeRecord } from "./oracle-execution-outcome.contract.js";
+import type { OracleStatisticalForecast } from "./oracle-statistical-forecast.contract.js";
+
+export class OracleStatisticalForecastEngine {
+  forecast(outcomes: OracleExecutionOutcomeRecord[]): OracleStatisticalForecast {
+    const sorted = [...outcomes].sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt));
+    const seven = sorted.slice(0, 7);
+    const thirty = sorted.slice(0, 30);
+    const sevenOutcomeAverage = this.average(seven.map((outcome) => outcome.actualRevenueLift));
+    const thirtyOutcomeAverage = this.average(thirty.map((outcome) => outcome.actualRevenueLift));
+    const weightedTrend = this.round((sevenOutcomeAverage * 0.65) + (thirtyOutcomeAverage * 0.35));
+    const baselineForecast = this.resolveBaselineForecast(sorted, weightedTrend);
+    const variance = this.resolveVariance(thirty.map((outcome) => outcome.actualRevenueLift), baselineForecast);
+    const confidence = this.resolveConfidence(sorted.length, variance);
+    const heuristicForecast = this.average(sorted.slice(0, 10).map((outcome) => outcome.forecastRevenueLift));
+    const heuristicComparison = this.resolveHeuristicComparison(sorted.length, heuristicForecast, baselineForecast);
+
+    return {
+      baselineForecast,
+      sevenOutcomeAverage,
+      thirtyOutcomeAverage,
+      weightedTrend,
+      trend: this.resolveTrend(sorted.length, sevenOutcomeAverage, thirtyOutcomeAverage),
+      variance,
+      confidence,
+      heuristicComparison,
+      hybridConfidence: this.resolveHybridConfidence(confidence, heuristicComparison),
+      sampleSize: sorted.length,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  resolveBaselineForecast(outcomes: OracleExecutionOutcomeRecord[], weightedTrend: number): number {
+    if (!outcomes.length) return 0;
+
+    const latestConfidence = outcomes[0]?.actualConfidence || 50;
+    return this.round(weightedTrend * (0.85 + (latestConfidence / 500)));
+  }
+
+  resolveTrend(sampleSize: number, sevenAverage: number, thirtyAverage: number): OracleStatisticalForecast["trend"] {
+    if (sampleSize < 3) return "insufficient_data";
+    if (sevenAverage > thirtyAverage + 3) return "up";
+    if (sevenAverage < thirtyAverage - 3) return "down";
+    return "flat";
+  }
+
+  resolveVariance(values: number[], baseline: number): number {
+    if (values.length < 2 || baseline === 0) return 0;
+
+    const averageDeviation = this.average(values.map((value) => Math.abs(value - baseline)));
+    return this.round(Math.min(1, Math.abs(averageDeviation / Math.max(1, Math.abs(baseline)))));
+  }
+
+  resolveConfidence(sampleSize: number, variance: number): number {
+    if (sampleSize === 0) return 0;
+
+    const sampleWeight = Math.min(0.82, sampleSize / 30);
+    const stabilityWeight = Math.max(0.1, 1 - variance);
+    return this.round(Math.min(0.95, sampleWeight * stabilityWeight));
+  }
+
+  resolveHeuristicComparison(
+    sampleSize: number,
+    heuristicForecast: number,
+    baselineForecast: number,
+  ): OracleStatisticalForecast["heuristicComparison"] {
+    if (sampleSize < 3 || baselineForecast === 0) return "insufficient_data";
+
+    const delta = (heuristicForecast - baselineForecast) / Math.max(1, Math.abs(baselineForecast));
+    if (delta > 0.18) return "overconfidence_flag";
+    if (delta < -0.18) return "missed_opportunity";
+    return "aligned";
+  }
+
+  resolveHybridConfidence(
+    confidence: number,
+    comparison: OracleStatisticalForecast["heuristicComparison"],
+  ): number {
+    if (comparison === "aligned") return this.round(Math.min(0.98, confidence + 0.12));
+    if (comparison === "overconfidence_flag") return this.round(Math.max(0, confidence - 0.16));
+    if (comparison === "missed_opportunity") return this.round(Math.min(0.92, confidence + 0.05));
+    return confidence;
+  }
+
+  average(values: number[]): number {
+    if (!values.length) return 0;
+    return this.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+  }
+
+  round(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+}
+
+export const oracleStatisticalForecastEngine = new OracleStatisticalForecastEngine();

--- a/apps/ingestion-api/src/oracle/oracle-statistical-forecast.routes.ts
+++ b/apps/ingestion-api/src/oracle/oracle-statistical-forecast.routes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from "express";
+import { oracleExecutionOutcomeStore } from "./oracle-execution-outcome.store.js";
+import { oracleStatisticalForecastEngine } from "./oracle-statistical-forecast.engine.js";
+
+export const oracleStatisticalForecastRouter = Router();
+
+oracleStatisticalForecastRouter.get("/statistical-forecast", async (req: Request, res: Response) => {
+  const limit = Number(req.query.limit || 90);
+  const outcomes = await oracleExecutionOutcomeStore.replay(Number.isFinite(limit) ? limit : 90);
+  const data = oracleStatisticalForecastEngine.forecast(outcomes);
+
+  return res.status(200).json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    data,
+  });
+});

--- a/assets/css/modules/santis-oracle-forecast-panel.css
+++ b/assets/css/modules/santis-oracle-forecast-panel.css
@@ -1,0 +1,84 @@
+/*
+  Santis Oracle Statistical Forecast Panel
+  Data-driven baseline for heuristic Oracle forecast comparison.
+*/
+
+.santis-boardroom-forecast {
+  background: var(--boardroom-surface);
+  border: 1px solid var(--boardroom-border);
+  border-radius: 8px;
+  padding: 24px;
+  margin-bottom: 40px;
+}
+
+.oracle-forecast-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.oracle-forecast-brief {
+  padding: 18px;
+  border-left: 2px solid var(--boardroom-accent);
+  border-radius: 4px;
+  background: rgba(212, 175, 55, 0.055);
+}
+
+.oracle-forecast-brief span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--boardroom-accent);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.oracle-forecast-brief p {
+  margin: 0;
+  color: #f1f1f1;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.oracle-forecast-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.oracle-forecast-metric {
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.oracle-forecast-metric span {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--boardroom-text-muted);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oracle-forecast-metric strong {
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.oracle-forecast-empty {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .oracle-forecast-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/modules/santis-boardroom-dev-health-overlay.js
+++ b/assets/js/modules/santis-boardroom-dev-health-overlay.js
@@ -141,6 +141,7 @@ class SantisBoardroomDevHealthOverlay {
       'strategy-simulation',
       'execution-guard',
       'execution-outcomes',
+      'statistical-forecast',
     ];
 
     try {

--- a/assets/js/modules/santis-boardroom-oracle-v2.js
+++ b/assets/js/modules/santis-boardroom-oracle-v2.js
@@ -12,6 +12,7 @@ import { SantisOracleGlobalExecutiveView } from './santis-oracle-global-executiv
 import { SantisOracleSimulationPanel } from './santis-oracle-simulation-panel.js';
 import { SantisOracleExecutionPlanPanel } from './santis-oracle-execution-plan-panel.js';
 import { SantisOracleOutcomeFeedbackPanel } from './santis-oracle-outcome-feedback-panel.js';
+import { SantisOracleForecastPanel } from './santis-oracle-forecast-panel.js';
 
 class BoardroomOracleV2 {
   constructor() {
@@ -25,6 +26,7 @@ class BoardroomOracleV2 {
     this.simulationPanel = new SantisOracleSimulationPanel();
     this.executionPlanPanel = new SantisOracleExecutionPlanPanel();
     this.outcomeFeedbackPanel = new SantisOracleOutcomeFeedbackPanel();
+    this.forecastPanel = new SantisOracleForecastPanel();
     this.container = document.getElementById('oracle-insights-container');
     
     this.init();
@@ -36,6 +38,7 @@ class BoardroomOracleV2 {
     this.simulationPanel.init();
     this.executionPlanPanel.init();
     this.outcomeFeedbackPanel.init();
+    this.forecastPanel.init();
     
     // Initial state
     this.container.innerHTML = `

--- a/assets/js/modules/santis-oracle-forecast-panel.js
+++ b/assets/js/modules/santis-oracle-forecast-panel.js
@@ -1,0 +1,108 @@
+/**
+ * santis-oracle-forecast-panel.js
+ * Displays statistical forecast baseline next to heuristic Oracle intelligence.
+ */
+import { SantisOracleStatisticalForecastClient } from './santis-oracle-statistical-forecast-client.js';
+
+export class SantisOracleForecastPanel {
+  constructor({
+    container = document.getElementById('oracle-statistical-forecast-container'),
+    client = new SantisOracleStatisticalForecastClient(),
+  } = {}) {
+    this.container = container;
+    this.client = client;
+    this.refresh = this.refresh.bind(this);
+  }
+
+  init() {
+    if (!this.container) return;
+
+    this.refresh();
+    window.addEventListener('santis:oracle:outcome-feedback:recorded', this.refresh);
+  }
+
+  async refresh() {
+    if (!this.container) return;
+
+    try {
+      const forecast = await this.client.read();
+      this.render(forecast);
+    } catch (error) {
+      console.warn('[Oracle Forecast Panel] Failed to read statistical forecast.', error);
+      this.renderUnavailable();
+    }
+  }
+
+  render(forecast) {
+    this.container.innerHTML = `
+      <div class="oracle-forecast-brief">
+        <span>${this.escapeHtml(this.resolveComparisonLabel(forecast?.heuristicComparison))}</span>
+        <p>${this.escapeHtml(this.resolveNarrative(forecast))}</p>
+      </div>
+      <div class="oracle-forecast-grid">
+        ${this.renderMetric('Baseline', `${Number(forecast?.baselineForecast || 0)}%`)}
+        ${this.renderMetric('Trend', forecast?.trend || 'insufficient_data')}
+        ${this.renderMetric('Variance', Number(forecast?.variance || 0).toFixed(2))}
+        ${this.renderMetric('Stat confidence', Number(forecast?.confidence || 0).toFixed(2))}
+        ${this.renderMetric('Hybrid confidence', Number(forecast?.hybridConfidence || 0).toFixed(2))}
+        ${this.renderMetric('Samples', forecast?.sampleSize ?? 0)}
+      </div>
+    `;
+  }
+
+  resolveNarrative(forecast) {
+    if (!forecast || forecast.sampleSize < 3) {
+      return 'Statistical baseline is collecting outcome density. Heuristic Oracle forecasts remain the primary reference until enough outcomes exist.';
+    }
+
+    if (forecast.heuristicComparison === 'overconfidence_flag') {
+      return 'Heuristic forecast is materially above statistical baseline. Treat future recommendations as overconfidence risk until more outcomes align.';
+    }
+
+    if (forecast.heuristicComparison === 'missed_opportunity') {
+      return 'Statistical baseline is outperforming heuristic expectation. Similar future scenarios may represent missed opportunity.';
+    }
+
+    return 'Heuristic and statistical forecast are aligned. Hybrid confidence can be lifted cautiously for similar strategy windows.';
+  }
+
+  resolveComparisonLabel(comparison) {
+    switch (comparison) {
+      case 'aligned':
+        return 'Hybrid forecast aligned';
+      case 'overconfidence_flag':
+        return 'Overconfidence flag';
+      case 'missed_opportunity':
+        return 'Missed opportunity';
+      case 'insufficient_data':
+      default:
+        return 'Collecting statistical baseline';
+    }
+  }
+
+  renderMetric(label, value) {
+    return `
+      <div class="oracle-forecast-metric">
+        <span>${this.escapeHtml(label)}</span>
+        <strong>${this.escapeHtml(String(value))}</strong>
+      </div>
+    `;
+  }
+
+  renderUnavailable() {
+    this.container.innerHTML = `
+      <div class="oracle-forecast-empty">
+        Statistical forecast is unavailable. Heuristic Oracle remains active.
+      </div>
+    `;
+  }
+
+  escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}

--- a/assets/js/modules/santis-oracle-statistical-forecast-client.js
+++ b/assets/js/modules/santis-oracle-statistical-forecast-client.js
@@ -1,0 +1,28 @@
+/**
+ * santis-oracle-statistical-forecast-client.js
+ * Read-only client for Oracle statistical forecast baseline.
+ */
+export class SantisOracleStatisticalForecastClient {
+  constructor({
+    baseUrl = 'http://localhost:3030/api/v1/oracle/statistical-forecast',
+  } = {}) {
+    this.baseUrl = baseUrl;
+  }
+
+  async read({ limit = 90 } = {}) {
+    const url = new URL(this.baseUrl);
+    url.searchParams.set('limit', String(limit));
+
+    const response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Oracle statistical forecast read failed: ${response.status}`);
+    }
+
+    const body = await response.json();
+    return body.data || null;
+  }
+}

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -36,6 +36,7 @@
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-simulation-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-execution-plan-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-oracle-outcome-feedback-panel.css" />
+  <link rel="stylesheet" href="/assets/css/modules/santis-oracle-forecast-panel.css" />
   <link rel="stylesheet" href="/assets/css/modules/santis-boardroom-dev-health-overlay.css" />
 </head>
 <body>
@@ -117,6 +118,16 @@
         </div>
         <div class="oracle-outcome-feedback" id="oracle-outcome-feedback-container">
           <div class="oracle-outcome-empty">Awaiting execution outcome feedback.</div>
+        </div>
+      </section>
+
+      <section class="santis-boardroom-forecast">
+        <div class="log-header">
+          <h2>Statistical Forecast</h2>
+          <span class="ai-badge">Baseline</span>
+        </div>
+        <div class="oracle-forecast-panel" id="oracle-statistical-forecast-container">
+          <div class="oracle-forecast-empty">Awaiting statistical forecast baseline.</div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Adds Oracle v2 statistical forecast baseline so outcome feedback data can be used alongside heuristic forecasting.

## Scope

- Adds GET /api/v1/oracle/statistical-forecast
- Adds outcome-history-based baseline forecast
- Adds 7/30 outcome moving averages
- Adds weighted trend and variance
- Adds statistical confidence
- Adds heuristic comparison states: aligned, overconfidence_flag, missed_opportunity, insufficient_data
- Adds hybrid confidence
- Adds Boardroom Statistical Forecast panel
- Adds Dev Health Overlay endpoint check

## Validation

- node --check passed for new and changed JS modules
- Targeted TypeScript check passed
- pnpm test:quality:static passed
- git diff --check passed

## Notes

PR #30 code is already present on main as 8db7994f and its remote branch has been removed; no additional action is required for that PR metadata mismatch.