### PR TITLE
chore: seal Santis OS architectural sovereignty layer

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -1,0 +1,39 @@
+name: "Santis OS — Sovereign CI/CD"
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  seal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout Sovereign Source"
+        uses: actions/checkout@v4
+
+      - name: "Initialize Node & Corepack"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: "Enable Corepack"
+        run: corepack enable
+
+      - name: "Resolve pnpm version"
+        run: corepack prepare pnpm@9.1.0 --activate
+
+      - name: "Sovereign Dependency Fetch"
+        run: pnpm fetch
+
+      - name: "Install Dependencies (Offline/Frozen)"
+        run: pnpm install --offline --frozen-lockfile
+
+      - name: "🛡️ Execute Sovereign Guards"
+        run: pnpm run audit:all
+
+      - name: "Build Sovereign Artifacts"
+        run: pnpm run build

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: "Install Dependencies (Offline/Frozen)"
         run: pnpm install --offline --frozen-lockfile
 
+      - name: "🧠 Boardroom Intelligence — Telemetry Bridge"
+        env:
+          SANTIS_TELEMETRY_KEY: ${{ secrets.SANTIS_TELEMETRY_KEY }}
+          SANTIS_API_URL: ${{ secrets.SANTIS_API_URL }}
+        run: node scripts/ci-telemetry-bridge.js
+
       - name: "🛡️ Execute Sovereign Guards"
         run: pnpm run audit:all
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,40 +1,50 @@
 # ╔══════════════════════════════════════════════════════╗
-# ║  SANTIS OS v3 — Frontend Dockerfile                 ║
-# ║  Stage 1: Vite Build (Node 20 LTS)                  ║
+# ║  SANTIS OS — Sovereign Frontend Dockerfile          ║
+# ║  Stage 1: pnpm/Turbo Build (Node 20 LTS)            ║
 # ║  Stage 2: Nginx Serve (Alpine)                      ║
 # ╚══════════════════════════════════════════════════════╝
 
-# ── Stage 1: Vite Builder ─────────────────────────────────────────────────────
+# ── Stage 1: Sovereign Builder ────────────────────────────────────────────────
 FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Layer cache: önce sadece package dosyaları (bağımlılıklar değişmezse cache'den gelir)
-COPY package.json package-lock.json* ./
-RUN npm ci --prefer-offline
+# Corepack seals pnpm into the container runtime.
+RUN corepack enable
 
-# Kaynak dosyaları kopyala
+# Layer cache: copy only dependency/workspace manifests first.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
+
+# Fetch dependency graph into the pnpm store before copying source.
+RUN pnpm fetch
+
+# Copy source after fetch to preserve dependency cache across code changes.
 COPY . .
 
-# Production Vite build → dist/
-RUN npm run build:vite
+# Install strictly from the previously fetched store.
+RUN pnpm install --offline --frozen-lockfile
 
-# ── Stage 2: Nginx Production ─────────────────────────────────────────────────
+# Constitutional guardrail before artifact creation.
+RUN pnpm run audit:all
+
+# Production build through the monorepo contract.
+RUN pnpm run build
+
+# ── Stage 2: Nginx Production ────────────────────────────────────────────────
 FROM nginx:1.27-alpine AS production
 
 WORKDIR /usr/share/nginx/html
 
-# Güvenlik: root olmayan nginx user
+# Security: run as non-root nginx user.
 RUN chown -R nginx:nginx /usr/share/nginx/html && \
     chown -R nginx:nginx /var/cache/nginx && \
     chown -R nginx:nginx /var/log/nginx && \
     touch /var/run/nginx.pid && \
     chown nginx:nginx /var/run/nginx.pid
 
-# Nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Vite dist → nginx html root
+# Serve only built artifacts.
 COPY --from=builder --chown=nginx:nginx /app/dist .
 
 USER nginx

--- a/admin-panel/src/components/TechnicalDebtPanel.tsx
+++ b/admin-panel/src/components/TechnicalDebtPanel.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useMemo, useState } from "react";
+
+export type TechnicalDebtSignal = {
+  id: string;
+  source: "ci" | "docker" | "local" | "runtime";
+  type: string;
+  severity: "low" | "medium" | "high" | "critical";
+  title: string;
+  detail: string;
+  detectedAt: string;
+  euroRisk: number;
+  confidence: number;
+  remediation: string;
+};
+
+export type TechnicalDebtSnapshot = {
+  generatedAt: string;
+  totalSignals: number;
+  criticalSignals: number;
+  highSignals: number;
+  euroRiskTotal: number;
+  posture: "sealed" | "watch" | "degraded" | "breach";
+  signals: TechnicalDebtSignal[];
+};
+
+type ApiSnapshotResponse = {
+  ok: boolean;
+  snapshot: TechnicalDebtSnapshot;
+};
+
+type Props = {
+  apiBaseUrl?: string;
+  streamUrl?: string;
+};
+
+const emptySnapshot: TechnicalDebtSnapshot = {
+  generatedAt: new Date(0).toISOString(),
+  totalSignals: 0,
+  criticalSignals: 0,
+  highSignals: 0,
+  euroRiskTotal: 0,
+  posture: "sealed",
+  signals: [],
+};
+
+const postureLabel: Record<TechnicalDebtSnapshot["posture"], string> = {
+  sealed: "Sealed",
+  watch: "Watch",
+  degraded: "Degraded",
+  breach: "Breach",
+};
+
+function formatEuro(value: number) {
+  return new Intl.NumberFormat("en-EU", {
+    style: "currency",
+    currency: "EUR",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function useTechnicalDebtSnapshot(apiBaseUrl = "") {
+  const [snapshot, setSnapshot] = useState<TechnicalDebtSnapshot>(emptySnapshot);
+  const [status, setStatus] = useState<"idle" | "loading" | "live" | "offline">("idle");
+
+  useEffect(() => {
+    let alive = true;
+    setStatus("loading");
+
+    fetch(`${apiBaseUrl}/api/v1/technical-debt/snapshot`)
+      .then((response) => response.json() as Promise<ApiSnapshotResponse>)
+      .then((payload) => {
+        if (!alive) return;
+        if (payload.ok && payload.snapshot) {
+          setSnapshot(payload.snapshot);
+          setStatus("live");
+        }
+      })
+      .catch(() => {
+        if (alive) setStatus("offline");
+      });
+
+    return () => {
+      alive = false;
+    };
+  }, [apiBaseUrl]);
+
+  return { snapshot, setSnapshot, status, setStatus };
+}
+
+export function TechnicalDebtPanel({ apiBaseUrl = "", streamUrl }: Props) {
+  const { snapshot, setSnapshot, status, setStatus } = useTechnicalDebtSnapshot(apiBaseUrl);
+
+  useEffect(() => {
+    if (!streamUrl || typeof EventSource === "undefined") return;
+
+    const source = new EventSource(streamUrl);
+
+    source.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data);
+        if (message?.type === "TECH_DEBT_UPDATE" && message?.payload) {
+          setSnapshot(message.payload as TechnicalDebtSnapshot);
+          setStatus("live");
+        }
+      } catch {
+        // Ignore malformed stream frames; contract enforcement lives server-side.
+      }
+    };
+
+    source.onerror = () => setStatus("offline");
+
+    return () => source.close();
+  }, [setSnapshot, setStatus, streamUrl]);
+
+  const latestSignals = useMemo(() => snapshot.signals.slice(-3).reverse(), [snapshot.signals]);
+
+  return (
+    <section className="rounded-[28px] border border-white/10 bg-[#101010]/95 p-6 text-[#ede9df] shadow-2xl shadow-black/30">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.32em] text-white/40">Technical Debt Intelligence</p>
+          <h2 className="mt-2 text-2xl font-light tracking-[-0.03em]">System Posture</h2>
+        </div>
+        <div className="rounded-full border border-white/10 px-4 py-2 text-xs uppercase tracking-[0.22em] text-white/55">
+          {status}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-white/35">Posture</p>
+          <p className="mt-3 text-3xl font-light">{postureLabel[snapshot.posture]}</p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-white/35">EURO Risk</p>
+          <p className="mt-3 text-3xl font-light">{formatEuro(snapshot.euroRiskTotal)}</p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-white/35">Critical</p>
+          <p className="mt-3 text-3xl font-light">{snapshot.criticalSignals}</p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-white/35">Trend</p>
+          <p className="mt-3 text-3xl font-light">—</p>
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-2xl border border-white/10 bg-black/20 p-4">
+        <div className="mb-3 flex items-center justify-between text-xs uppercase tracking-[0.24em] text-white/35">
+          <span>Latest Signals</span>
+          <span>{snapshot.totalSignals} total</span>
+        </div>
+
+        {latestSignals.length === 0 ? (
+          <p className="py-6 text-sm text-white/45">No active technical debt signals. The estate is quiet.</p>
+        ) : (
+          <div className="space-y-3">
+            {latestSignals.map((signal) => (
+              <article key={signal.id} className="rounded-xl border border-white/10 bg-white/[0.025] p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium text-white/80">{signal.title}</p>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-white/45">{signal.detail}</p>
+                  </div>
+                  <p className="shrink-0 text-sm text-white/70">{formatEuro(signal.euroRisk)}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default TechnicalDebtPanel;

--- a/apps/ingestion-api/src/boardroom/override-token.service.ts
+++ b/apps/ingestion-api/src/boardroom/override-token.service.ts
@@ -1,0 +1,58 @@
+import crypto from "node:crypto";
+import { ingestTechnicalDebtSignal } from "../technical-debt/technical-debt.ingestion";
+
+const TTL_MS = 15 * 60 * 1000;
+
+const inMemoryTokens = new Map<string, {
+  expiresAt: number;
+  used: boolean;
+  reason: string;
+  createdAt: number;
+}>();
+
+function generateToken() {
+  return `SNT-OVERRIDE-${crypto.randomBytes(6).toString("hex")}`;
+}
+
+export function createOverrideToken(reason: string, generatedBy = "boardroom") {
+  const token = generateToken();
+  const now = Date.now();
+
+  inMemoryTokens.set(token, {
+    expiresAt: now + TTL_MS,
+    used: false,
+    reason,
+    createdAt: now,
+  });
+
+  return {
+    token,
+    expiresAt: new Date(now + TTL_MS).toISOString(),
+  };
+}
+
+export async function consumeOverrideToken(token: string) {
+  const entry = inMemoryTokens.get(token);
+
+  if (!entry) return { valid: false, reason: "NOT_FOUND" };
+  if (entry.used) return { valid: false, reason: "ALREADY_USED" };
+  if (Date.now() > entry.expiresAt) return { valid: false, reason: "EXPIRED" };
+
+  entry.used = true;
+
+  // 🔥 CRITICAL: FEED BACK INTO SYSTEM AS TRAUMA SIGNAL
+  await ingestTechnicalDebtSignal({
+    id: `forced-bypass-${Date.now()}`,
+    source: "boardroom",
+    type: "forced_bypass",
+    severity: "high",
+    title: "Sovereign Override Executed",
+    detail: entry.reason,
+    detectedAt: new Date().toISOString(),
+    euroRisk: 800, // cost of breaking safety envelope
+    confidence: 1,
+    remediation: "Investigate root cause of override necessity",
+  });
+
+  return { valid: true };
+}

--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -3,10 +3,12 @@ import cors from "cors";
 import { WebSocketServer } from "ws";
 
 import { SovereignBus } from "@santis/sovereign-bus";
+import { registerCommandHandlers } from "./handlers/register-command-handlers";
 import { CommandIngressService } from "./services/command-ingress";
 import { createIngressRouter } from "./routes/ingress";
 import { evaluateConciergeRules, deriveSignalFromDecision } from './decision-kernel';
 import { broadcastToGodMode } from "./routes/sse-streams";
+import { resolveWebSocketGatewayConfig } from "./config/websocket-gateway.config";
 
 import { createReadRoutes } from "./routes/read-queries";
 import { createHistoryReadRouter } from "./routes/read-history";
@@ -17,6 +19,9 @@ import pricingRouter from "./routes/pricing.route";
 import streamRoutes from "./routes/stream.route";
 import { registerCoreStateRoute } from "./routes/core-state";
 import { createCoreStateStreamRouter } from "./routes/core-state-stream";
+
+import { authRouter } from "./routes/auth.routes";
+import { verifySessionToken } from "./security/crypto-token";
 
 import { boardroomRouter } from "./routes/boardroom";
 import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
@@ -54,9 +59,41 @@ async function bootstrap() {
   await EventStore.replay(projectEvent);
 
   const bus = new SovereignBus();
+  registerCommandHandlers(bus);
 
-  const WS_PORT = process.env.WS_PORT || 8080;
-  const wss = new WebSocketServer({ port: Number(WS_PORT) });
+  const wsConfig = resolveWebSocketGatewayConfig();
+  const wss = new WebSocketServer({ 
+    host: wsConfig.WS_HOST,
+    port: wsConfig.WS_PORT,
+    path: wsConfig.WS_PATH,
+    verifyClient: (info, callback) => {
+      const origin = info.origin;
+      const isAllowedExact = origin && wsConfig.WS_ALLOWED_ORIGINS.includes(origin);
+      const isAllowedPattern = origin && wsConfig.WS_ALLOWED_ORIGIN_PATTERNS.some(pattern => new RegExp(pattern).test(origin));
+
+      if (!isAllowedExact && !isAllowedPattern) {
+        console.warn(`🚨 [Security] WS Rejected: Unauthorized origin -> ${origin || 'UNKNOWN'}`);
+        return callback(false, 403, "Forbidden Origin");
+      }
+
+      try {
+        const urlObj = new URL(info.req.url || "", `http://${info.req.headers.host || "localhost"}`);
+        const token = urlObj.searchParams.get("token");
+
+        if (!token) {
+          console.warn(`🚨 [Security] WS Rejected: Missing bearer query token`);
+          return callback(false, 401, "Unauthorized - Missing Token");
+        }
+
+        const payload = verifySessionToken(token);
+        (info.req as any).session = payload;
+        callback(true);
+      } catch (err: any) {
+        console.warn(`🚨 [Security] WS Rejected: Invalid or expired token -> ${err.message}`);
+        return callback(false, 403, "Forbidden Token");
+      }
+    }
+  });
   
   wss.on('connection', (ws) => {
     console.log(`🔌 [WebSocket Gateway] İstemci bağlandı.`);
@@ -64,6 +101,8 @@ async function bootstrap() {
     ws.on('error', (err) => console.error('[WS Gateway] Hata:', err));
   });
 
+  console.log(`\n📡 WEBSOCKET GATEWAY ONLINE | ${wsConfig.WS_HOST}:${wsConfig.WS_PORT}${wsConfig.WS_PATH}\n`);
+  
   bus.addObserver({
     onEventPublished: async (event) => {
       await EventStore.append(event).catch(err => 
@@ -87,9 +126,33 @@ async function bootstrap() {
         decision
       });
 
-      const wsMessage = JSON.stringify({ type: "TELEMETRY", payload: { value: 1 } });
+      let wsPayloadType = "TELEMETRY";
+      let wsPayloadValue: any = 1;
+      const evtType = (event as any).eventType || (event as any).type;
+
+      if (evtType === 'GuestCheckoutCompleted' || evtType === 'RevenueGenerated' || evtType === 'commerce.upsell.therapist_accepted' || evtType === 'commerce.checkout.completed') {
+         wsPayloadType = "REVENUE_UPDATE";
+         wsPayloadValue = payloadData.totalAmount || payloadData.amount || payloadData.revenue || payloadData.upsellAmount || Math.floor(Math.random() * 500) + 150;
+      } else if (decision.includes('risk') || decision.includes('escalate')) {
+         wsPayloadType = "RISK_SIGNAL";
+         wsPayloadValue = Math.floor(metrics.abandon_risk * 100) || 85;
+      } else if (evtType === 'boardroom.oracle.executed') {
+         wsPayloadType = "ORACLE_LOOPBACK_ACK";
+         wsPayloadValue = payloadData.actionId || 1;
+      } else if (evtType === 'boardroom.strategy.applied') {
+         wsPayloadType = "STRATEGY_APPLY_ACK";
+         wsPayloadValue = payloadData.recommendationId || payloadData.sessionId || "strategy-unknown";
+      }
+
+      const wsMessage = JSON.stringify({
+          type: wsPayloadType,
+          message: `Olay: ${evtType} (${signalType})`,
+          payload: { value: wsPayloadValue },
+          value: wsPayloadValue
+      });
+
       wss.clients.forEach(client => {
-        if (client.readyState === 1) client.send(wsMessage);
+          if (client.readyState === 1) client.send(wsMessage);
       });
     }
   });
@@ -99,8 +162,29 @@ async function bootstrap() {
   const intentSnapshotRepo = new InMemoryIntentSnapshotRepository();
   const outboxRepo = new InMemoryOutboxRepository();
   const moodReadModelRepo = new InMemoryMoodReadModelRepository();
+  
+  const fallbackRepo = {
+      incrementFallbackIncident: async () => {},
+      getSnapshot: async () => ({
+          tenantId: "dev_tenant",
+          window: "5m" as const,
+          totalCount: 0,
+          byReason: { webgpu_unavailable: 0, module_load_failed: 0, worker_timeout: 0, api_timeout: 0, device_constraint: 0 },
+          byTransition: [],
+          latestIncidentAt: null,
+          lastTraceId: null,
+          updatedAt: new Date().toISOString()
+      })
+  };
 
-  registerGuestSelectMoodFlow({ bus, uow, guestSessionRepo, intentSnapshotRepo, outboxRepo, moodReadModelRepo });
+  registerGuestSelectMoodFlow({
+    bus,
+    uow,
+    guestSessionRepo,
+    intentSnapshotRepo,
+    outboxRepo,
+    moodReadModelRepo,
+  });
 
   const commandIngress = new CommandIngressService(bus);
   const fallbackSseRegistry = new FallbackSseRegistry();
@@ -109,8 +193,13 @@ async function bootstrap() {
   app.use(cors({ origin: "*" })); 
   app.use(express.json({ limit: "100kb" })); 
 
-  app.get("/api/v1/analytics/god/health", (_req, res) => {
-    res.json({ status: "SOVEREIGN_OS_ONLINE", timestamp: new Date().toISOString() });
+  app.get("/api/v1/analytics/god/health", (_req: Request, res: Response) => {
+    res.json({
+      status: "SOVEREIGN_OS_ONLINE",
+      version: "1.0.0",
+      uptime: process.uptime(),
+      timestamp: new Date().toISOString()
+    });
   });
 
   registerBoardroomProjections(bus);
@@ -128,6 +217,7 @@ async function bootstrap() {
   app.use("/api/v1/oracle", oracleStatisticalForecastRouter);
   app.use("/api/v1/decision-kernel", oracleDecisionKernelRouter);
   app.use("/api/v1", telemetryRouter);
+  app.use("/api/v1/auth", authRouter);
   app.use("/api/v1", navRouter);
   app.use("/api/v1/rituals/pricing", pricingRouter);
   app.use("/api/v1/stream", streamRoutes);
@@ -137,18 +227,35 @@ async function bootstrap() {
 
   app.use("/api/v1/read", createReadRoutes(intentSnapshotRepo));
   app.use("/api/v1/read", createHistoryReadRouter());
-  app.use("/", createFallbackIncidentsReadRouter({ repo: fallbackSseRegistry }));
+  app.use("/", createFallbackIncidentsReadRouter({ repo: fallbackRepo }));
 
   app.use("/api/v1/streams", createSseRoutes(intentSnapshotRepo));
-  app.use("/", createFallbackSseRouter({ repo: fallbackSseRegistry, registry: fallbackSseRegistry }));
+  app.use("/", createFallbackSseRouter({ repo: fallbackRepo, registry: fallbackSseRegistry }));
 
   app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     const traceId = (req.headers["x-trace-id"] as string) || "unknown-trace";
-    return sendNack(res, traceId, { type: "InternalSystemError", message: "System failure" }, 500);
+    console.error(`🚨 [Dead-Letter Queue] Kritik Sistem Hatası! Trace: ${traceId}`);
+    console.error(err.stack);
+    return sendNack(res, traceId, { 
+      type: "InternalSystemError", 
+      message: "Otoriter sistem geçici olarak hizmet veremiyor. TraceID ile logları kontrol edin." 
+    }, 500);
   });
 
   const PORT = process.env.PORT || 3030;
-  app.listen(PORT, () => console.log(`👑 Santis Ingestion running on ${PORT}`));
+  const server = app.listen(PORT, () => console.log(`👑 Santis Ingestion running on ${PORT}`));
+
+  server.on('error', (e: any) => {
+    if (e.code === 'EADDRINUSE') {
+      console.error(`\n❌ [Ingestion API] Port ${PORT} already in use.`);
+      process.exit(1);
+    }
+    console.error('❌ [Ingestion API] Server error:', e);
+    process.exit(1);
+  });
 }
 
-bootstrap();
+bootstrap().catch((err) => {
+  console.error("🔥 [FATAL] Boot sequence failed:", err);
+  process.exit(1);
+});

--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -46,44 +46,30 @@ import { InMemoryUnitOfWork } from "@santis/application/uow/in-memory-uow";
 import { registerGuestSelectMoodFlow } from "@santis/application/bootstrap/register-guest-select-mood";
 
 import { sendNack } from "./utils/http-contract";
+import { createTechnicalDebtRouter } from "./routes/technical-debt.routes";
 
 async function bootstrap() {
   console.log("⚡ [Ingestion API] Booting Sovereign Backend...");
 
-  // 1. ZAMANDA YOLCULUK: Geçmiş olayları diskten oku ve RAM'i doldur (Rehydration)
   await EventStore.replay(projectEvent);
 
-  // 2. Core Altyapı
   const bus = new SovereignBus();
 
-  // --- WEBSOCKET GATEWAY (Port 8080) ---
   const WS_PORT = process.env.WS_PORT || 8080;
   const wss = new WebSocketServer({ port: Number(WS_PORT) });
   
   wss.on('connection', (ws) => {
     console.log(`🔌 [WebSocket Gateway] İstemci bağlandı.`);
     ws.send(JSON.stringify({ type: "CONNECTION_ACK", message: "Sovereign WS Gateway Connected." }));
-    
-    ws.on('error', (err) => {
-      console.error('[WS Gateway] Hata:', err);
-    });
+    ws.on('error', (err) => console.error('[WS Gateway] Hata:', err));
   });
 
-  console.log(`
-  ╔═══════════════════════════════════════════════════╗
-  ║  📡 WEBSOCKET GATEWAY ONLINE                      ║
-  ║  Port: ${WS_PORT}                                       ║
-  ╚═══════════════════════════════════════════════════╝
-  `);
-  
-  // 3. FIREHOSE: Bundan sonra olacak HER ŞEYİ silinmez deftere kaydet
   bus.addObserver({
     onEventPublished: async (event) => {
       await EventStore.append(event).catch(err => 
         console.error("🚨 [Event Store] Kritik Yazma Hatası!", err)
       );
 
-      // --- Zeka Katmanı Entegrasyonu ---
       const payloadData = (event.payload || {}) as Record<string, any>;
       const metrics = {
         hesitation_index: Number(payloadData.hesitation_index || 0),
@@ -95,41 +81,15 @@ async function bootstrap() {
       const decision = evaluateConciergeRules(metrics);
       const signalType = deriveSignalFromDecision(decision);
 
-      // God Mode Radar'a Fırlat
       broadcastToGodMode("EVENT_STREAM", {
         ...event,
         signalType,
         decision
       });
 
-      // --- WEBSOCKET CANLI YAYINI (BROADCAST) ---
-      // Frontend (Boardroom Pro) UI updaters ile eşleşen format
-      let wsPayloadType = "TELEMETRY";
-      let wsPayloadValue = 1; // Default sayım
-      
-      const evtType = (event as any).eventType || (event as any).type;
-
-      // Event tipine göre payload hazırlama
-      if (evtType === 'GuestCheckoutCompleted' || evtType === 'RevenueGenerated' || evtType === 'commerce.upsell.therapist_accepted' || evtType === 'commerce.checkout.completed') {
-         wsPayloadType = "REVENUE_UPDATE";
-         wsPayloadValue = payloadData.totalAmount || payloadData.amount || payloadData.revenue || payloadData.upsellAmount || Math.floor(Math.random() * 500) + 150;
-      } else if (decision.includes('risk') || decision.includes('escalate')) {
-         wsPayloadType = "RISK_SIGNAL";
-         wsPayloadValue = Math.floor(metrics.abandon_risk * 100) || 85;
-      }
-
-      const wsMessage = JSON.stringify({
-          type: wsPayloadType,
-          message: `Olay: ${evtType} (${signalType})`,
-          payload: { value: wsPayloadValue },
-          value: wsPayloadValue
-      });
-
-      // Bağlı olan tüm WS istemcilerine fırlat
+      const wsMessage = JSON.stringify({ type: "TELEMETRY", payload: { value: 1 } });
       wss.clients.forEach(client => {
-          if (client.readyState === 1) { // 1 = OPEN
-              client.send(wsMessage);
-          }
+        if (client.readyState === 1) client.send(wsMessage);
       });
     }
   });
@@ -139,58 +99,24 @@ async function bootstrap() {
   const intentSnapshotRepo = new InMemoryIntentSnapshotRepository();
   const outboxRepo = new InMemoryOutboxRepository();
   const moodReadModelRepo = new InMemoryMoodReadModelRepository();
-  
-  // Fake Fallback Repo
-  const fallbackRepo = {
-      incrementFallbackIncident: async () => {},
-      getSnapshot: async () => ({
-          tenantId: "dev_tenant",
-          window: "5m" as const,
-          totalCount: 0,
-          byReason: { webgpu_unavailable: 0, module_load_failed: 0, worker_timeout: 0, api_timeout: 0, device_constraint: 0 },
-          byTransition: [],
-          latestIncidentAt: null,
-          lastTraceId: null,
-          updatedAt: new Date().toISOString()
-      })
-  };
 
-  // 2. Command Flow (UoW, Outbox, Bus) Kayıtları
-  registerGuestSelectMoodFlow({
-    bus,
-    uow,
-    guestSessionRepo,
-    intentSnapshotRepo,
-    outboxRepo,
-    moodReadModelRepo,
-  });
+  registerGuestSelectMoodFlow({ bus, uow, guestSessionRepo, intentSnapshotRepo, outboxRepo, moodReadModelRepo });
 
-  // 3. Servisler & Registry'ler
   const commandIngress = new CommandIngressService(bus);
   const fallbackSseRegistry = new FallbackSseRegistry();
 
-  // 4. Express App
   const app = express();
-  
-  // DOS Koruması: Raw Body parse limiti 100kb
   app.use(cors({ origin: "*" })); 
   app.use(express.json({ limit: "100kb" })); 
 
-  // --- HEALTH CHECK ---
-  app.get("/api/v1/analytics/god/health", (req: Request, res: Response) => {
-    res.json({
-      status: "SOVEREIGN_OS_ONLINE",
-      version: "1.0.0",
-      uptime: process.uptime(),
-      timestamp: new Date().toISOString()
-    });
+  app.get("/api/v1/analytics/god/health", (_req, res) => {
+    res.json({ status: "SOVEREIGN_OS_ONLINE", timestamp: new Date().toISOString() });
   });
 
-  // 1. Otoriter Okuma Modellerini (Projections) Başlat
   registerBoardroomProjections(bus);
 
-  // --- Otoriter Gümrük Kapısı (COMMAND ROTASI) ---
   app.use("/api/v1", createIngressRouter(bus, commandIngress));
+  app.use("/api/v1", createTechnicalDebtRouter());
   app.use("/api/v1/boardroom", boardroomRouter);
   app.use("/api/v1/oracle", oracleActionMemoryRouter);
   app.use("/api/v1/oracle", oracleNodeSyncRouter);
@@ -209,60 +135,20 @@ async function bootstrap() {
   registerCoreStateRoute(app);
   app.use("/api/v1", createCoreStateStreamRouter());
 
-  // --- PROJECTION (OKUMA) ROTALARI ---
   app.use("/api/v1/read", createReadRoutes(intentSnapshotRepo));
   app.use("/api/v1/read", createHistoryReadRouter());
-  app.use("/", createFallbackIncidentsReadRouter({ repo: fallbackRepo }));
+  app.use("/", createFallbackIncidentsReadRouter({ repo: fallbackSseRegistry }));
 
-  // --- SSE (CANLI AKIŞ) ROTALARI ---
   app.use("/api/v1/streams", createSseRoutes(intentSnapshotRepo));
-  app.use("/", createFallbackSseRouter({ repo: fallbackRepo, registry: fallbackSseRegistry }));
+  app.use("/", createFallbackSseRouter({ repo: fallbackSseRegistry, registry: fallbackSseRegistry }));
 
-  // --- DEAD-LETTER FALLBACK (Global Error Handler) ---
-  app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
     const traceId = (req.headers["x-trace-id"] as string) || "unknown-trace";
-    
-    console.error(`🚨 [Dead-Letter Queue] Kritik Sistem Hatası! Trace: ${traceId}`);
-    console.error(err.stack);
-
-    // Dış dünyaya asla stack trace sızdırmayız.
-    return sendNack(res, traceId, { 
-      type: "InternalSystemError", 
-      message: "Otoriter sistem geçici olarak hizmet veremiyor. TraceID ile logları kontrol edin." 
-    }, 500);
+    return sendNack(res, traceId, { type: "InternalSystemError", message: "System failure" }, 500);
   });
 
-  // 5. Sunucuyu Başlat (Orijinal limanımız port 3030)
   const PORT = process.env.PORT || 3030;
-  const server = app.listen(PORT, () => {
-    console.log(`
-  ╔═══════════════════════════════════════════════════╗
-  ║  👑 SANTIS INGESTION GATEWAY v1.0                 ║
-  ║  Zero-Trust Zod Parse | CQRS Dispatch             ║
-  ╠═══════════════════════════════════════════════════╣
-  ║  📡 Port: ${PORT}                                      ║
-  ║  🛡️  Endpoint: POST /api/v1/commands              ║
-  ╚═══════════════════════════════════════════════════╝
-    `);
-  });
-
-  server.on('error', (e: any) => {
-    if (e.code === 'EADDRINUSE') {
-      console.error(`\n❌ [Ingestion API] Port ${PORT} already in use.`);
-      console.error(`Run: netstat -ano | findstr :${PORT}`);
-      console.error(`Then: taskkill /PID <PID> /F\n`);
-      process.exit(1);
-    } else {
-      console.error('❌ [Ingestion API] Server error:', e);
-      process.exit(1);
-    }
-  });
-
-  // WS Gateway moved to top of bootstrap
-
+  app.listen(PORT, () => console.log(`👑 Santis Ingestion running on ${PORT}`));
 }
 
-bootstrap().catch((err) => {
-  console.error("🔥 [FATAL] Boot sequence failed:", err);
-  process.exit(1);
-});
+bootstrap();

--- a/apps/ingestion-api/src/middleware/sovereign-context.middleware.ts
+++ b/apps/ingestion-api/src/middleware/sovereign-context.middleware.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { Request, Response, NextFunction } from "express";
 import { createCoreState } from "@santis/domain-schema/src/core-state.interface";
 

--- a/apps/ingestion-api/src/middleware/sovereign-context.middleware.ts
+++ b/apps/ingestion-api/src/middleware/sovereign-context.middleware.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+import { createCoreState } from "@santis/domain-schema/src/core-state.interface";
+
+const coreState = createCoreState();
+
+export function requireSovereignContext(req: Request, res: Response, next: NextFunction) {
+  const tenantId = req.headers["x-santis-tenant-id"] as string | undefined;
+
+  if (!tenantId) {
+    return res.status(400).json({ error: "FATAL: Sovereign Context Required" });
+  }
+
+  const ctx = coreState.activeTenants.get(tenantId);
+
+  if (!ctx) {
+    return res.status(404).json({ error: "FATAL: Tenant Reality Not Found" });
+  }
+
+  (req as any).sovereignContext = {
+    tenant: ctx.tenant,
+    requestId: crypto.randomUUID(),
+    timestamp: Date.now(),
+  };
+
+  next();
+}

--- a/apps/ingestion-api/src/routes/technical-debt.routes.ts
+++ b/apps/ingestion-api/src/routes/technical-debt.routes.ts
@@ -2,10 +2,22 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import { TechnicalDebtSignalSchema } from "../technical-debt/technical-debt.contract";
 import { ingestTechnicalDebtSignal, getTechnicalDebtSnapshot } from "../technical-debt/technical-debt.ingestion";
+import { getTechnicalDebtTrendProjection } from "../technical-debt/technical-debt.trend";
+import { createOverrideToken, consumeOverrideToken } from "../boardroom/override-token.service";
 import { broadcastToGodMode } from "./sse-streams";
 
 const TechnicalDebtIngestRequestSchema = z.object({
   signals: z.array(TechnicalDebtSignalSchema).min(1),
+});
+
+const OverrideTokenRequestSchema = z.object({
+  reason: z.string().min(12),
+  generatedBy: z.string().min(1).default("boardroom"),
+});
+
+const OverrideConsumeRequestSchema = z.object({
+  token: z.string().min(1),
+  reason: z.string().min(12),
 });
 
 function isAuthorized(req: Request) {
@@ -19,41 +31,76 @@ function isAuthorized(req: Request) {
 export function createTechnicalDebtRouter() {
   const router = Router();
 
-  router.post("/technical-debt", (req: Request, res: Response) => {
+  router.post("/technical-debt", async (req: Request, res: Response) => {
     if (!isAuthorized(req)) {
-      return res.status(401).json({
-        ok: false,
-        error: "UnauthorizedTechnicalDebtTelemetry",
-      });
+      return res.status(401).json({ ok: false, error: "UnauthorizedTechnicalDebtTelemetry" });
     }
 
     const parsed = TechnicalDebtIngestRequestSchema.safeParse(req.body);
-
     if (!parsed.success) {
-      return res.status(400).json({
-        ok: false,
-        error: "InvalidTechnicalDebtPayload",
-        issues: parsed.error.issues,
-      });
+      return res.status(400).json({ ok: false, error: "InvalidTechnicalDebtPayload", issues: parsed.error.issues });
     }
 
-    const accepted = parsed.data.signals.map(signal => ingestTechnicalDebtSignal(signal));
-    const snapshot = getTechnicalDebtSnapshot();
+    const accepted = await Promise.all(parsed.data.signals.map(signal => ingestTechnicalDebtSignal(signal)));
+    const snapshot = await getTechnicalDebtSnapshot();
 
     broadcastToGodMode("TECH_DEBT_UPDATE", snapshot);
 
-    return res.status(202).json({
+    return res.status(202).json({ ok: true, accepted: accepted.length, snapshot });
+  });
+
+  router.get("/technical-debt/snapshot", async (_req: Request, res: Response) => {
+    return res.json({ ok: true, snapshot: await getTechnicalDebtSnapshot() });
+  });
+
+  router.get("/technical-debt/trend", async (req: Request, res: Response) => {
+    const windowDays = Number(req.query.windowDays || 30);
+    const thresholdEuro = Number(req.query.thresholdEuro || 5000);
+    return res.json({
       ok: true,
-      accepted: accepted.length,
-      snapshot,
+      projection: await getTechnicalDebtTrendProjection({ windowDays, thresholdEuro }),
     });
   });
 
-  router.get("/technical-debt/snapshot", (_req: Request, res: Response) => {
-    return res.json({
-      ok: true,
-      snapshot: getTechnicalDebtSnapshot(),
+  router.post("/boardroom/override-token", async (req: Request, res: Response) => {
+    if (!isAuthorized(req)) {
+      return res.status(401).json({ ok: false, error: "UnauthorizedOverrideTokenRequest" });
+    }
+
+    const parsed = OverrideTokenRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: "InvalidOverrideTokenRequest", issues: parsed.error.issues });
+    }
+
+    const token = createOverrideToken(parsed.data.reason, parsed.data.generatedBy);
+    broadcastToGodMode("ARCHITECT_OVERRULE", {
+      generatedBy: parsed.data.generatedBy,
+      reason: parsed.data.reason,
+      expiresAt: token.expiresAt,
     });
+
+    return res.status(201).json({ ok: true, event: "ARCHITECT_OVERRULE", ...token });
+  });
+
+  router.post("/boardroom/override-token/consume", async (req: Request, res: Response) => {
+    if (!isAuthorized(req)) {
+      return res.status(401).json({ ok: false, error: "UnauthorizedOverrideTokenConsume" });
+    }
+
+    const parsed = OverrideConsumeRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ ok: false, error: "InvalidOverrideConsumeRequest", issues: parsed.error.issues });
+    }
+
+    const result = await consumeOverrideToken(parsed.data.token);
+    if (!result.valid) {
+      return res.status(403).json({ ok: false, error: result.reason });
+    }
+
+    const snapshot = await getTechnicalDebtSnapshot();
+    broadcastToGodMode("TECH_DEBT_UPDATE", snapshot);
+
+    return res.json({ ok: true, event: "ARCHITECT_OVERRULE", consumed: true, snapshot });
   });
 
   return router;

--- a/apps/ingestion-api/src/routes/technical-debt.routes.ts
+++ b/apps/ingestion-api/src/routes/technical-debt.routes.ts
@@ -1,0 +1,60 @@
+import { Router, Request, Response } from "express";
+import { z } from "zod";
+import { TechnicalDebtSignalSchema } from "../technical-debt/technical-debt.contract";
+import { ingestTechnicalDebtSignal, getTechnicalDebtSnapshot } from "../technical-debt/technical-debt.ingestion";
+import { broadcastToGodMode } from "./sse-streams";
+
+const TechnicalDebtIngestRequestSchema = z.object({
+  signals: z.array(TechnicalDebtSignalSchema).min(1),
+});
+
+function isAuthorized(req: Request) {
+  const expected = process.env.SANTIS_TELEMETRY_KEY;
+  if (!expected) return true;
+
+  const authorization = req.headers.authorization || "";
+  return authorization === `Bearer ${expected}`;
+}
+
+export function createTechnicalDebtRouter() {
+  const router = Router();
+
+  router.post("/technical-debt", (req: Request, res: Response) => {
+    if (!isAuthorized(req)) {
+      return res.status(401).json({
+        ok: false,
+        error: "UnauthorizedTechnicalDebtTelemetry",
+      });
+    }
+
+    const parsed = TechnicalDebtIngestRequestSchema.safeParse(req.body);
+
+    if (!parsed.success) {
+      return res.status(400).json({
+        ok: false,
+        error: "InvalidTechnicalDebtPayload",
+        issues: parsed.error.issues,
+      });
+    }
+
+    const accepted = parsed.data.signals.map(signal => ingestTechnicalDebtSignal(signal));
+    const snapshot = getTechnicalDebtSnapshot();
+
+    broadcastToGodMode("TECH_DEBT_UPDATE", snapshot);
+
+    return res.status(202).json({
+      ok: true,
+      accepted: accepted.length,
+      snapshot,
+    });
+  });
+
+  router.get("/technical-debt/snapshot", (_req: Request, res: Response) => {
+    return res.json({
+      ok: true,
+      snapshot: getTechnicalDebtSnapshot(),
+    });
+  });
+
+  return router;
+}

--- a/apps/ingestion-api/src/technical-debt/technical-debt.contract.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.contract.ts
@@ -10,11 +10,12 @@ export const TechnicalDebtSignalTypeSchema = z.enum([
   "bundle_size_regression",
   "security_advisory",
   "runtime_contract_violation",
+  "forced_bypass",
 ]);
 
 export const TechnicalDebtSignalSchema = z.object({
   id: z.string().min(1),
-  source: z.enum(["ci", "docker", "local", "runtime"]),
+  source: z.enum(["ci", "docker", "local", "runtime", "boardroom"]),
   type: TechnicalDebtSignalTypeSchema,
   severity: TechnicalDebtSeveritySchema,
   title: z.string().min(1),

--- a/apps/ingestion-api/src/technical-debt/technical-debt.contract.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.contract.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export const TechnicalDebtSeveritySchema = z.enum(["low", "medium", "high", "critical"]);
+export const TechnicalDebtSignalTypeSchema = z.enum([
+  "workspace_script_missing",
+  "forbidden_lockfile",
+  "node_version_drift",
+  "pnpm_version_drift",
+  "dependency_drift",
+  "bundle_size_regression",
+  "security_advisory",
+  "runtime_contract_violation",
+]);
+
+export const TechnicalDebtSignalSchema = z.object({
+  id: z.string().min(1),
+  source: z.enum(["ci", "docker", "local", "runtime"]),
+  type: TechnicalDebtSignalTypeSchema,
+  severity: TechnicalDebtSeveritySchema,
+  title: z.string().min(1),
+  detail: z.string().min(1),
+  workspace: z.string().optional(),
+  filePath: z.string().optional(),
+  detectedAt: z.string().datetime(),
+  euroRisk: z.number().nonnegative(),
+  confidence: z.number().min(0).max(1),
+  remediation: z.string().min(1),
+});
+
+export const TechnicalDebtSnapshotSchema = z.object({
+  generatedAt: z.string().datetime(),
+  totalSignals: z.number().int().nonnegative(),
+  criticalSignals: z.number().int().nonnegative(),
+  highSignals: z.number().int().nonnegative(),
+  euroRiskTotal: z.number().nonnegative(),
+  posture: z.enum(["sealed", "watch", "degraded", "breach"]),
+  signals: z.array(TechnicalDebtSignalSchema),
+});
+
+export type TechnicalDebtSeverity = z.infer<typeof TechnicalDebtSeveritySchema>;
+export type TechnicalDebtSignalType = z.infer<typeof TechnicalDebtSignalTypeSchema>;
+export type TechnicalDebtSignal = z.infer<typeof TechnicalDebtSignalSchema>;
+export type TechnicalDebtSnapshot = z.infer<typeof TechnicalDebtSnapshotSchema>;

--- a/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
@@ -1,0 +1,39 @@
+import { TechnicalDebtSignalSchema, TechnicalDebtSnapshot } from "./technical-debt.contract";
+
+const inMemorySignals: any[] = [];
+
+export function ingestTechnicalDebtSignal(raw: unknown) {
+  const parsed = TechnicalDebtSignalSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    throw new Error("Invalid technical debt signal payload");
+  }
+
+  inMemorySignals.push(parsed.data);
+
+  return parsed.data;
+}
+
+export function getTechnicalDebtSnapshot(): TechnicalDebtSnapshot {
+  const signals = [...inMemorySignals];
+
+  const critical = signals.filter(s => s.severity === "critical").length;
+  const high = signals.filter(s => s.severity === "high").length;
+  const euroRiskTotal = signals.reduce((acc, s) => acc + s.euroRisk, 0);
+
+  let posture: TechnicalDebtSnapshot["posture"] = "sealed";
+
+  if (critical > 0) posture = "breach";
+  else if (high > 2) posture = "degraded";
+  else if (signals.length > 0) posture = "watch";
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalSignals: signals.length,
+    criticalSignals: critical,
+    highSignals: high,
+    euroRiskTotal,
+    posture,
+    signals,
+  };
+}

--- a/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
@@ -1,21 +1,37 @@
 import { TechnicalDebtSignalSchema, TechnicalDebtSnapshot } from "./technical-debt.contract";
+import { persistTechnicalDebtSignal, readTechnicalDebtSignals } from "./technical-debt.repository";
 
 const inMemorySignals: any[] = [];
 
-export function ingestTechnicalDebtSignal(raw: unknown) {
+export async function ingestTechnicalDebtSignal(raw: unknown) {
   const parsed = TechnicalDebtSignalSchema.safeParse(raw);
 
   if (!parsed.success) {
     throw new Error("Invalid technical debt signal payload");
   }
 
-  inMemorySignals.push(parsed.data);
+  const signal = parsed.data;
 
-  return parsed.data;
+  // Always keep in-memory for local/dev continuity
+  inMemorySignals.push(signal);
+
+  // Attempt persistence (non-blocking philosophy)
+  try {
+    await persistTechnicalDebtSignal(signal);
+  } catch (err) {
+    console.warn("[MEMORY] Persistence failed, falling back to in-memory only.");
+  }
+
+  return signal;
 }
 
-export function getTechnicalDebtSnapshot(): TechnicalDebtSnapshot {
-  const signals = [...inMemorySignals];
+export async function getTechnicalDebtSnapshot(): Promise<TechnicalDebtSnapshot> {
+  // Prefer DB if available
+  let signals = await readTechnicalDebtSignals();
+
+  if (!signals) {
+    signals = [...inMemorySignals];
+  }
 
   const critical = signals.filter(s => s.severity === "critical").length;
   const high = signals.filter(s => s.severity === "high").length;

--- a/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.ingestion.ts
@@ -1,9 +1,10 @@
-import { TechnicalDebtSignalSchema, TechnicalDebtSnapshot } from "./technical-debt.contract";
+import type { SovereignAction } from "@santis/domain-schema/src/core-state.interface";
+import { TechnicalDebtSignalSchema, TechnicalDebtSnapshot, type TechnicalDebtSignal } from "./technical-debt.contract";
 import { persistTechnicalDebtSignal, readTechnicalDebtSignals } from "./technical-debt.repository";
 
-const inMemorySignals: any[] = [];
+const inMemorySignalsByTenant = new Map<string, TechnicalDebtSignal[]>();
 
-export async function ingestTechnicalDebtSignal(raw: unknown) {
+export const ingestTechnicalDebtSignal: SovereignAction<unknown, TechnicalDebtSignal> = async (ctx, raw) => {
   const parsed = TechnicalDebtSignalSchema.safeParse(raw);
 
   if (!parsed.success) {
@@ -11,26 +12,27 @@ export async function ingestTechnicalDebtSignal(raw: unknown) {
   }
 
   const signal = parsed.data;
+  const tenantId = ctx.tenant.tenantId;
+  const tenantSignals = inMemorySignalsByTenant.get(tenantId) ?? [];
 
-  // Always keep in-memory for local/dev continuity
-  inMemorySignals.push(signal);
+  tenantSignals.push(signal);
+  inMemorySignalsByTenant.set(tenantId, tenantSignals);
 
-  // Attempt persistence (non-blocking philosophy)
   try {
-    await persistTechnicalDebtSignal(signal);
-  } catch (err) {
-    console.warn("[MEMORY] Persistence failed, falling back to in-memory only.");
+    await persistTechnicalDebtSignal(ctx, signal);
+  } catch {
+    console.warn(`[MEMORY] Persistence failed for tenant ${tenantId}, falling back to in-memory only.`);
   }
 
   return signal;
-}
+};
 
-export async function getTechnicalDebtSnapshot(): Promise<TechnicalDebtSnapshot> {
-  // Prefer DB if available
-  let signals = await readTechnicalDebtSignals();
+export async function getTechnicalDebtSnapshot(ctx: Parameters<typeof ingestTechnicalDebtSignal>[0]): Promise<TechnicalDebtSnapshot> {
+  const tenantId = ctx.tenant.tenantId;
+  let signals = await readTechnicalDebtSignals(ctx);
 
   if (!signals) {
-    signals = [...inMemorySignals];
+    signals = [...(inMemorySignalsByTenant.get(tenantId) ?? [])];
   }
 
   const critical = signals.filter(s => s.severity === "critical").length;

--- a/apps/ingestion-api/src/technical-debt/technical-debt.repository.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.repository.ts
@@ -1,0 +1,88 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { desc } from "drizzle-orm";
+import pg from "pg";
+import { technicalDebtSignals } from "@santis/db/schema";
+import type { TechnicalDebtSignal } from "./technical-debt.contract";
+
+const { Pool } = pg;
+
+type TechnicalDebtPersistenceState = {
+  enabled: boolean;
+  db?: ReturnType<typeof drizzle>;
+};
+
+let state: TechnicalDebtPersistenceState | null = null;
+
+function getPersistenceState(): TechnicalDebtPersistenceState {
+  if (state) return state;
+
+  const connectionString = process.env.DATABASE_URL;
+
+  if (!connectionString) {
+    state = { enabled: false };
+    return state;
+  }
+
+  const pool = new Pool({ connectionString });
+  state = {
+    enabled: true,
+    db: drizzle(pool),
+  };
+
+  return state;
+}
+
+export async function persistTechnicalDebtSignal(signal: TechnicalDebtSignal) {
+  const persistence = getPersistenceState();
+
+  if (!persistence.enabled || !persistence.db) {
+    return { persisted: false as const, reason: "DATABASE_URL_NOT_CONFIGURED" };
+  }
+
+  await persistence.db.insert(technicalDebtSignals).values({
+    id: signal.id,
+    source: signal.source,
+    type: signal.type,
+    severity: signal.severity,
+    title: signal.title,
+    detail: signal.detail,
+    workspace: signal.workspace ?? null,
+    filePath: signal.filePath ?? null,
+    detectedAt: new Date(signal.detectedAt),
+    euroRisk: String(signal.euroRisk),
+    confidence: signal.confidence,
+    remediation: signal.remediation,
+    payload: signal,
+  });
+
+  return { persisted: true as const };
+}
+
+export async function readTechnicalDebtSignals(limit = 100): Promise<TechnicalDebtSignal[] | null> {
+  const persistence = getPersistenceState();
+
+  if (!persistence.enabled || !persistence.db) {
+    return null;
+  }
+
+  const rows = await persistence.db
+    .select()
+    .from(technicalDebtSignals)
+    .orderBy(desc(technicalDebtSignals.detectedAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    id: row.id,
+    source: row.source as TechnicalDebtSignal["source"],
+    type: row.type as TechnicalDebtSignal["type"],
+    severity: row.severity as TechnicalDebtSignal["severity"],
+    title: row.title,
+    detail: row.detail,
+    workspace: row.workspace ?? undefined,
+    filePath: row.filePath ?? undefined,
+    detectedAt: row.detectedAt.toISOString(),
+    euroRisk: Number(row.euroRisk),
+    confidence: Number(row.confidence),
+    remediation: row.remediation,
+  }));
+}

--- a/apps/ingestion-api/src/technical-debt/technical-debt.trend.ts
+++ b/apps/ingestion-api/src/technical-debt/technical-debt.trend.ts
@@ -1,0 +1,147 @@
+import type { TechnicalDebtSignal } from "./technical-debt.contract";
+import { readTechnicalDebtSignals } from "./technical-debt.repository";
+
+export type TechnicalDebtTrendPoint = {
+  date: string;
+  signalCount: number;
+  criticalSignals: number;
+  highSignals: number;
+  euroRiskAdded: number;
+  cumulativeEuroRisk: number;
+};
+
+export type TechnicalDebtTrendProjection = {
+  generatedAt: string;
+  windowDays: number;
+  thresholdEuro: number;
+  currentEuroDebt: number;
+  debtVelocityEuroPerDay: number;
+  trendDirection: "STABLE" | "DEGRADING" | "IMPROVING";
+  estimatedBreachDate: string | null;
+  slope: "flat" | "rising" | "accelerating";
+  totalSignals: number;
+  points: TechnicalDebtTrendPoint[];
+};
+
+const DEFAULT_THRESHOLD_EURO = 5000;
+
+function createWindowKeys(windowDays: number) {
+  const keys: string[] = [];
+  const now = new Date();
+
+  for (let i = windowDays - 1; i >= 0; i -= 1) {
+    const date = new Date(now);
+    date.setUTCDate(now.getUTCDate() - i);
+    keys.push(date.toISOString().slice(0, 10));
+  }
+
+  return keys;
+}
+
+function deriveSlope(points: TechnicalDebtTrendPoint[]) {
+  if (points.length < 3) return "flat" as const;
+
+  const midpoint = Math.floor(points.length / 2);
+  const firstHalf = points.slice(0, midpoint).reduce((sum, point) => sum + point.euroRiskAdded, 0);
+  const secondHalf = points.slice(midpoint).reduce((sum, point) => sum + point.euroRiskAdded, 0);
+
+  if (secondHalf === 0) return "flat" as const;
+  if (firstHalf === 0 && secondHalf > 0) return "accelerating" as const;
+  if (secondHalf > firstHalf * 1.5) return "accelerating" as const;
+  if (secondHalf > firstHalf) return "rising" as const;
+  return "flat" as const;
+}
+
+function calculateLinearVelocity(points: TechnicalDebtTrendPoint[]) {
+  if (points.length < 2) return 0;
+
+  const xs = points.map((_, index) => index);
+  const ys = points.map(point => point.cumulativeEuroRisk);
+  const n = points.length;
+  const sumX = xs.reduce((sum, value) => sum + value, 0);
+  const sumY = ys.reduce((sum, value) => sum + value, 0);
+  const sumXY = xs.reduce((sum, value, index) => sum + value * ys[index], 0);
+  const sumXX = xs.reduce((sum, value) => sum + value * value, 0);
+  const denominator = n * sumXX - sumX * sumX;
+
+  if (denominator === 0) return 0;
+
+  return (n * sumXY - sumX * sumY) / denominator;
+}
+
+function estimateBreachDate(currentDebt: number, velocityPerDay: number, thresholdEuro: number) {
+  if (currentDebt >= thresholdEuro) return new Date().toISOString();
+  if (velocityPerDay <= 0) return null;
+
+  const daysUntilBreach = Math.ceil((thresholdEuro - currentDebt) / velocityPerDay);
+  const breach = new Date();
+  breach.setUTCDate(breach.getUTCDate() + daysUntilBreach);
+  return breach.toISOString();
+}
+
+export async function getTechnicalDebtTrendProjection(options: { windowDays?: number; thresholdEuro?: number } = {}): Promise<TechnicalDebtTrendProjection> {
+  const windowDays = Math.max(1, Math.min(options.windowDays ?? 30, 180));
+  const thresholdEuro = Math.max(1, options.thresholdEuro ?? DEFAULT_THRESHOLD_EURO);
+  const signals = (await readTechnicalDebtSignals(1000)) ?? [];
+  const keys = createWindowKeys(windowDays);
+  const buckets = new Map<string, TechnicalDebtTrendPoint>();
+
+  for (const key of keys) {
+    buckets.set(key, {
+      date: key,
+      signalCount: 0,
+      criticalSignals: 0,
+      highSignals: 0,
+      euroRiskAdded: 0,
+      cumulativeEuroRisk: 0,
+    });
+  }
+
+  const oldestKey = keys[0];
+  let priorRisk = 0;
+
+  for (const signal of signals as TechnicalDebtSignal[]) {
+    const key = signal.detectedAt.slice(0, 10);
+
+    if (key < oldestKey) {
+      priorRisk += signal.euroRisk;
+      continue;
+    }
+
+    const bucket = buckets.get(key);
+    if (!bucket) continue;
+
+    bucket.signalCount += 1;
+    bucket.euroRiskAdded += signal.euroRisk;
+    if (signal.severity === "critical") bucket.criticalSignals += 1;
+    if (signal.severity === "high") bucket.highSignals += 1;
+  }
+
+  let cumulative = priorRisk;
+  const points = keys.map((key) => {
+    const point = buckets.get(key)!;
+    cumulative += point.euroRiskAdded;
+    return { ...point, cumulativeEuroRisk: cumulative };
+  });
+
+  const debtVelocityEuroPerDay = calculateLinearVelocity(points);
+  const currentEuroDebt = points.at(-1)?.cumulativeEuroRisk ?? 0;
+  const trendDirection = debtVelocityEuroPerDay > 0
+    ? "DEGRADING"
+    : debtVelocityEuroPerDay < 0
+      ? "IMPROVING"
+      : "STABLE";
+
+  return {
+    generatedAt: new Date().toISOString(),
+    windowDays,
+    thresholdEuro,
+    currentEuroDebt,
+    debtVelocityEuroPerDay,
+    trendDirection,
+    estimatedBreachDate: estimateBreachDate(currentEuroDebt, debtVelocityEuroPerDay, thresholdEuro),
+    slope: deriveSlope(points),
+    totalSignals: signals.length,
+    points,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "db:push": "pnpm --filter @santis/domain-schema db:push",
     "test:quality:static": "turbo run test:quality:static",
     "test:quality:runtime": "turbo run test:quality:runtime",
-    "audit:runtime": "node scripts/audit-runtime-contract.js"
+    "audit:runtime": "node scripts/audit-runtime-contract.js",
+    "audit:env": "node scripts/active/audit-environment.js",
+    "audit:workspace": "node scripts/active/audit-workspace-scripts.js",
+    "audit:all": "pnpm run audit:env && pnpm run audit:workspace",
+    "prebuild": "pnpm run audit:all"
   },
   "dependencies": {
     "zod": "^3.22.4"

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, uuid, text, jsonb, timestamp, numeric, real } from "drizzle-orm/pg-core";
 
 // ==========================================
 // KUTSAL KAYIT (EVENT STORE)
@@ -6,7 +6,7 @@ import { pgTable, uuid, text, jsonb, timestamp } from "drizzle-orm/pg-core";
 // ==========================================
 export const events = pgTable("events", {
   id: uuid("id").defaultRandom().primaryKey(),
-  tenantId: text("tenant_id").notNull(), // İzolasyon için zorunlu
+  tenantId: text("tenant_id").notNull(),
   type: text("type").notNull(),
   subject: text("subject").notNull(),
   payload: jsonb("payload").notNull(),
@@ -22,4 +22,25 @@ export const bookingProjection = pgTable("booking_projection", {
   tenantId: text("tenant_id").notNull(),
   currentIntent: text("current_intent"),
   lastUpdated: timestamp("last_updated"),
+});
+
+// ==========================================
+// TECHNICAL DEBT MEMORY
+// APPEND-ONLY RISK SIGNALS FOR BOARDROOM INTELLIGENCE
+// ==========================================
+export const technicalDebtSignals = pgTable("technical_debt_signals", {
+  id: text("id").primaryKey(),
+  source: text("source").notNull(),
+  type: text("type").notNull(),
+  severity: text("severity").notNull(),
+  title: text("title").notNull(),
+  detail: text("detail").notNull(),
+  workspace: text("workspace"),
+  filePath: text("file_path"),
+  detectedAt: timestamp("detected_at").notNull(),
+  euroRisk: numeric("euro_risk", { precision: 12, scale: 2 }).notNull(),
+  confidence: real("confidence").notNull(),
+  remediation: text("remediation").notNull(),
+  payload: jsonb("payload").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
 });

--- a/packages/decision-kernel/src/bounded-pathfinding.service.ts
+++ b/packages/decision-kernel/src/bounded-pathfinding.service.ts
@@ -1,0 +1,121 @@
+import type { SovereignAction } from "@santis/domain-schema/src/core-state.interface";
+import type { BiologicalTargetVector } from "@santis/domain-schema/src/intent.contract";
+import type { Contraindication, RitualEdge, RitualGraph, RitualNode } from "./ritual-graph.contract";
+import { scorePath, type PathScore, type PathStep } from "./path-scoring";
+
+export type PathfindingRequest = {
+  graph: RitualGraph;
+  targetVector: BiologicalTargetVector;
+  guestContraindications?: Contraindication[];
+  maxDepth?: number;
+  maxDurationMinutes?: number;
+  maxResults?: number;
+};
+
+export type RitualPathCandidate = {
+  steps: PathStep[];
+  score: PathScore;
+};
+
+export type PathfindingResult = {
+  status: "PATHS_FOUND" | "NO_SAFE_PATH";
+  candidates: RitualPathCandidate[];
+  discardedPaths: number;
+};
+
+const DEFAULT_MAX_DEPTH = 4;
+const DEFAULT_MAX_DURATION = 240;
+const DEFAULT_MAX_RESULTS = 3;
+
+function buildAdjacency(edges: RitualEdge[]) {
+  const map = new Map<string, RitualEdge[]>();
+  for (const edge of edges) {
+    const list = map.get(edge.fromNodeId) ?? [];
+    list.push(edge);
+    map.set(edge.fromNodeId, list);
+  }
+  return map;
+}
+
+function nodeMap(nodes: RitualNode[]) {
+  return new Map(nodes.map(node => [node.id, node]));
+}
+
+function violatesContraindications(edge: RitualEdge | undefined, guestContraindications: Contraindication[]) {
+  if (!edge) return false;
+  return edge.constraints.contraindications.some(item => guestContraindications.includes(item));
+}
+
+function computeCurrentDuration(path: PathStep[]) {
+  return path.reduce((sum, step) => sum + step.node.durationMinutes + step.restMinutesBefore, 0);
+}
+
+export const findBoundedRitualPaths: SovereignAction<PathfindingRequest, PathfindingResult> = async (ctx, request) => {
+  if (request.graph.tenantId !== ctx.tenant.tenantId) {
+    throw new Error("FATAL: Graph tenant mismatch");
+  }
+
+  const maxDepth = Math.max(1, Math.min(request.maxDepth ?? DEFAULT_MAX_DEPTH, 5));
+  const maxDuration = Math.max(30, Math.min(request.maxDurationMinutes ?? DEFAULT_MAX_DURATION, 360));
+  const maxResults = Math.max(1, Math.min(request.maxResults ?? DEFAULT_MAX_RESULTS, 5));
+  const guestContraindications = request.guestContraindications ?? [];
+  const adjacency = buildAdjacency(request.graph.edges);
+  const nodesById = nodeMap(request.graph.nodes);
+  const validCandidates: RitualPathCandidate[] = [];
+  let discardedPaths = 0;
+
+  function visit(path: PathStep[], visited: Set<string>) {
+    const duration = computeCurrentDuration(path);
+
+    if (path.length > maxDepth || duration > maxDuration) {
+      discardedPaths += 1;
+      return;
+    }
+
+    if (path.length > 0) {
+      const score = scorePath(path, request.targetVector);
+      if (score.loadPenalty === 0) {
+        validCandidates.push({ steps: path, score });
+      } else {
+        discardedPaths += 1;
+      }
+    }
+
+    if (path.length === maxDepth) return;
+
+    const current = path.at(-1)?.node;
+    const outgoing = current ? adjacency.get(current.id) ?? [] : [];
+
+    for (const edge of outgoing) {
+      const nextNode = nodesById.get(edge.toNodeId);
+      if (!nextNode || visited.has(nextNode.id)) continue;
+      if (violatesContraindications(edge, guestContraindications)) {
+        discardedPaths += 1;
+        continue;
+      }
+
+      visit([
+        ...path,
+        {
+          node: nextNode,
+          viaEdge: edge,
+          restMinutesBefore: edge.constraints.minRestMinutes,
+        },
+      ], new Set([...visited, nextNode.id]));
+    }
+  }
+
+  for (const startNode of request.graph.nodes) {
+    visit([{ node: startNode, restMinutesBefore: 0 }], new Set([startNode.id]));
+  }
+
+  const candidates = validCandidates
+    .sort((a, b) => b.score.totalScore - a.score.totalScore)
+    .slice(0, maxResults);
+
+  return {
+    status: candidates.length > 0 ? "PATHS_FOUND" : "NO_SAFE_PATH",
+    candidates,
+    discardedPaths,
+  };
+};

--- a/packages/decision-kernel/src/concierge-narrative.engine.ts
+++ b/packages/decision-kernel/src/concierge-narrative.engine.ts
@@ -1,0 +1,59 @@
+import type { SovereignAction } from "@santis/domain-schema/src/core-state.interface";
+import type { ResolvedIntentState } from "./intent-resolution.service";
+import type { RitualPathCandidate } from "./bounded-pathfinding.service";
+import type { TieredPrice } from "./tiered-pricing.engine";
+
+export type ConciergeNarrativeRequest = {
+  resolvedIntent: ResolvedIntentState;
+  candidate: RitualPathCandidate;
+  price: TieredPrice;
+};
+
+export type ConciergeNarrative = {
+  headline: string;
+  whyThisPath: string;
+  constraintTruth: string;
+  tierStatement: string;
+  confidenceStatement: string;
+};
+
+function topVectorLabel(vector: ResolvedIntentState["targetVector"]) {
+  const entries = Object.entries(vector).sort((a, b) => b[1] - a[1]);
+  return entries[0]?.[0] ?? "biologicalTarget";
+}
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`;
+}
+
+export const createConciergeNarrative: SovereignAction<ConciergeNarrativeRequest, ConciergeNarrative> = async (_ctx, request) => {
+  const { resolvedIntent, candidate, price } = request;
+  const vectorFocus = topVectorLabel(resolvedIntent.targetVector);
+  const alignment = formatPercent(candidate.score.alignmentScore);
+
+  const headline = price.tier === "SOVEREIGN"
+    ? "A complete route has been calibrated for your state."
+    : price.tier === "SIGNATURE"
+      ? "A precise ritual path has been selected."
+      : "A restrained essential path is available.";
+
+  const whyThisPath = `Your declared intent resolves most strongly toward ${vectorFocus}. This route matches the target vector with ${alignment} alignment while preserving biological restraint.`;
+
+  const constraintTruth = candidate.score.loadPenalty === 0
+    ? "No safety constraint was violated. Rest phases and sequence load remain inside the tenant guard envelope."
+    : "This route carries load pressure and should be reviewed before confirmation.";
+
+  const tierStatement = `${price.tier} is assigned because the path combines alignment ${formatPercent(price.explanation.alignmentScore)} with synergy ${price.explanation.synergyScore.toFixed(2)}.`;
+
+  const confidenceStatement = resolvedIntent.status === "RESOLVED"
+    ? `Intent confidence is ${formatPercent(resolvedIntent.confidenceScore)}.`
+    : "The intent blend requires clarification before a final ritual path can be sealed.";
+
+  return {
+    headline,
+    whyThisPath,
+    constraintTruth,
+    tierStatement,
+    confidenceStatement,
+  };
+};

--- a/packages/decision-kernel/src/intent-resolution.service.ts
+++ b/packages/decision-kernel/src/intent-resolution.service.ts
@@ -1,0 +1,108 @@
+import type { SovereignAction } from "@santis/domain-schema/src/core-state.interface";
+import {
+  DefaultIntentVectors,
+  GuestIntentSignalSchema,
+  type BiologicalTargetVector,
+  type GuestIntentSignal,
+  type IntentType,
+} from "@santis/domain-schema/src/intent.contract";
+
+export type IntentConflict = {
+  code: "RESET_PERFORMANCE_TENSION" | "BEAUTY_RECOVER_TENSION";
+  intents: IntentType[];
+  detail: string;
+  suggestedPrimaryIntent: IntentType;
+};
+
+export type ResolvedIntentState = {
+  targetVector: BiologicalTargetVector;
+  confidenceScore: number;
+  primaryIntent: IntentType;
+  weightedIntents: Array<{ intent: IntentType; weight: number }>;
+  identifiedConflicts: IntentConflict[];
+  status: "RESOLVED" | "REJECTED_REQUIRES_CLARIFICATION";
+};
+
+const VECTOR_KEYS: Array<keyof BiologicalTargetVector> = [
+  "cortisolReductionTarget",
+  "muscularRecoveryTarget",
+  "cellularTurnoverTarget",
+  "energyOptimizationTarget",
+  "socialSynchronizationTarget",
+];
+
+function normalizeIntentWeights(signal: GuestIntentSignal) {
+  const secondary = [...new Set(signal.secondaryIntents.filter(intent => intent !== signal.primaryIntent))];
+  const primaryWeight = secondary.length === 0 ? 1 : 0.7;
+  const secondaryWeight = secondary.length === 0 ? 0 : 0.3 / secondary.length;
+
+  return [
+    { intent: signal.primaryIntent, weight: primaryWeight },
+    ...secondary.map(intent => ({ intent, weight: secondaryWeight })),
+  ];
+}
+
+function blendVectors(weightedIntents: Array<{ intent: IntentType; weight: number }>): BiologicalTargetVector {
+  const result = Object.fromEntries(VECTOR_KEYS.map(key => [key, 0])) as BiologicalTargetVector;
+
+  for (const { intent, weight } of weightedIntents) {
+    const vector = DefaultIntentVectors[intent].biologicalTargets;
+    for (const key of VECTOR_KEYS) {
+      result[key] += vector[key] * weight;
+    }
+  }
+
+  return result;
+}
+
+function detectConflicts(signal: GuestIntentSignal): IntentConflict[] {
+  const intents = new Set<IntentType>([signal.primaryIntent, ...signal.secondaryIntents]);
+  const conflicts: IntentConflict[] = [];
+
+  if (intents.has("RESET") && intents.has("PERFORMANCE")) {
+    conflicts.push({
+      code: "RESET_PERFORMANCE_TENSION",
+      intents: ["RESET", "PERFORMANCE"],
+      detail: "RESET prioritizes nervous-system downshift while PERFORMANCE prioritizes energy elevation.",
+      suggestedPrimaryIntent: signal.primaryIntent,
+    });
+  }
+
+  if (intents.has("BEAUTY") && intents.has("RECOVER")) {
+    conflicts.push({
+      code: "BEAUTY_RECOVER_TENSION",
+      intents: ["BEAUTY", "RECOVER"],
+      detail: "BEAUTY may require cellular stimulation while RECOVER may require tissue restraint.",
+      suggestedPrimaryIntent: signal.primaryIntent,
+    });
+  }
+
+  return conflicts;
+}
+
+function deriveConfidence(baseConfidence: number, conflicts: IntentConflict[]) {
+  const penalty = conflicts.length * 0.25;
+  return Math.max(0, Math.min(1, baseConfidence - penalty));
+}
+
+export const resolveGuestIntent: SovereignAction<unknown, ResolvedIntentState> = async (_ctx, raw) => {
+  const parsed = GuestIntentSignalSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error("Invalid guest intent signal");
+  }
+
+  const signal = parsed.data;
+  const conflicts = detectConflicts(signal);
+  const weightedIntents = normalizeIntentWeights(signal);
+  const targetVector = blendVectors(weightedIntents);
+  const confidenceScore = deriveConfidence(signal.confidence, conflicts);
+
+  return {
+    targetVector,
+    confidenceScore,
+    primaryIntent: signal.primaryIntent,
+    weightedIntents,
+    identifiedConflicts: conflicts,
+    status: conflicts.length > 0 ? "REJECTED_REQUIRES_CLARIFICATION" : "RESOLVED",
+  };
+};

--- a/packages/decision-kernel/src/path-scoring.ts
+++ b/packages/decision-kernel/src/path-scoring.ts
@@ -1,0 +1,99 @@
+import type { BiologicalTargetVector } from "@santis/domain-schema/src/intent.contract";
+import type { RitualNode, RitualEdge } from "./ritual-graph.contract";
+
+export type PathStep = {
+  node: RitualNode;
+  viaEdge?: RitualEdge;
+  restMinutesBefore: number;
+};
+
+export type PathScore = {
+  alignmentScore: number; // 0..1 closeness to target
+  synergyScore: number;   // multiplicative effect from edges
+  loadPenalty: number;    // penalties from sequential load/rest violations
+  totalScore: number;     // final objective for A*
+  totalCost: number;
+  totalDuration: number;
+};
+
+const VECTOR_KEYS: Array<keyof BiologicalTargetVector> = [
+  "cortisolReductionTarget",
+  "muscularRecoveryTarget",
+  "cellularTurnoverTarget",
+  "energyOptimizationTarget",
+  "socialSynchronizationTarget",
+];
+
+export function accumulateVector(path: PathStep[]): BiologicalTargetVector {
+  const acc = Object.fromEntries(VECTOR_KEYS.map(k => [k, 0])) as BiologicalTargetVector;
+  for (const step of path) {
+    const v = step.node.vectorDelta;
+    for (const k of VECTOR_KEYS) acc[k] += v[k];
+  }
+  return acc;
+}
+
+export function computeAlignmentScore(current: BiologicalTargetVector, target: BiologicalTargetVector): number {
+  // cosine-like normalized dot product (bounded 0..1 for non-negative vectors)
+  let dot = 0, normC = 0, normT = 0;
+  for (const k of VECTOR_KEYS) {
+    dot += current[k] * target[k];
+    normC += current[k] * current[k];
+    normT += target[k] * target[k];
+  }
+  if (normC === 0 || normT === 0) return 0;
+  const cos = dot / (Math.sqrt(normC) * Math.sqrt(normT));
+  return Math.max(0, Math.min(1, cos));
+}
+
+export function computeSynergyScore(path: PathStep[]): number {
+  // product of edge multipliers (bounded to avoid runaway growth)
+  let score = 1;
+  for (const step of path) {
+    if (step.viaEdge) score *= step.viaEdge.synergyMultiplier;
+  }
+  // clamp
+  return Math.max(0.5, Math.min(2.0, score));
+}
+
+export function computeLoadPenalty(path: PathStep[]): number {
+  let penalty = 0;
+  let rollingLoad = 0;
+  for (const step of path) {
+    const nodeLoad = step.node.loadScore;
+    rollingLoad += nodeLoad;
+    if (step.viaEdge) {
+      const { maxSequentialLoad, minRestMinutes } = step.viaEdge.constraints;
+      if (rollingLoad > maxSequentialLoad) penalty += (rollingLoad - maxSequentialLoad);
+      if (step.restMinutesBefore < minRestMinutes) penalty += (minRestMinutes - step.restMinutesBefore) / 60; // hour-normalized
+    }
+    // decay after rest
+    if (step.restMinutesBefore > 0) {
+      const decay = Math.min(1, step.restMinutesBefore / 30);
+      rollingLoad *= (1 - decay);
+    }
+  }
+  return penalty; // higher is worse
+}
+
+export function computeCost(path: PathStep[]): number {
+  return path.reduce((acc, s) => acc + s.node.baseCost, 0);
+}
+
+export function computeDuration(path: PathStep[]): number {
+  return path.reduce((acc, s) => acc + s.node.durationMinutes + s.restMinutesBefore, 0);
+}
+
+export function scorePath(path: PathStep[], target: BiologicalTargetVector): PathScore {
+  const current = accumulateVector(path);
+  const alignmentScore = computeAlignmentScore(current, target);
+  const synergyScore = computeSynergyScore(path);
+  const loadPenalty = computeLoadPenalty(path);
+  const totalCost = computeCost(path);
+  const totalDuration = computeDuration(path);
+
+  // objective: maximize alignment & synergy, minimize penalty & time/cost (soft)
+  const totalScore = (alignmentScore * 0.6 + synergyScore * 0.4) - loadPenalty * 0.5 - (totalDuration / 300) * 0.1 - (totalCost / 500) * 0.1;
+
+  return { alignmentScore, synergyScore, loadPenalty, totalScore, totalCost, totalDuration };
+}

--- a/packages/decision-kernel/src/ritual-graph.contract.ts
+++ b/packages/decision-kernel/src/ritual-graph.contract.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+import { BiologicalTargetVectorSchema } from "@santis/domain-schema/src/intent.contract";
+
+export const ContraindicationSchema = z.enum([
+  "HIGH_BLOOD_PRESSURE",
+  "PREGNANCY",
+  "ACUTE_INFLAMMATION",
+  "RECENT_SURGERY",
+  "CARDIOVASCULAR_RISK",
+  "SKIN_SENSITIVITY",
+]);
+
+export const RitualNodeSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  vectorDelta: BiologicalTargetVectorSchema,
+  baseCost: z.number().nonnegative(),
+  durationMinutes: z.number().int().positive(),
+  loadScore: z.number().min(0).max(1),
+});
+
+export const RitualEdgeSchema = z.object({
+  fromNodeId: z.string().min(1),
+  toNodeId: z.string().min(1),
+  constraints: z.object({
+    minRestMinutes: z.number().int().min(0),
+    maxSequentialLoad: z.number().min(0).max(2),
+    contraindications: z.array(ContraindicationSchema).default([]),
+  }),
+  synergyMultiplier: z.number().min(0.5).max(1.75).default(1),
+});
+
+export const RitualGraphSchema = z.object({
+  tenantId: z.string().uuid(),
+  nodes: z.array(RitualNodeSchema).min(1),
+  edges: z.array(RitualEdgeSchema),
+});
+
+export type Contraindication = z.infer<typeof ContraindicationSchema>;
+export type RitualNode = z.infer<typeof RitualNodeSchema>;
+export type RitualEdge = z.infer<typeof RitualEdgeSchema>;
+export type RitualGraph = z.infer<typeof RitualGraphSchema>;

--- a/packages/decision-kernel/src/tiered-pricing.engine.ts
+++ b/packages/decision-kernel/src/tiered-pricing.engine.ts
@@ -1,0 +1,70 @@
+import type { SovereignAction } from "@santis/domain-schema/src/core-state.interface";
+import type { RitualPathCandidate } from "./bounded-pathfinding.service";
+
+export type PricingTier = "ESSENTIAL" | "SIGNATURE" | "SOVEREIGN";
+
+export type PricingContext = {
+  candidate: RitualPathCandidate;
+  demandFactor?: number; // 0.8..1.4 operational demand signal
+};
+
+export type TieredPrice = {
+  tier: PricingTier;
+  baseCost: number;
+  multiplier: number;
+  finalPrice: number;
+  explanation: {
+    alignmentScore: number;
+    synergyScore: number;
+    loadPenalty: number;
+    demandFactor: number;
+    boundedByTenantPolicy: boolean;
+  };
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function psychologicalRound(price: number) {
+  if (price < 100) return Math.round(price / 5) * 5;
+  return Math.round(price / 10) * 10;
+}
+
+function resolveTier(alignment: number, synergy: number, penalty: number): PricingTier {
+  if (alignment >= 0.85 && synergy >= 1.25 && penalty <= 0.05) return "SOVEREIGN";
+  if (alignment >= 0.6 && synergy >= 1.1 && penalty <= 0.2) return "SIGNATURE";
+  return "ESSENTIAL";
+}
+
+export const priceRitualPath: SovereignAction<PricingContext, TieredPrice> = async (ctx, payload) => {
+  const score = payload.candidate.score;
+  const demandFactor = clamp(payload.demandFactor ?? 1, 0.8, 1.4);
+
+  const minMultiplier = 0.8;
+  const maxMultiplier = 1.8;
+
+  const alignmentPremium = Math.pow(score.alignmentScore, 1.35) * 0.45;
+  const synergyPremium = Math.max(0, score.synergyScore - 1) * 0.55;
+  const penaltyDiscount = score.loadPenalty * 0.35;
+  const demandPremium = (demandFactor - 1) * 0.25;
+
+  const rawMultiplier = 1 + alignmentPremium + synergyPremium + demandPremium - penaltyDiscount;
+  const multiplier = clamp(rawMultiplier, minMultiplier, maxMultiplier);
+  const tier = resolveTier(score.alignmentScore, score.synergyScore, score.loadPenalty);
+  const finalPrice = psychologicalRound(score.totalCost * multiplier);
+
+  return {
+    tier,
+    baseCost: score.totalCost,
+    multiplier,
+    finalPrice,
+    explanation: {
+      alignmentScore: score.alignmentScore,
+      synergyScore: score.synergyScore,
+      loadPenalty: score.loadPenalty,
+      demandFactor,
+      boundedByTenantPolicy: rawMultiplier !== multiplier,
+    },
+  };
+};

--- a/packages/domain-schema/src/core-state.interface.ts
+++ b/packages/domain-schema/src/core-state.interface.ts
@@ -1,0 +1,27 @@
+import type { TenantContract } from "./tenant.contract";
+
+export interface SovereignContext {
+  tenant: TenantContract;
+  requestId: string;
+  timestamp: number;
+}
+
+export interface CoreState {
+  activeTenants: Map<string, SovereignContext>;
+  suspendTenant: (tenantId: string, reason: string) => void;
+}
+
+// Minimal default in-memory implementation (non-invasive)
+export const createCoreState = (): CoreState => {
+  const activeTenants = new Map<string, SovereignContext>();
+
+  return {
+    activeTenants,
+    suspendTenant: (tenantId: string, reason: string) => {
+      const ctx = activeTenants.get(tenantId);
+      if (!ctx) return;
+      console.warn(`[CORE] Tenant suspended: ${tenantId} | ${reason}`);
+      activeTenants.delete(tenantId);
+    },
+  };
+};

--- a/packages/domain-schema/src/core-state.interface.ts
+++ b/packages/domain-schema/src/core-state.interface.ts
@@ -6,12 +6,16 @@ export interface SovereignContext {
   timestamp: number;
 }
 
+export type SovereignAction<TPayload, TResult> = (
+  ctx: SovereignContext,
+  payload: TPayload
+) => Promise<TResult>;
+
 export interface CoreState {
   activeTenants: Map<string, SovereignContext>;
   suspendTenant: (tenantId: string, reason: string) => void;
 }
 
-// Minimal default in-memory implementation (non-invasive)
 export const createCoreState = (): CoreState => {
   const activeTenants = new Map<string, SovereignContext>();
 

--- a/packages/domain-schema/src/intent.contract.ts
+++ b/packages/domain-schema/src/intent.contract.ts
@@ -1,0 +1,95 @@
+import { z } from "zod";
+
+export const IntentTypeSchema = z.enum([
+  "RESET",
+  "RECOVER",
+  "BEAUTY",
+  "PERFORMANCE",
+  "CONNECTION",
+]);
+
+export const BiologicalTargetVectorSchema = z.object({
+  cortisolReductionTarget: z.number().min(0).max(1).default(0),
+  muscularRecoveryTarget: z.number().min(0).max(1).default(0),
+  cellularTurnoverTarget: z.number().min(0).max(1).default(0),
+  energyOptimizationTarget: z.number().min(0).max(1).default(0),
+  socialSynchronizationTarget: z.number().min(0).max(1).default(0),
+});
+
+export const IntentVectorSchema = z.object({
+  intent: IntentTypeSchema,
+  weight: z.number().min(0).max(1),
+  biologicalTargets: BiologicalTargetVectorSchema,
+});
+
+export const GuestIntentSignalSchema = z.object({
+  tenantId: z.string().uuid(),
+  sessionId: z.string().min(1),
+  primaryIntent: IntentTypeSchema,
+  secondaryIntents: z.array(IntentTypeSchema).default([]),
+  declaredAt: z.string().datetime(),
+  confidence: z.number().min(0).max(1),
+});
+
+export const DefaultIntentVectors: Record<z.infer<typeof IntentTypeSchema>, z.infer<typeof IntentVectorSchema>> = {
+  RESET: {
+    intent: "RESET",
+    weight: 1,
+    biologicalTargets: {
+      cortisolReductionTarget: 0.9,
+      muscularRecoveryTarget: 0.35,
+      cellularTurnoverTarget: 0.15,
+      energyOptimizationTarget: 0.25,
+      socialSynchronizationTarget: 0.1,
+    },
+  },
+  RECOVER: {
+    intent: "RECOVER",
+    weight: 1,
+    biologicalTargets: {
+      cortisolReductionTarget: 0.45,
+      muscularRecoveryTarget: 0.9,
+      cellularTurnoverTarget: 0.25,
+      energyOptimizationTarget: 0.45,
+      socialSynchronizationTarget: 0.05,
+    },
+  },
+  BEAUTY: {
+    intent: "BEAUTY",
+    weight: 1,
+    biologicalTargets: {
+      cortisolReductionTarget: 0.25,
+      muscularRecoveryTarget: 0.1,
+      cellularTurnoverTarget: 0.95,
+      energyOptimizationTarget: 0.25,
+      socialSynchronizationTarget: 0.15,
+    },
+  },
+  PERFORMANCE: {
+    intent: "PERFORMANCE",
+    weight: 1,
+    biologicalTargets: {
+      cortisolReductionTarget: 0.25,
+      muscularRecoveryTarget: 0.65,
+      cellularTurnoverTarget: 0.2,
+      energyOptimizationTarget: 0.95,
+      socialSynchronizationTarget: 0.05,
+    },
+  },
+  CONNECTION: {
+    intent: "CONNECTION",
+    weight: 1,
+    biologicalTargets: {
+      cortisolReductionTarget: 0.5,
+      muscularRecoveryTarget: 0.2,
+      cellularTurnoverTarget: 0.15,
+      energyOptimizationTarget: 0.35,
+      socialSynchronizationTarget: 0.95,
+    },
+  },
+};
+
+export type IntentType = z.infer<typeof IntentTypeSchema>;
+export type BiologicalTargetVector = z.infer<typeof BiologicalTargetVectorSchema>;
+export type IntentVector = z.infer<typeof IntentVectorSchema>;
+export type GuestIntentSignal = z.infer<typeof GuestIntentSignalSchema>;

--- a/packages/domain-schema/src/tenant.contract.ts
+++ b/packages/domain-schema/src/tenant.contract.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const TenantEconomicsSchema = z.object({
+  baseCurrency: z.literal("EUR"),
+  commissionModel: z.enum(["STANDARD", "TIERED", "CUSTOM"]),
+  taxRate: z.number().min(0).max(1),
+});
+
+export const TenantGuardSchema = z.object({
+  fatalEuroDebtThreshold: z.number().min(1000).default(5000),
+  maxVelocityEuroPerDay: z.number().min(100).default(500),
+  allowBoardroomOverride: z.boolean().default(true),
+});
+
+export const TenantFeaturesSchema = z.object({
+  intentEngineEnabled: z.boolean().default(false),
+  ritualStackAlgorithm: z.boolean().default(false),
+});
+
+export const TenantSchema = z.object({
+  tenantId: z.string().uuid(),
+  slug: z.string().min(2),
+  name: z.string().min(1),
+  isDefault: z.boolean().default(false),
+  isActive: z.boolean().default(true),
+  economics: TenantEconomicsSchema,
+  guardPolicy: TenantGuardSchema,
+  features: TenantFeaturesSchema,
+});
+
+export const DefaultSantisTenant = TenantSchema.parse({
+  tenantId: "00000000-0000-4000-8000-000000000001",
+  slug: "santis-club-default",
+  name: "Santis Club",
+  isDefault: true,
+  isActive: true,
+  economics: {
+    baseCurrency: "EUR",
+    commissionModel: "STANDARD",
+    taxRate: 0.21,
+  },
+  guardPolicy: {
+    fatalEuroDebtThreshold: 5000,
+    maxVelocityEuroPerDay: 500,
+    allowBoardroomOverride: true,
+  },
+  features: {
+    intentEngineEnabled: true,
+    ritualStackAlgorithm: true,
+  },
+});
+
+export type TenantEconomics = z.infer<typeof TenantEconomicsSchema>;
+export type TenantGuard = z.infer<typeof TenantGuardSchema>;
+export type TenantFeatures = z.infer<typeof TenantFeaturesSchema>;
+export type TenantContract = z.infer<typeof TenantSchema>;

--- a/packages/persistence/src/base.repository.ts
+++ b/packages/persistence/src/base.repository.ts
@@ -1,0 +1,24 @@
+import type { SovereignContext } from "@santis/domain-schema/src/core-state.interface";
+
+export abstract class SovereignRepository<T extends { tenantId?: string }> {
+  protected abstract db: any;
+
+  protected async secureInsert(ctx: SovereignContext, data: Partial<T>) {
+    const safeData = {
+      ...data,
+      tenantId: ctx.tenant.tenantId,
+    };
+
+    return this.db.insert(safeData);
+  }
+
+  protected async secureQuery(ctx: SovereignContext, query: any) {
+    return this.db.query({
+      ...query,
+      where: {
+        ...(query.where || {}),
+        tenantId: ctx.tenant.tenantId,
+      },
+    });
+  }
+}

--- a/scripts/active/audit-environment.js
+++ b/scripts/active/audit-environment.js
@@ -1,0 +1,56 @@
+/**
+ * SANTIS OS — Sovereign Environment Auditor
+ * Purpose: Enforces pnpm/Node runtime determinism before build execution.
+ * Logic: Production-grade, zero-dependency, fail-fast validation.
+ */
+import fs from "node:fs";
+import { execSync } from "node:child_process";
+
+const REQUIRED_NODE_MAJOR = 20;
+const REQUIRED_PNPM_MAJOR = 9;
+const FORBIDDEN_LOCKFILES = [
+  "package-lock.json",
+  "npm-shrinkwrap.json",
+  "yarn.lock",
+];
+
+console.log("🛡️ [Sovereign Guard] Environment audit starting...");
+
+let failed = false;
+
+for (const file of FORBIDDEN_LOCKFILES) {
+  if (fs.existsSync(file)) {
+    console.error(`❌ Forbidden lockfile detected: ${file}`);
+    failed = true;
+  }
+}
+
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+if (Number.isNaN(nodeMajor) || nodeMajor < REQUIRED_NODE_MAJOR) {
+  console.error(`❌ Node.js ${REQUIRED_NODE_MAJOR}+ required. Current: ${process.versions.node}`);
+  failed = true;
+} else {
+  console.log(`✅ Node.js runtime sealed: ${process.versions.node}`);
+}
+
+try {
+  const pnpmVersion = execSync("pnpm --version", { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+  const pnpmMajor = Number.parseInt(pnpmVersion.split(".")[0], 10);
+
+  if (Number.isNaN(pnpmMajor) || pnpmMajor < REQUIRED_PNPM_MAJOR) {
+    console.error(`❌ pnpm ${REQUIRED_PNPM_MAJOR}+ required. Current: ${pnpmVersion}`);
+    failed = true;
+  } else {
+    console.log(`✅ pnpm runtime sealed: ${pnpmVersion}`);
+  }
+} catch {
+  console.error("❌ pnpm is required but was not found in PATH.");
+  failed = true;
+}
+
+if (failed) {
+  console.error("\n🚨 Environment constitutional audit failed.");
+  process.exit(1);
+}
+
+console.log("\n✨ Environment conforms to sovereign runtime standards.");

--- a/scripts/active/audit-workspace-scripts.js
+++ b/scripts/active/audit-workspace-scripts.js
@@ -1,0 +1,128 @@
+/**
+ * SANTIS OS — Sovereign Workspace Auditor
+ * Purpose: Ensures all active workspace units define mandatory architectural scripts.
+ * Logic: Production-grade, zero-dependency, workspace-aware validation.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT_DIR = process.cwd();
+const WORKSPACE_FILE = path.join(ROOT_DIR, "pnpm-workspace.yaml");
+const MANDATORY_SCRIPTS = ["build", "lint", "typecheck"];
+const IGNORE_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".turbo",
+  ".next",
+  "dist",
+  "build",
+  "coverage",
+  "_archive",
+  "archive",
+]);
+
+console.log("🛡️ [Sovereign Guard] Workspace script audit starting...");
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    console.error(`❌ Invalid JSON: ${path.relative(ROOT_DIR, filePath)}`);
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+function parseWorkspacePatterns() {
+  if (!fs.existsSync(WORKSPACE_FILE)) {
+    console.error("❌ pnpm-workspace.yaml not found. Workspace reality cannot be audited.");
+    process.exit(1);
+  }
+
+  const lines = fs.readFileSync(WORKSPACE_FILE, "utf8").split(/\r?\n/);
+  const patterns = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("-")) continue;
+
+    const pattern = trimmed
+      .slice(1)
+      .trim()
+      .replace(/^['\"]|['\"]$/g, "");
+
+    if (pattern && !pattern.startsWith("!")) {
+      patterns.push(pattern);
+    }
+  }
+
+  if (patterns.length === 0) {
+    console.error("❌ No workspace package patterns found in pnpm-workspace.yaml.");
+    process.exit(1);
+  }
+
+  return patterns;
+}
+
+function listDirectories(baseDir) {
+  if (!fs.existsSync(baseDir)) return [];
+
+  return fs
+    .readdirSync(baseDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) => !IGNORE_DIRS.has(entry.name))
+    .map((entry) => path.join(baseDir, entry.name));
+}
+
+function expandWorkspacePattern(pattern) {
+  const normalized = pattern.replace(/\\/g, "/");
+
+  if (normalized.endsWith("/*")) {
+    const base = path.join(ROOT_DIR, normalized.slice(0, -2));
+    return listDirectories(base);
+  }
+
+  const direct = path.join(ROOT_DIR, normalized);
+  return fs.existsSync(direct) ? [direct] : [];
+}
+
+const workspaceDirs = [...new Set(parseWorkspacePatterns().flatMap(expandWorkspacePattern))]
+  .sort((a, b) => a.localeCompare(b));
+
+let failed = false;
+let checked = 0;
+
+for (const workspaceDir of workspaceDirs) {
+  const pkgPath = path.join(workspaceDir, "package.json");
+  const relativeDir = path.relative(ROOT_DIR, workspaceDir);
+
+  if (!fs.existsSync(pkgPath)) {
+    console.error(`❌ Workspace path has no package.json: ${relativeDir}`);
+    failed = true;
+    continue;
+  }
+
+  const pkg = readJson(pkgPath);
+  const scripts = pkg.scripts || {};
+  const missing = MANDATORY_SCRIPTS.filter((scriptName) => !scripts[scriptName]);
+  checked += 1;
+
+  if (missing.length > 0) {
+    console.error(`❌ ${pkg.name || relativeDir} missing scripts: ${missing.join(", ")}`);
+    failed = true;
+  } else {
+    console.log(`✅ ${pkg.name || relativeDir} sealed.`);
+  }
+}
+
+if (checked === 0) {
+  console.error("❌ No workspace package.json files were audited.");
+  process.exit(1);
+}
+
+if (failed) {
+  console.error("\n🚨 Workspace constitutional audit failed.");
+  process.exit(1);
+}
+
+console.log(`\n✨ ${checked} workspace unit(s) conform to sovereign script standards.`);

--- a/scripts/ci-telemetry-bridge.js
+++ b/scripts/ci-telemetry-bridge.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * SANTIS OS — CI Telemetry Bridge
+ * Purpose: Converts CI dependency/security findings into Boardroom technical-debt signals.
+ * Runtime: ESM, zero external dependencies, non-blocking telemetry transport.
+ */
+import { execSync } from "node:child_process";
+import https from "node:https";
+import http from "node:http";
+
+const API_URL = process.env.SANTIS_API_URL || "https://api.santis.club";
+const API_KEY = process.env.SANTIS_TELEMETRY_KEY || "";
+const CI_RUN_ID = process.env.GITHUB_RUN_ID || `local-${Date.now()}`;
+const CI_SHA = process.env.GITHUB_SHA || "unknown-sha";
+const CI_REF = process.env.GITHUB_REF_NAME || process.env.GITHUB_REF || "unknown-ref";
+
+console.log("🦅 [SANTIS CI] Telemetry Bridge active. Translating audit findings into Boardroom signals...");
+
+function safeJsonParse(raw, fallback) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function runPnpmAudit() {
+  try {
+    const output = execSync("pnpm audit --json", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return safeJsonParse(output, {});
+  } catch (error) {
+    const stdout = typeof error?.stdout === "string" ? error.stdout : "";
+    return safeJsonParse(stdout, {});
+  }
+}
+
+function readVulnerabilityCounts(auditResult) {
+  const meta = auditResult?.metadata?.vulnerabilities || {};
+
+  return {
+    critical: Number(meta.critical || 0),
+    high: Number(meta.high || 0),
+    moderate: Number(meta.moderate || 0),
+    low: Number(meta.low || 0),
+  };
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function createSignal({ type, severity, count, euroUnit, confidence, title, detail, remediation }) {
+  return {
+    id: `ci-${type}-${CI_RUN_ID}-${Date.now()}`,
+    source: "ci",
+    type,
+    severity,
+    title,
+    detail: `${detail} Commit: ${CI_SHA}. Ref: ${CI_REF}. Count: ${count}.`,
+    detectedAt: nowIso(),
+    euroRisk: count * euroUnit,
+    confidence,
+    remediation,
+  };
+}
+
+function calculateSignals(counts) {
+  const signals = [];
+
+  if (counts.critical > 0) {
+    signals.push(createSignal({
+      type: "security_advisory",
+      severity: "critical",
+      count: counts.critical,
+      euroUnit: 4500,
+      confidence: 0.95,
+      title: "Critical dependency advisory detected",
+      detail: "CI dependency audit found critical vulnerabilities before deployment.",
+      remediation: "Run pnpm audit, upgrade or override the affected dependency, and re-run Sovereign CI.",
+    }));
+  }
+
+  if (counts.high > 0) {
+    signals.push(createSignal({
+      type: "dependency_drift",
+      severity: "high",
+      count: counts.high,
+      euroUnit: 1200,
+      confidence: 0.85,
+      title: "High dependency drift detected",
+      detail: "CI dependency audit found high-severity dependency risk.",
+      remediation: "Patch dependency graph and confirm pnpm-lock.yaml remains deterministic.",
+    }));
+  }
+
+  if (counts.moderate > 0) {
+    signals.push(createSignal({
+      type: "dependency_drift",
+      severity: "medium",
+      count: counts.moderate,
+      euroUnit: 350,
+      confidence: 0.72,
+      title: "Moderate dependency drift detected",
+      detail: "CI dependency audit found moderate-severity dependency risk.",
+      remediation: "Schedule dependency update during the next hardening window.",
+    }));
+  }
+
+  return signals;
+}
+
+function transmit(signals) {
+  if (signals.length === 0) {
+    console.log("✅ [SANTIS CI] No dependency risk signal detected. EURO risk: €0");
+    return Promise.resolve();
+  }
+
+  if (!API_KEY) {
+    console.warn("⚠️ [SANTIS CI] SANTIS_TELEMETRY_KEY is not set. Telemetry skipped without failing CI.");
+    return Promise.resolve();
+  }
+
+  const endpoint = new URL("/api/v1/technical-debt", API_URL);
+  const payload = JSON.stringify({ signals });
+  const transport = endpoint.protocol === "http:" ? http : https;
+
+  console.log(`📡 [SANTIS CI] Transmitting ${signals.length} Boardroom signal(s) to ${endpoint.origin}...`);
+
+  return new Promise((resolve) => {
+    const req = transport.request(endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "authorization": `Bearer ${API_KEY}`,
+        "content-length": Buffer.byteLength(payload),
+      },
+    }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", chunk => { body += chunk; });
+      res.on("end", () => {
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          console.log("🥂 [SANTIS CI] Boardroom telemetry accepted.");
+        } else {
+          console.warn(`⚠️ [SANTIS CI] Boardroom telemetry rejected with status ${res.statusCode}. ${body}`);
+        }
+        resolve();
+      });
+    });
+
+    req.on("error", (error) => {
+      console.warn(`⚠️ [SANTIS CI] Telemetry transport failed without blocking CI: ${error.message}`);
+      resolve();
+    });
+
+    req.write(payload);
+    req.end();
+  });
+}
+
+const auditResult = runPnpmAudit();
+const counts = readVulnerabilityCounts(auditResult);
+const signals = calculateSignals(counts);
+
+await transmit(signals);

--- a/scripts/production-signature-guard.js
+++ b/scripts/production-signature-guard.js
@@ -1,9 +1,4 @@
 #!/usr/bin/env node
-/**
- * SANTIS OS — Production Signature Guard
- * Purpose: Blocks deploys when technical-debt forecast indicates operational risk.
- * Contract: Telemetry failure is observable; guard failure is deploy-blocking.
- */
 import https from "node:https";
 import http from "node:http";
 import crypto from "node:crypto";
@@ -13,121 +8,74 @@ const API_KEY = process.env.SANTIS_TELEMETRY_KEY || "";
 const OVERRIDE_TOKEN = process.env.SANTIS_DEPLOY_OVERRIDE_TOKEN || "";
 const OVERRIDE_REASON = process.env.SANTIS_DEPLOY_OVERRIDE_REASON || "";
 
-const FATAL_EURO_THRESHOLD = Number(process.env.SANTIS_FATAL_EURO_THRESHOLD || 5000);
-const IMMINENT_BREACH_DAYS = Number(process.env.SANTIS_IMMINENT_BREACH_DAYS || 7);
-const VELOCITY_BLOCK_THRESHOLD = Number(process.env.SANTIS_VELOCITY_BLOCK_THRESHOLD || 500);
-const RECOVERY_PASS_THRESHOLD = Number(process.env.SANTIS_RECOVERY_PASS_THRESHOLD || 4000);
-const OPTIMAL_PASS_THRESHOLD = Number(process.env.SANTIS_OPTIMAL_PASS_THRESHOLD || 2000);
-
-function requestJson(pathname) {
+function requestJson(pathname, method = "GET", body) {
   const endpoint = new URL(pathname, API_URL);
   const transport = endpoint.protocol === "http:" ? http : https;
 
   return new Promise((resolve, reject) => {
     const req = transport.request(endpoint, {
-      method: "GET",
+      method,
       headers: {
         "accept": "application/json",
+        "content-type": "application/json",
         ...(API_KEY ? { "authorization": `Bearer ${API_KEY}` } : {}),
       },
     }, (res) => {
-      let body = "";
-      res.setEncoding("utf8");
-      res.on("data", chunk => { body += chunk; });
+      let data = "";
+      res.on("data", chunk => data += chunk);
       res.on("end", () => {
-        if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
-          reject(new Error(`HTTP ${res.statusCode}: ${body}`));
-          return;
-        }
-
         try {
-          resolve(JSON.parse(body));
+          resolve(JSON.parse(data));
         } catch {
-          reject(new Error("Invalid JSON returned by Boardroom trend endpoint"));
+          reject(new Error("Invalid JSON response"));
         }
       });
     });
 
     req.on("error", reject);
+    if (body) req.write(JSON.stringify(body));
     req.end();
   });
-}
-
-function daysUntil(isoDate) {
-  if (!isoDate) return null;
-  return Math.ceil((new Date(isoDate).getTime() - Date.now()) / 86_400_000);
 }
 
 function hashToken(token) {
   return crypto.createHash("sha256").update(token).digest("hex").slice(0, 12);
 }
 
-function isOverrideAllowed() {
-  if (!OVERRIDE_TOKEN) return false;
-  if (OVERRIDE_REASON.trim().length < 12) {
-    console.error("❌ Override token supplied without sufficient reason. SANTIS_DEPLOY_OVERRIDE_REASON must be explicit.");
-    return false;
-  }
-
-  console.warn(`⚠️ Sovereign override active. token=${hashToken(OVERRIDE_TOKEN)} reason=${OVERRIDE_REASON}`);
-  return true;
+async function verifyOverride(token, reason) {
+  return requestJson("/api/v1/boardroom/override-token/consume", "POST", { token, reason });
 }
 
-function evaluate(projection) {
-  const breachDays = daysUntil(projection.estimatedBreachDate);
+async function runGuard() {
+  console.log("🔒 Santis OS Guard running...");
 
-  if (projection.currentEuroDebt >= FATAL_EURO_THRESHOLD) {
-    return { pass: false, reason: `Fatal State: currentEuroDebt ${projection.currentEuroDebt} >= ${FATAL_EURO_THRESHOLD}` };
-  }
+  const trend = await requestJson("/api/v1/technical-debt/trend");
+  const projection = trend.projection;
 
-  if (breachDays !== null && breachDays < IMMINENT_BREACH_DAYS && projection.trendDirection === "DEGRADING") {
-    return { pass: false, reason: `Imminent Breach: estimated breach in ${breachDays} day(s)` };
-  }
-
-  if (projection.debtVelocityEuroPerDay > VELOCITY_BLOCK_THRESHOLD) {
-    return { pass: false, reason: `Velocity Anomaly: ${projection.debtVelocityEuroPerDay.toFixed(2)} EUR/day` };
-  }
-
-  if (projection.currentEuroDebt > RECOVERY_PASS_THRESHOLD && projection.trendDirection === "IMPROVING") {
-    return { pass: true, reason: "Recovery State: high debt but improving trend" };
-  }
-
-  if (projection.currentEuroDebt < OPTIMAL_PASS_THRESHOLD && projection.trendDirection === "STABLE") {
-    return { pass: true, reason: "Optimal State: low debt and stable trend" };
-  }
-
-  return { pass: true, reason: "Risk accepted within sovereign deploy envelope" };
-}
-
-try {
-  console.log("🔒 [SANTIS] Production Signature Guard evaluating deploy risk...");
-  const response = await requestJson(`/api/v1/technical-debt/trend?thresholdEuro=${FATAL_EURO_THRESHOLD}`);
-  const projection = response.projection || response;
-  const decision = evaluate(projection);
-
-  console.log(`Current Debt: €${projection.currentEuroDebt}`);
-  console.log(`Velocity: €${Number(projection.debtVelocityEuroPerDay).toFixed(2)}/day`);
-  console.log(`Trend: ${projection.trendDirection}`);
-  console.log(`Breach: ${projection.estimatedBreachDate || "none"}`);
-
-  if (decision.pass) {
-    console.log(`✅ Deploy signature granted. ${decision.reason}`);
+  if (projection.currentEuroDebt < 2000 && projection.trendDirection === "STABLE") {
+    console.log("✅ Deploy approved.");
     process.exit(0);
   }
 
-  if (isOverrideAllowed()) {
-    console.warn(`🟡 Deploy signature granted by sovereign override. Original block: ${decision.reason}`);
+  console.warn("🚫 Deploy blocked by Sovereign Guard.");
+
+  if (!OVERRIDE_TOKEN) {
+    console.error("❌ No override token.");
+    process.exit(1);
+  }
+
+  const result = await verifyOverride(OVERRIDE_TOKEN, OVERRIDE_REASON);
+
+  if (result.ok) {
+    console.warn(`🟡 Override accepted: ${hashToken(OVERRIDE_TOKEN)}`);
     process.exit(0);
   }
 
-  console.error(`🚫 Deploy signature denied. ${decision.reason}`);
-  process.exit(1);
-} catch (error) {
-  if (isOverrideAllowed()) {
-    console.warn(`🟡 Deploy signature granted by override because guard could not evaluate: ${error.message}`);
-    process.exit(0);
-  }
-
-  console.error(`🚫 Deploy signature denied because guard could not evaluate trend endpoint: ${error.message}`);
+  console.error("❌ Invalid override token.");
   process.exit(1);
 }
+
+runGuard().catch(err => {
+  console.error("Guard failure:", err.message);
+  process.exit(1);
+});

--- a/scripts/production-signature-guard.js
+++ b/scripts/production-signature-guard.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * SANTIS OS — Production Signature Guard
+ * Purpose: Blocks deploys when technical-debt forecast indicates operational risk.
+ * Contract: Telemetry failure is observable; guard failure is deploy-blocking.
+ */
+import https from "node:https";
+import http from "node:http";
+import crypto from "node:crypto";
+
+const API_URL = process.env.SANTIS_API_URL || "https://api.santis.club";
+const API_KEY = process.env.SANTIS_TELEMETRY_KEY || "";
+const OVERRIDE_TOKEN = process.env.SANTIS_DEPLOY_OVERRIDE_TOKEN || "";
+const OVERRIDE_REASON = process.env.SANTIS_DEPLOY_OVERRIDE_REASON || "";
+
+const FATAL_EURO_THRESHOLD = Number(process.env.SANTIS_FATAL_EURO_THRESHOLD || 5000);
+const IMMINENT_BREACH_DAYS = Number(process.env.SANTIS_IMMINENT_BREACH_DAYS || 7);
+const VELOCITY_BLOCK_THRESHOLD = Number(process.env.SANTIS_VELOCITY_BLOCK_THRESHOLD || 500);
+const RECOVERY_PASS_THRESHOLD = Number(process.env.SANTIS_RECOVERY_PASS_THRESHOLD || 4000);
+const OPTIMAL_PASS_THRESHOLD = Number(process.env.SANTIS_OPTIMAL_PASS_THRESHOLD || 2000);
+
+function requestJson(pathname) {
+  const endpoint = new URL(pathname, API_URL);
+  const transport = endpoint.protocol === "http:" ? http : https;
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request(endpoint, {
+      method: "GET",
+      headers: {
+        "accept": "application/json",
+        ...(API_KEY ? { "authorization": `Bearer ${API_KEY}` } : {}),
+      },
+    }, (res) => {
+      let body = "";
+      res.setEncoding("utf8");
+      res.on("data", chunk => { body += chunk; });
+      res.on("end", () => {
+        if (!res.statusCode || res.statusCode < 200 || res.statusCode >= 300) {
+          reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(body));
+        } catch {
+          reject(new Error("Invalid JSON returned by Boardroom trend endpoint"));
+        }
+      });
+    });
+
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function daysUntil(isoDate) {
+  if (!isoDate) return null;
+  return Math.ceil((new Date(isoDate).getTime() - Date.now()) / 86_400_000);
+}
+
+function hashToken(token) {
+  return crypto.createHash("sha256").update(token).digest("hex").slice(0, 12);
+}
+
+function isOverrideAllowed() {
+  if (!OVERRIDE_TOKEN) return false;
+  if (OVERRIDE_REASON.trim().length < 12) {
+    console.error("❌ Override token supplied without sufficient reason. SANTIS_DEPLOY_OVERRIDE_REASON must be explicit.");
+    return false;
+  }
+
+  console.warn(`⚠️ Sovereign override active. token=${hashToken(OVERRIDE_TOKEN)} reason=${OVERRIDE_REASON}`);
+  return true;
+}
+
+function evaluate(projection) {
+  const breachDays = daysUntil(projection.estimatedBreachDate);
+
+  if (projection.currentEuroDebt >= FATAL_EURO_THRESHOLD) {
+    return { pass: false, reason: `Fatal State: currentEuroDebt ${projection.currentEuroDebt} >= ${FATAL_EURO_THRESHOLD}` };
+  }
+
+  if (breachDays !== null && breachDays < IMMINENT_BREACH_DAYS && projection.trendDirection === "DEGRADING") {
+    return { pass: false, reason: `Imminent Breach: estimated breach in ${breachDays} day(s)` };
+  }
+
+  if (projection.debtVelocityEuroPerDay > VELOCITY_BLOCK_THRESHOLD) {
+    return { pass: false, reason: `Velocity Anomaly: ${projection.debtVelocityEuroPerDay.toFixed(2)} EUR/day` };
+  }
+
+  if (projection.currentEuroDebt > RECOVERY_PASS_THRESHOLD && projection.trendDirection === "IMPROVING") {
+    return { pass: true, reason: "Recovery State: high debt but improving trend" };
+  }
+
+  if (projection.currentEuroDebt < OPTIMAL_PASS_THRESHOLD && projection.trendDirection === "STABLE") {
+    return { pass: true, reason: "Optimal State: low debt and stable trend" };
+  }
+
+  return { pass: true, reason: "Risk accepted within sovereign deploy envelope" };
+}
+
+try {
+  console.log("🔒 [SANTIS] Production Signature Guard evaluating deploy risk...");
+  const response = await requestJson(`/api/v1/technical-debt/trend?thresholdEuro=${FATAL_EURO_THRESHOLD}`);
+  const projection = response.projection || response;
+  const decision = evaluate(projection);
+
+  console.log(`Current Debt: €${projection.currentEuroDebt}`);
+  console.log(`Velocity: €${Number(projection.debtVelocityEuroPerDay).toFixed(2)}/day`);
+  console.log(`Trend: ${projection.trendDirection}`);
+  console.log(`Breach: ${projection.estimatedBreachDate || "none"}`);
+
+  if (decision.pass) {
+    console.log(`✅ Deploy signature granted. ${decision.reason}`);
+    process.exit(0);
+  }
+
+  if (isOverrideAllowed()) {
+    console.warn(`🟡 Deploy signature granted by sovereign override. Original block: ${decision.reason}`);
+    process.exit(0);
+  }
+
+  console.error(`🚫 Deploy signature denied. ${decision.reason}`);
+  process.exit(1);
+} catch (error) {
+  if (isOverrideAllowed()) {
+    console.warn(`🟡 Deploy signature granted by override because guard could not evaluate: ${error.message}`);
+    process.exit(0);
+  }
+
+  console.error(`🚫 Deploy signature denied because guard could not evaluate trend endpoint: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

This PR seals the Santis OS transition from a single-product codebase into a multi-tenant Sovereign Platform foundation.

## What changed

### Sovereign Guard & CI
- Added pnpm/native CI pipeline with `audit:all` enforcement.
- Added environment and workspace audit guards.
- Hardened Docker build toward pnpm + Corepack + frozen/offline install.
- Added CI telemetry bridge for Boardroom technical-debt intelligence.

### Technical Debt Intelligence
- Added technical-debt Zod contracts, ingestion, snapshot, trend projection, persistence schema, and Boardroom panel.
- Added Production Signature Guard for forecast-based deploy blocking.
- Added Boardroom override token service and `ARCHITECT_OVERRULE` event path.

### Multi-tenant Sovereign Platform
- Added tenant contract, default Santis tenant, sovereign context, compiler/runtime/persistence walls.
- Began tenant-aware technical-debt memory isolation and context enforcement.

### Ritual Stack Intelligence
- Added Intent Contract with biological target vectors.
- Added Intent Resolution Engine with weighted vector merge and explicit conflict rejection.
- Added Constraint Ritual Graph contract.
- Added bounded pathfinding and path scoring with alignment, synergy, load penalty, cost and duration.
- Added bounded multi-factor tiered pricing engine.
- Added Concierge Narrative Engine to translate mathematical truth into Quiet Luxury UX language.

## Architectural principles sealed

- Logic can be shared; state must be tenant-isolated.
- Technical debt is an analytical signal stream, not a domain event.
- Pricing is outcome precision, not service cost.
- The UI should reveal truth gracefully, not simulate thinking.
- Additive only; never destructive.

## Known follow-ups

- Complete context hardening across every existing service/route.
- Replace temporary in-memory override token store with durable single-use token persistence.
- Add migrations for new DB schema fields/tables.
- Wire `TechnicalDebtPanel` into the active Boardroom shell.
- Add tests for guard scripts, tenant isolation, path scoring and pricing bounds.

Closes #75 when all follow-up hardening slices are completed.