### PR TITLE
feat(boardroom): wire oracle actions to command loopback

### DIFF
--- a/apps/ingestion-api/src/handlers/register-command-handlers.ts
+++ b/apps/ingestion-api/src/handlers/register-command-handlers.ts
@@ -68,4 +68,41 @@ export function registerCommandHandlers(bus: SovereignBus): void {
 
     return ack(command);
   });
+  bus.commands.registerHandler("boardroom.oracle.execute", async (command: CommandOfType<"boardroom.oracle.execute">) => {
+    await bus.events.publish({
+      eventId: crypto.randomUUID(),
+      eventType: "boardroom.oracle.executed",
+      occurredAt: new Date().toISOString(),
+      traceId: command.traceId,
+      sessionId: command.sessionId,
+      schemaVersion: "v1",
+      tenant: command.tenant || {
+        hotelId: "system",
+        hotelCode: "SYS",
+        region: "GLOBAL",
+        locale: "en",
+        currency: "EUR",
+        activePolicies: [],
+        fallbackMode: false,
+      },
+      intent: {
+        guestId: "system",
+        isReturningGuest: true,
+        segment: "vip",
+        moodAffinity: [],
+        premiumThreshold: 100,
+      },
+      payload: {
+        actionId: command.payload.actionId,
+        sourceEventId: command.payload.sourceEventId,
+        actionType: command.payload.actionType,
+        operatorId: command.payload.operatorId,
+        accepted: true,
+        executedAt: new Date().toISOString(),
+        metadata: command.payload.metadata,
+      },
+    } as any);
+
+    return ack(command);
+  });
 }

--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -158,7 +158,11 @@ async function bootstrap() {
       } else if (decision.includes('risk') || decision.includes('escalate')) {
          wsPayloadType = "RISK_SIGNAL";
          wsPayloadValue = Math.floor(metrics.abandon_risk * 100) || 85;
+      } else if (evtType === 'boardroom.oracle.executed') {
+         wsPayloadType = "ORACLE_LOOPBACK_ACK";
+         wsPayloadValue = payloadData.actionId || 1;
       }
+
 
       const wsMessage = JSON.stringify({
           type: wsPayloadType,

--- a/assets/js/modules/santis-boardroom-pro-live.js
+++ b/assets/js/modules/santis-boardroom-pro-live.js
@@ -441,6 +441,19 @@ document.addEventListener('DOMContentLoaded', () => {
     if (type === 'TELEMETRY' && payload && payload.value !== undefined) {
         uiUpdaters.counter('telemetry-count', payload.value);
     }
+
+    // Loopback ACK dinleyicisi
+    if (type === 'ORACLE_LOOPBACK_ACK') {
+        // UI Pulse animasyonu (sadece Action Memory loglarında)
+        const logStream = document.getElementById('oracle-log-stream');
+        if (logStream && typeof gsap !== 'undefined') {
+            gsap.fromTo(logStream, 
+                { backgroundColor: 'rgba(212, 175, 55, 0.1)' },
+                { backgroundColor: 'transparent', duration: 1.5, ease: 'power2.out' }
+            );
+        }
+        logOracleAction('SYSTEM_CONFIRM', `Kernel Ack: İşlem doğrulandı (ID: ${value})`);
+    }
   });
 
   /**
@@ -521,15 +534,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
               try {
                   // Komutu Backend'e gönder (window.SantisApi kullanıyoruz api-client.js deki tanımımız)
-                  await window.SantisApi.sendCommand('ExecuteOracleAction', {
-                      originalEvent: eventData.type,
-                      chosenAction: actionText,
-                      context: eventData.payload || {}
+                  let actionType = "acknowledge";
+                  if (actionText.includes("İndirim")) actionType = "apply_pricing_override";
+                  else if (actionText.includes("Askı")) actionType = "suppress";
+                  else if (actionText.includes("Ata") || actionText.includes("Güvenlik")) actionType = "escalate";
+                  
+                  await window.SantisApi.sendCommand('boardroom.oracle.execute', {
+                      actionId: typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).substring(2, 15),
+                      actionType: actionType,
+                      operatorId: "boardroom-operator",
+                      metadata: {
+                          originalEvent: eventData.type,
+                          chosenAction: actionText,
+                          context: eventData.payload || {}
+                      }
                   });
 
-                  // Başarı durumunda modalı kapat ve logger'a mesaj düş
+                  // Başarı durumunda modalı kapat, log'u loop-back ACK'dan alacağız, buraya success log koymaya gerek yok.
                   closeOracleModal();
-                  logOracleAction('SYSTEM_CONFIRM', `Onaylandı: ${actionText}`);
 
               } catch (err) {
                   // Hata durumunda kartı kırmızıya boyayalım
@@ -577,18 +599,6 @@ document.addEventListener('DOMContentLoaded', () => {
       const sessionId = controls.dataset.sessionId || 'session-unknown';
       const traceId = controls.dataset.traceId || crypto.randomUUID();
 
-      const payload = {
-          commandId: crypto.randomUUID(),
-          commandType: 'pricing.override.apply',
-          requestedAt: new Date().toISOString(),
-          traceId,
-          sessionId,
-          payload: {
-              recommendationId,
-              decision
-          }
-      };
-
       try {
           // Geri bildirim: butonları pasif yap
           const btns = controls.querySelectorAll('button');
@@ -597,13 +607,12 @@ document.addEventListener('DOMContentLoaded', () => {
               btn.style.opacity = '0.5';
           });
 
-          const response = await fetch('http://localhost:3030/api/v1/commands', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify(payload)
+          // Artık fetch localhost yerine api client kullanıyoruz
+          await window.SantisApi.sendCommand('pricing.override.apply', {
+              recommendationId,
+              decision,
+              operatorId: "boardroom-operator"
           });
-
-          if (!response.ok) throw new Error('Kernel override failed');
 
           logOracleAction('SYSTEM_CONFIRM', `Pricing Override Sent: ${decision}`);
           

--- a/packages/event-dictionary/src/index.ts
+++ b/packages/event-dictionary/src/index.ts
@@ -255,6 +255,22 @@ export const PricingOverrideAppliedEventSchema = BaseEventSchema.extend({
   payload: PricingOverrideAppliedSchema.shape.payload
 });
 
+export const BoardroomOracleExecutedPayloadSchema = z.object({
+  actionId: z.string(),
+  sourceEventId: z.string().optional(),
+  actionType: z.string(),
+  operatorId: z.string(),
+  accepted: z.literal(true),
+  executedAt: z.string().datetime(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const BoardroomOracleExecutedEventSchema = BaseEventSchema.extend({
+  eventType: z.literal("boardroom.oracle.executed"),
+  payload: BoardroomOracleExecutedPayloadSchema,
+});
+
+
 export const SantisEventSchema = z.discriminatedUnion("eventType", [
   MoodSelectedEventSchema,
   FlowAbandonedEventSchema,
@@ -267,6 +283,7 @@ export const SantisEventSchema = z.discriminatedUnion("eventType", [
   PricingRecommendationEmittedEventSchema,
   PricingAutonomousRecommendedEventSchema,
   PricingOverrideAppliedEventSchema,
+  BoardroomOracleExecutedEventSchema,
 ]);
 
 export type SantisEvent = z.infer<typeof SantisEventSchema>;
@@ -324,6 +341,27 @@ export const TriggerRiskSignalCommandSchema = BaseCommandSchema.extend({
 
 import { PricingOverrideCommandSchema } from "./pricing.schemas";
 
+export const BoardroomOracleExecutePayloadSchema = z.object({
+  actionId: z.string(),
+  sourceEventId: z.string().optional(),
+  actionType: z.enum([
+    "acknowledge",
+    "suppress",
+    "escalate",
+    "apply_pricing_override",
+    "lock_recommendation"
+  ]),
+  operatorId: z.string(),
+  reason: z.string().optional(),
+  metadata: z.record(z.unknown()).optional(),
+});
+
+export const BoardroomOracleExecuteCommandSchema = BaseCommandSchema.extend({
+  commandType: z.literal("boardroom.oracle.execute"),
+  payload: BoardroomOracleExecutePayloadSchema,
+});
+
+
 export const SantisCommandSchema = z.discriminatedUnion("commandType", [
   SelectMoodCommandSchema,
   CalculateOfferCommandSchema,
@@ -331,6 +369,7 @@ export const SantisCommandSchema = z.discriminatedUnion("commandType", [
   CommerceRecordCheckoutCommandSchema,
   TriggerRiskSignalCommandSchema,
   PricingOverrideCommandSchema,
+  BoardroomOracleExecuteCommandSchema,
 ]);
 
 export type SantisCommand = z.infer<typeof SantisCommandSchema>;


### PR DESCRIPTION
Adds boardroom.oracle.execute and boardroom.oracle.executed contracts, routes Oracle actions through the Sovereign command bus, broadcasts ORACLE_LOOPBACK_ACK over WebSocket, and updates Boardroom PRO to send Oracle actions through SantisApi.sendCommand.