### PR TITLE
fix(runtime): resolve static site api and ws origins

### DIFF
--- a/assets/js/core/santis-telemetry-client.js
+++ b/assets/js/core/santis-telemetry-client.js
@@ -9,20 +9,52 @@
 
 class SantisTelemetryClient {
     constructor() {
-        this.wsUrl = 'ws://localhost:8080/ws';
+        const config = window.getRuntimeConfig ? window.getRuntimeConfig() : {};
+        this.wsUrl = config.wsUrl || 'ws://localhost:8080/ws';
+        this.apiBaseUrl = config.apiBaseUrl || '/api/v1';
         this.reconnectTimeout = null;
         this.reconnectAttempts = 0;
         this.maxReconnectAttempts = 3;
         this.initConnection();
     }
 
-    initConnection() {
+    async resolveAuthenticatedWsUrl() {
+        let token = null;
+
+        if (window.SantisApi && typeof window.SantisApi.getSessionToken === 'function') {
+            token = await window.SantisApi.getSessionToken();
+        }
+
+        if (!token) {
+            try {
+                const response = await fetch(`${this.apiBaseUrl}/auth/session`, {
+                    headers: { Accept: 'application/json' },
+                    cache: 'no-store',
+                });
+                if (response.ok) {
+                    const data = await response.json();
+                    token = data.token || null;
+                }
+            } catch (error) {
+                console.warn('[Telemetry Client] Session token alınamadı:', error.message);
+            }
+        }
+
+        if (!token) return this.wsUrl;
+
+        const url = new URL(this.wsUrl, window.location.href);
+        url.searchParams.set('client_type', 'telemetry');
+        url.searchParams.set('token', token);
+        return url.toString();
+    }
+
+    async initConnection() {
         // İstemci tarafında bağlantı fırtınasını engelleyen Singleton Kalkanı
         if (!window.SantisSocket || window.SantisSocket.readyState === WebSocket.CLOSED) {
             console.log(`🛡️ [Telemetry Client] Singleton Kalkanı aktif ediliyor. Bağlantı başlatılıyor... (Deneme: ${this.reconnectAttempts + 1}/${this.maxReconnectAttempts + 1})`);
             
             try {
-                window.SantisSocket = new WebSocket(this.wsUrl);
+                window.SantisSocket = new WebSocket(await this.resolveAuthenticatedWsUrl());
             } catch (e) {
                 console.error("🚨 [Telemetry Client] Socket oluşturma hatası:", e);
                 this.scheduleReconnect();

--- a/tr/index.html
+++ b/tr/index.html
@@ -11,9 +11,10 @@ if (window.location.protocol === 'file:') {
     ? normalizedPath.slice(markerIndex + marker.length - 1)
     : '/tr/index.html';
 
-  window.location.replace(`http://localhost:3030${routePath}${window.location.search}${window.location.hash}`);
+  window.location.replace(`http://127.0.0.1:5500${routePath}${window.location.search}${window.location.hash}`);
 }
 </script>
+<script src="/assets/js/core/santis-runtime-resolver.js"></script>
 <script src="/assets/js/santis-config.js"></script>
 <script src="/assets/js/api-client.js"></script>
 <script src="/assets/js/santis-public-runtime-shim.js"></script>


### PR DESCRIPTION
Fixes local static site runtime origin resolution without changing the Boardroom port contract. Loads the runtime resolver before Santis config/API client on tr/index.html, points file:// guard to the static 5500 origin, and makes the telemetry singleton use the resolved token-authenticated WS gateway instead of a hardcoded tokenless localhost URL.