### PR TITLE
feat(boardroom): add strategy approval queue

### DIFF
--- a/assets/css/modules/santis-oracle-simulation-panel.css
+++ b/assets/css/modules/santis-oracle-simulation-panel.css
@@ -17,6 +17,213 @@
   gap: 18px;
 }
 
+.simulation-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  margin-bottom: 4px;
+}
+
+.simulation-metric-card {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.simulation-label {
+  display: block;
+  margin-bottom: 8px;
+  color: #a0a0a0;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.simulation-value {
+  color: #e0e0e0;
+  font-size: 20px;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.simulation-value-accent {
+  color: var(--boardroom-accent);
+}
+
+.simulation-value-positive {
+  color: #4caf50;
+}
+
+.simulation-action-rail {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.btn-queue-strategy,
+.strategy-queue-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 38px;
+  border-radius: 4px;
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--boardroom-accent);
+  cursor: pointer;
+  font-family: 'Cinzel', serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
+}
+
+.btn-queue-strategy {
+  padding: 10px 20px;
+}
+
+.btn-queue-strategy:disabled,
+.strategy-queue-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.strategy-approval-queue {
+  display: grid;
+  gap: 12px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.strategy-queue-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.strategy-queue-header span {
+  color: var(--boardroom-text-muted);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.strategy-queue-header strong {
+  min-width: 32px;
+  color: var(--boardroom-accent);
+  font-size: 18px;
+  text-align: right;
+}
+
+.strategy-queue-list {
+  display: grid;
+  gap: 10px;
+}
+
+.strategy-queue-empty,
+.strategy-queue-card {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.strategy-queue-empty {
+  padding: 14px;
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.strategy-queue-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  padding: 14px;
+}
+
+.strategy-queue-card.is-applying {
+  border-color: rgba(212, 175, 55, 0.42);
+}
+
+.strategy-queue-card.is-sealed {
+  border-color: rgba(76, 175, 80, 0.45);
+}
+
+.strategy-queue-card.is-rejected {
+  border-color: rgba(244, 67, 54, 0.38);
+}
+
+.strategy-queue-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.strategy-queue-title strong {
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.35;
+}
+
+.strategy-queue-status {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: rgba(212, 175, 55, 0.1);
+  color: var(--boardroom-accent);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.strategy-queue-status.is-sealed {
+  background: rgba(76, 175, 80, 0.12);
+  color: #4caf50;
+}
+
+.strategy-queue-status.is-rejected {
+  background: rgba(244, 67, 54, 0.12);
+  color: #f44336;
+}
+
+.strategy-queue-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  color: var(--boardroom-text-muted);
+  font-size: 12px;
+}
+
+.strategy-queue-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.strategy-queue-action {
+  min-width: 86px;
+  padding: 8px 12px;
+}
+
+.strategy-queue-action-approve {
+  border-color: rgba(76, 175, 80, 0.45);
+  background: rgba(76, 175, 80, 0.12);
+  color: #4caf50;
+}
+
+.strategy-queue-action-reject {
+  border-color: rgba(244, 67, 54, 0.38);
+  background: rgba(244, 67, 54, 0.1);
+  color: #f44336;
+}
+
 .oracle-simulation-brief {
   padding: 18px;
   border-left: 2px solid var(--boardroom-accent);
@@ -123,8 +330,28 @@
 }
 
 @media (max-width: 768px) {
+  .simulation-grid,
   .oracle-simulation-grid,
   .oracle-simulation-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .simulation-action-rail {
+    justify-content: stretch;
+  }
+
+  .btn-queue-strategy,
+  .strategy-queue-actions,
+  .strategy-queue-action {
+    width: 100%;
+  }
+
+  .strategy-queue-card,
+  .strategy-queue-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .strategy-queue-actions {
+    display: grid;
   }
 }

--- a/assets/js/modules/santis-boardroom-pro-live.js
+++ b/assets/js/modules/santis-boardroom-pro-live.js
@@ -8,6 +8,9 @@ import { SantisBoardroomProCoreStateAdapter } from './santis-boardroom-pro-cores
 document.addEventListener('DOMContentLoaded', () => {
   console.log('🚀 Bootstrapping Boardroom PRO Live Nervous System...');
 
+  let pendingStrategyApply = null;
+  const strategyApprovalQueue = [];
+
   // Initialize the adapter first so it's ready to catch events
   SantisBoardroomProCoreStateAdapter.init();
 
@@ -266,10 +269,12 @@ document.addEventListener('DOMContentLoaded', () => {
             applyBtn.dataset.recommendationId = recommendationId;
             applyBtn.dataset.sessionId = sessionId;
             applyBtn.dataset.traceId = s.traceId || '';
+            applyBtn.dataset.action = s.simulatedAction || s.action || 'strategy';
             applyBtn.dataset.delta = simulatedDelta;
             applyBtn.dataset.expectedRevenueDelta = expectedRevenueDelta;
             applyBtn.dataset.confidence = s.confidence || 0;
             applyBtn.dataset.trigger = s.trigger || s.reasonCodes?.[0] || 'shadow_pricing';
+            updateQueueButtonState();
         }
     },
 
@@ -484,8 +489,6 @@ document.addEventListener('DOMContentLoaded', () => {
   // Başlangıçta logları yükle
   loadOracleLogsFromMemory();
 
-  let pendingStrategyApply = null;
-
   function logOracleAction(type, message) {
       const streamContainer = document.getElementById('oracle-log-stream');
       if (!streamContainer) return;
@@ -552,6 +555,200 @@ document.addEventListener('DOMContentLoaded', () => {
       pending.button.innerHTML = pending.originalHtml;
   }
 
+  function escapeHtml(value) {
+      return String(value ?? '')
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;')
+          .replace(/'/g, '&#039;');
+  }
+
+  function createStrategyQueueId() {
+      if (window.crypto && typeof window.crypto.randomUUID === 'function') {
+          return window.crypto.randomUUID();
+      }
+
+      return `strategy-${Date.now()}-${Math.round(Math.random() * 100000)}`;
+  }
+
+  function formatDeltaPct(value) {
+      const numeric = Number(value) || 0;
+      const rounded = Math.round(numeric * 100);
+      return rounded > 0 ? `+${rounded}%` : `${rounded}%`;
+  }
+
+  function formatRevenueDelta(value) {
+      const numeric = Number(value) || 0;
+      const prefix = numeric > 0 ? '+' : '';
+      return `${prefix}${formatCurrency(Math.abs(numeric))}`;
+  }
+
+  function getQueuedStrategyByRecommendation(recommendationId) {
+      return strategyApprovalQueue.find((item) => item.recommendationId === recommendationId);
+  }
+
+  function updateQueueButtonState() {
+      const btn = document.getElementById('btn-apply-simulation') || document.getElementById('btn-guarded-strategy-apply');
+      if (!btn) return;
+
+      const recommendationId = btn.dataset.recommendationId;
+      const sessionId = btn.dataset.sessionId;
+      const queued = recommendationId ? getQueuedStrategyByRecommendation(recommendationId) : null;
+      const label = document.getElementById('btn-apply-simulation-label');
+
+      btn.disabled = !(recommendationId && sessionId) || Boolean(queued && queued.status !== 'rejected');
+      btn.classList.toggle('is-queued', Boolean(queued && queued.status !== 'rejected'));
+      if (label) {
+          label.innerText = queued && queued.status !== 'rejected' ? 'Queued' : 'Queue Strategy';
+      }
+  }
+
+  function createStrategyQueueItemFromButton(button) {
+      const recommendationId = button.dataset.recommendationId;
+      const sessionId = button.dataset.sessionId;
+      const simulatedDeltaPct = parseFloat(button.dataset.delta);
+      const expectedRevenueDelta = parseFloat(button.dataset.expectedRevenueDelta);
+      const confidence = parseFloat(button.dataset.confidence);
+
+      if (!recommendationId || !sessionId) {
+          throw new Error('Strategy queue requires recommendationId and sessionId');
+      }
+
+      return {
+          id: createStrategyQueueId(),
+          recommendationId,
+          sessionId,
+          traceId: button.dataset.traceId || '',
+          simulatedAction: button.dataset.action || 'strategy',
+          simulatedDeltaPct: Number.isFinite(simulatedDeltaPct) ? simulatedDeltaPct : 0,
+          expectedRevenueDelta: Number.isFinite(expectedRevenueDelta) ? expectedRevenueDelta : 0,
+          confidence: Number.isFinite(confidence) ? confidence : 0,
+          trigger: button.dataset.trigger || 'shadow_pricing',
+          status: 'pending',
+          createdAt: new Date().toISOString(),
+      };
+  }
+
+  function renderStrategyApprovalQueue() {
+      const queueList = document.getElementById('strategy-queue-list');
+      const queueCount = document.getElementById('strategy-queue-count');
+      if (!queueList) return;
+
+      const activeCount = strategyApprovalQueue.filter((item) => item.status === 'pending' || item.status === 'applying').length;
+      if (queueCount) queueCount.innerText = String(activeCount);
+
+      if (strategyApprovalQueue.length === 0) {
+          queueList.innerHTML = '<div class="strategy-queue-empty">No queued strategy decisions.</div>';
+          updateQueueButtonState();
+          return;
+      }
+
+      queueList.innerHTML = strategyApprovalQueue.map((item) => {
+          const statusLabel = item.status === 'applying'
+              ? 'Applying'
+              : item.status === 'sealed'
+                  ? 'Sealed'
+                  : item.status === 'rejected'
+                      ? 'Rejected'
+                      : 'Pending';
+          const canAct = item.status === 'pending';
+          const disabledAttr = canAct ? '' : ' disabled';
+
+          return `
+              <article class="strategy-queue-card is-${escapeHtml(item.status)}" data-queue-id="${escapeHtml(item.id)}">
+                  <div>
+                      <div class="strategy-queue-title">
+                          <strong>${escapeHtml(String(item.simulatedAction || 'strategy').replace(/_/g, ' ').toUpperCase())}</strong>
+                          <span class="strategy-queue-status is-${escapeHtml(item.status)}">${escapeHtml(statusLabel)}</span>
+                      </div>
+                      <div class="strategy-queue-meta">
+                          <span>${escapeHtml(formatDeltaPct(item.simulatedDeltaPct))}</span>
+                          <span>${escapeHtml(formatRevenueDelta(item.expectedRevenueDelta))}</span>
+                          <span>${Math.round((Number(item.confidence) || 0) * 100)}% confidence</span>
+                      </div>
+                  </div>
+                  <div class="strategy-queue-actions">
+                      <button class="strategy-queue-action strategy-queue-action-approve" data-queue-action="approve" data-queue-id="${escapeHtml(item.id)}"${disabledAttr}>Approve</button>
+                      <button class="strategy-queue-action strategy-queue-action-reject" data-queue-action="reject" data-queue-id="${escapeHtml(item.id)}"${disabledAttr}>Reject</button>
+                  </div>
+              </article>
+          `;
+      }).join('');
+
+      updateQueueButtonState();
+  }
+
+  function buildStrategyApplyPayload(item) {
+      return {
+          recommendationId: item.recommendationId,
+          sessionId: item.sessionId,
+          traceId: item.traceId,
+          strategy: {
+              type: 'price_adjustment',
+              deltaPct: item.simulatedDeltaPct,
+              expectedRevenueDelta: item.expectedRevenueDelta
+          },
+          decision: 'approve',
+          operatorContext: {
+              operatorId: 'boardroom-operator',
+              source: 'boardroom-ui'
+          },
+          meta: {
+              confidence: item.confidence,
+              trigger: item.trigger
+          }
+      };
+  }
+
+  async function approveQueuedStrategy(item) {
+      const panel = document.getElementById('oracle-strategy-simulation-container');
+      item.status = 'applying';
+      renderStrategyApprovalQueue();
+
+      if (typeof gsap !== 'undefined' && panel) {
+          gsap.fromTo(panel,
+              { boxShadow: '0 0 0 rgba(212, 175, 55, 0)', borderColor: 'rgba(212, 175, 55, 0.72)' },
+              { boxShadow: '0 0 32px rgba(212, 175, 55, 0.2)', borderColor: 'rgba(212, 175, 55, 0.38)', duration: 0.45, ease: 'power2.out' }
+          );
+      }
+
+      const payload = buildStrategyApplyPayload(item);
+      pendingStrategyApply = {
+          itemId: item.id,
+          panel,
+          payload,
+          timeoutId: null
+      };
+
+      pendingStrategyApply.timeoutId = setTimeout(() => {
+          if (!pendingStrategyApply || pendingStrategyApply.itemId !== item.id) return;
+          pendingStrategyApply = null;
+          item.status = 'pending';
+          renderStrategyApprovalQueue();
+          logOracleAction('RISK_SIGNAL', 'Strategy Apply ACK timeout');
+      }, 8000);
+
+      try {
+          await window.SantisApi.sendCommand('boardroom.strategy.apply', payload);
+      } catch (err) {
+          console.error('[Strategy Queue] Apply failed:', err);
+          if (pendingStrategyApply?.timeoutId) {
+              clearTimeout(pendingStrategyApply.timeoutId);
+          }
+          pendingStrategyApply = null;
+          item.status = 'pending';
+          renderStrategyApprovalQueue();
+          logOracleAction('RISK_SIGNAL', 'Strategy Apply Failed');
+      }
+  }
+
+  function rejectQueuedStrategy(item) {
+      item.status = 'rejected';
+      renderStrategyApprovalQueue();
+      logOracleAction('STRATEGY_REJECTED', `Strategy Rejected: ${formatDeltaPct(item.simulatedDeltaPct)} price adjustment`);
+  }
+
   function resolvePendingStrategyApply(ackId) {
       if (!pendingStrategyApply) return false;
 
@@ -564,6 +761,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const deltaPct = Math.round((pending.payload.strategy.deltaPct || 0) * 100);
       const deltaText = deltaPct > 0 ? `+${deltaPct}%` : `${deltaPct}%`;
+      const item = strategyApprovalQueue.find((queued) => queued.id === pending.itemId || queued.recommendationId === ackId);
+      if (item) {
+          item.status = 'sealed';
+      }
 
       if (typeof gsap !== 'undefined') {
           if (pending.panel) {
@@ -573,18 +774,21 @@ document.addEventListener('DOMContentLoaded', () => {
               );
           }
 
-          gsap.to(pending.button, {
-              backgroundColor: 'rgba(76, 175, 80, 0.2)',
-              color: '#4caf50',
-              duration: 0.25,
-              onComplete: () => {
-                  setTimeout(() => restoreStrategyApplyButton(pending), 2000);
+          if (item) {
+              const card = Array.from(document.querySelectorAll('[data-queue-id]'))
+                  .find((candidate) => candidate.dataset.queueId === item.id);
+              if (card) {
+                  gsap.fromTo(card,
+                      { backgroundColor: 'rgba(76, 175, 80, 0.12)' },
+                      { backgroundColor: 'rgba(255, 255, 255, 0.025)', duration: 1.2, ease: 'power2.out' }
+                  );
               }
-          });
+          }
       } else {
           restoreStrategyApplyButton(pending);
       }
 
+      renderStrategyApprovalQueue();
       logOracleAction('STRATEGY_APPLIED', `Strategy Applied: ${deltaText} price adjustment (ACK: ${ackId})`);
       return true;
   }
@@ -846,84 +1050,47 @@ document.addEventListener('DOMContentLoaded', () => {
   const btnRejectPricing = document.getElementById('btn-reject-pricing');
   if (btnRejectPricing) btnRejectPricing.addEventListener('click', () => sendPricingOverride('reject'));
 
-  // Strategy Simulation Guarded Apply logic
+  // Strategy Simulation Queue logic
   const btnStrategyApply = document.getElementById('btn-apply-simulation') || document.getElementById('btn-guarded-strategy-apply');
   if (btnStrategyApply) {
-      btnStrategyApply.addEventListener('click', async () => {
-          const panel = document.getElementById('oracle-strategy-simulation-container');
-          const originalHtml = btnStrategyApply.innerHTML;
-
+      btnStrategyApply.addEventListener('click', () => {
           try {
-              const recommendationId = btnStrategyApply.dataset.recommendationId;
-              const sessionId = btnStrategyApply.dataset.sessionId;
-              const deltaPct = parseFloat(btnStrategyApply.dataset.delta);
-              const expectedRevenueDelta = parseFloat(btnStrategyApply.dataset.expectedRevenueDelta);
-              const confidence = parseFloat(btnStrategyApply.dataset.confidence);
+              const item = createStrategyQueueItemFromButton(btnStrategyApply);
+              const existing = getQueuedStrategyByRecommendation(item.recommendationId);
 
-              if (!recommendationId || !sessionId) {
-                  throw new Error('Strategy apply requires recommendationId and sessionId');
+              if (existing && existing.status !== 'rejected') {
+                  updateQueueButtonState();
+                  return;
               }
 
-              btnStrategyApply.disabled = true;
-              btnStrategyApply.style.opacity = '0.5';
-              btnStrategyApply.innerHTML = 'APPLYING...';
-
-              if (typeof gsap !== 'undefined' && panel) {
-                  gsap.fromTo(panel,
-                      { boxShadow: '0 0 0 rgba(212, 175, 55, 0)', borderColor: 'rgba(212, 175, 55, 0.72)' },
-                      { boxShadow: '0 0 32px rgba(212, 175, 55, 0.2)', borderColor: 'rgba(212, 175, 55, 0.38)', duration: 0.45, ease: 'power2.out' }
-                  );
-              }
-              
-              const payload = {
-                  recommendationId,
-                  sessionId,
-                  traceId: btnStrategyApply.dataset.traceId,
-                  strategy: {
-                      type: 'price_adjustment',
-                      deltaPct: Number.isFinite(deltaPct) ? deltaPct : 0,
-                      expectedRevenueDelta: Number.isFinite(expectedRevenueDelta) ? expectedRevenueDelta : 0
-                  },
-                  decision: 'approve',
-                  operatorContext: {
-                      operatorId: 'boardroom-operator',
-                      source: 'boardroom-ui'
-                  },
-                  meta: {
-                      confidence: Number.isFinite(confidence) ? confidence : 0,
-                      trigger: btnStrategyApply.dataset.trigger || 'shadow_pricing'
-                  }
-              };
-
-              pendingStrategyApply = {
-                  button: btnStrategyApply,
-                  panel,
-                  originalHtml,
-                  payload,
-                  timeoutId: null
-              };
-
-              pendingStrategyApply.timeoutId = setTimeout(() => {
-                  if (!pendingStrategyApply) return;
-                  const pending = pendingStrategyApply;
-                  pendingStrategyApply = null;
-                  restoreStrategyApplyButton(pending);
-                  logOracleAction('RISK_SIGNAL', 'Strategy Apply ACK timeout');
-              }, 8000);
-
-              await window.SantisApi.sendCommand('boardroom.strategy.apply', payload);
+              strategyApprovalQueue.unshift(item);
+              renderStrategyApprovalQueue();
+              logOracleAction('STRATEGY_QUEUED', `Strategy Queued: ${formatDeltaPct(item.simulatedDeltaPct)} price adjustment`);
           } catch (err) {
-              console.error('[Strategy Apply] Error:', err);
-              logOracleAction('RISK_SIGNAL', `Strategy Apply Failed`);
-              if (pendingStrategyApply?.timeoutId) {
-                  clearTimeout(pendingStrategyApply.timeoutId);
-              }
-              pendingStrategyApply = null;
-              btnStrategyApply.disabled = false;
-              btnStrategyApply.style.opacity = '1';
-              btnStrategyApply.innerHTML = originalHtml;
+              console.error('[Strategy Queue] Queue failed:', err);
+              logOracleAction('RISK_SIGNAL', 'Strategy Queue Failed');
           }
       });
   }
+
+  const strategyQueueList = document.getElementById('strategy-queue-list');
+  if (strategyQueueList) {
+      strategyQueueList.addEventListener('click', (event) => {
+          if (!(event.target instanceof Element)) return;
+          const actionButton = event.target.closest('[data-queue-action]');
+          if (!actionButton) return;
+
+          const item = strategyApprovalQueue.find((queued) => queued.id === actionButton.dataset.queueId);
+          if (!item || item.status !== 'pending') return;
+
+          if (actionButton.dataset.queueAction === 'approve') {
+              approveQueuedStrategy(item);
+          } else if (actionButton.dataset.queueAction === 'reject') {
+              rejectQueuedStrategy(item);
+          }
+      });
+  }
+
+  renderStrategyApprovalQueue();
 
 });

--- a/tr/boardroom/index.html
+++ b/tr/boardroom/index.html
@@ -177,30 +177,39 @@
           <span class="ai-badge">Preview</span>
         </div>
         <div class="oracle-simulation-panel" id="oracle-strategy-simulation-container">
-          <div class="simulation-grid" id="sim-grid-state" style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1rem;">
-            <div class="simulation-metric-card" style="padding: 1rem; background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.05); border-radius: 8px;">
-              <span class="simulation-label" style="display: block; font-size: 0.75rem; color: #a0a0a0; margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 1px;">Simulated Action</span>
-              <strong class="simulation-value" id="sim-val-action" style="font-size: 1.25rem; color: #d4af37;">--</strong>
+          <div class="simulation-grid" id="sim-grid-state">
+            <div class="simulation-metric-card">
+              <span class="simulation-label">Simulated Action</span>
+              <strong class="simulation-value simulation-value-accent" id="sim-val-action">--</strong>
             </div>
-            <div class="simulation-metric-card" style="padding: 1rem; background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.05); border-radius: 8px;">
-              <span class="simulation-label" style="display: block; font-size: 0.75rem; color: #a0a0a0; margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 1px;">Price Delta</span>
-              <strong class="simulation-value" id="sim-val-delta" style="font-size: 1.25rem; color: #e0e0e0;">--</strong>
+            <div class="simulation-metric-card">
+              <span class="simulation-label">Price Delta</span>
+              <strong class="simulation-value" id="sim-val-delta">--</strong>
             </div>
-            <div class="simulation-metric-card" style="padding: 1rem; background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.05); border-radius: 8px;">
-              <span class="simulation-label" style="display: block; font-size: 0.75rem; color: #a0a0a0; margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 1px;">Expected Revenue</span>
-              <strong class="simulation-value" id="sim-val-revenue" style="font-size: 1.25rem; color: #4caf50;">--</strong>
+            <div class="simulation-metric-card">
+              <span class="simulation-label">Expected Revenue</span>
+              <strong class="simulation-value simulation-value-positive" id="sim-val-revenue">--</strong>
             </div>
-            <div class="simulation-metric-card" style="padding: 1rem; background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.05); border-radius: 8px;">
-              <span class="simulation-label" style="display: block; font-size: 0.75rem; color: #a0a0a0; margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 1px;">Confidence</span>
-              <strong class="simulation-value" id="sim-val-confidence" style="font-size: 1.25rem; color: #e0e0e0;">--</strong>
+            <div class="simulation-metric-card">
+              <span class="simulation-label">Confidence</span>
+              <strong class="simulation-value" id="sim-val-confidence">--</strong>
             </div>
           </div>
           
-          <div class="simulation-action-rail" id="simulation-guarded-apply-container" style="border-top: 1px solid rgba(255,255,255,0.1); padding-top: 1rem; display: flex; justify-content: flex-end;">
-            <button id="btn-apply-simulation" class="btn-oracle-override" disabled style="background: rgba(212, 175, 55, 0.1); border: 1px solid rgba(212, 175, 55, 0.4); color: #d4af37; padding: 10px 20px; border-radius: 4px; cursor: pointer; display: flex; align-items: center; gap: 8px; transition: all 0.3s ease; font-family: 'Cinzel', serif; letter-spacing: 1px;">
+          <div class="simulation-action-rail" id="simulation-guarded-apply-container">
+            <button id="btn-apply-simulation" class="btn-oracle-override btn-queue-strategy" disabled>
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
-              GUARDED APPLY
+              <span id="btn-apply-simulation-label">Queue Strategy</span>
             </button>
+          </div>
+          <div class="strategy-approval-queue" id="strategy-approval-queue">
+            <div class="strategy-queue-header">
+              <span>Pending Human Seal</span>
+              <strong id="strategy-queue-count">0</strong>
+            </div>
+            <div class="strategy-queue-list" id="strategy-queue-list">
+              <div class="strategy-queue-empty">No queued strategy decisions.</div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Adds a local Strategy Approval Queue over the existing boardroom.strategy.apply command. Operators can queue the current Strategy Simulation recommendation, see it as Pending Human Seal, approve to dispatch the existing command and seal on STRATEGY_APPLY_ACK, or reject locally with Action Memory logging. Scope is frontend-only orchestration: Boardroom HTML, live module logic, and simulation panel CSS.