### PR TITLE
fix(admin): clean up vite config lint issue

### DIFF
--- a/admin-panel/vite.config.js
+++ b/admin-panel/vite.config.js
@@ -2,11 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import autoprefixer from 'autoprefixer'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
-import tailwindcss from 'tailwindcss'
-import autoprefixer from 'autoprefixer'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -14,7 +13,6 @@ export default defineConfig({
   css: {
     postcss: {
       plugins: [
-        tailwindcss,
         autoprefixer,
       ],
     },


### PR DESCRIPTION
Cleans up the admin panel Vite config lint issue without changing the Boardroom runtime port contract.