### PR TITLE
fix(runtime): validate websocket gateway config

### DIFF
--- a/apps/ingestion-api/src/config/websocket-gateway.config.ts
+++ b/apps/ingestion-api/src/config/websocket-gateway.config.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+const WebSocketGatewayEnvSchema = z.object({
+  WS_PORT: z.coerce.number().int().min(1024).max(65535).default(8080),
+  WS_HOST: z.string().min(1).default("0.0.0.0"),
+  WS_PATH: z.string().startsWith("/").default("/ws"),
+});
+
+export type WebSocketGatewayConfig = z.infer<typeof WebSocketGatewayEnvSchema>;
+
+export function resolveWebSocketGatewayConfig(env: NodeJS.ProcessEnv = process.env): WebSocketGatewayConfig {
+  const parsed = WebSocketGatewayEnvSchema.safeParse(env);
+
+  if (!parsed.success) {
+    const details = parsed.error.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join("; ");
+
+    throw new Error(`[WS Gateway Config] Invalid environment: ${details}`);
+  }
+
+  return parsed.data;
+}

--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -8,6 +8,7 @@ import { CommandIngressService } from "./services/command-ingress";
 import { createIngressRouter } from "./routes/ingress";
 import { evaluateConciergeRules, deriveSignalFromDecision } from './decision-kernel';
 import { broadcastToGodMode } from "./routes/sse-streams";
+import { resolveWebSocketGatewayConfig } from "./config/websocket-gateway.config";
 
 import { createReadRoutes } from "./routes/read-queries";
 import { createHistoryReadRouter } from "./routes/read-history";
@@ -59,8 +60,12 @@ async function bootstrap() {
   registerCommandHandlers(bus);
 
   // --- WEBSOCKET GATEWAY (Port 8080) ---
-  const WS_PORT = process.env.WS_PORT || 8080;
-  const wss = new WebSocketServer({ port: Number(WS_PORT) });
+  const wsConfig = resolveWebSocketGatewayConfig();
+  const wss = new WebSocketServer({ 
+    host: wsConfig.WS_HOST,
+    port: wsConfig.WS_PORT,
+    path: wsConfig.WS_PATH
+  });
   
   wss.on('connection', (ws) => {
     console.log(`🔌 [WebSocket Gateway] İstemci bağlandı.`);
@@ -74,7 +79,9 @@ async function bootstrap() {
   console.log(`
   ╔═══════════════════════════════════════════════════╗
   ║  📡 WEBSOCKET GATEWAY ONLINE                      ║
-  ║  Port: ${WS_PORT}                                       ║
+  ║  Host: ${wsConfig.WS_HOST}
+  ║  Port: ${wsConfig.WS_PORT}
+  ║  Path: ${wsConfig.WS_PATH}
   ╚═══════════════════════════════════════════════════╝
   `);
   


### PR DESCRIPTION
Moves WebSocket gateway environment parsing into a dedicated Zod-validated config module and fails fast on invalid host, port, or path values.