### PR TITLE
chore(sovereign-guard): seal pnpm workspace and CI audit contracts

### DIFF
--- a/.github/workflows/sovereign-guard.yml
+++ b/.github/workflows/sovereign-guard.yml
@@ -1,0 +1,20 @@
+name: Sovereign Guard
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: corepack enable
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit:all
+        env:
+          NODE_ENV: test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "packageManager": "pnpm@9.1.0",
   "scripts": {
-    "build": "pnpm run audit:localhost && turbo run build",
+    "build": "pnpm run audit:all && turbo run build",
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
@@ -16,8 +16,12 @@
     "stitch:enforce": "node packages/design-system/scripts/validate.js && node packages/design-system/scripts/check.js && node packages/design-system/scripts/guard.js",
     "test:quality:static": "turbo run test:quality:static",
     "test:quality:runtime": "turbo run test:quality:runtime",
+    "audit:environment": "node scripts/active/audit-environment.mjs",
+    "audit:workspace": "node scripts/active/audit-workspace-scripts.mjs",
+    "audit:contract": "turbo run audit:contract",
     "audit:runtime": "node scripts/audit-runtime-contract.js",
-    "audit:localhost": "node scripts/audit-localhost-leak.js"
+    "audit:localhost": "node scripts/audit-localhost-leak.js",
+    "audit:all": "pnpm run audit:environment && pnpm run audit:workspace && pnpm run audit:contract && pnpm run audit:localhost"
   },
   "dependencies": {
     "zod": "^3.22.4"

--- a/scripts/active/audit-environment.mjs
+++ b/scripts/active/audit-environment.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT_DIR = process.cwd();
+const PACKAGE_PATH = path.join(ROOT_DIR, 'package.json');
+const FOREIGN_LOCKFILES = ['package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock'];
+
+function fail(invariant, details) {
+  console.error(`\n❌ [Sovereign Guard] ${invariant}`);
+  for (const [key, value] of Object.entries(details)) {
+    console.error(`   ${key}: ${value}`);
+  }
+  process.exitCode = 1;
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    fail('PACKAGE_JSON_UNREADABLE', {
+      path: filePath,
+      error: error instanceof Error ? error.message : String(error),
+      fix: 'Ensure package.json is valid JSON.'
+    });
+    return null;
+  }
+}
+
+function parseMajor(versionLike) {
+  const match = String(versionLike).match(/(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+function getPnpmVersion() {
+  try {
+    return execFileSync('pnpm', ['--version'], {
+      cwd: ROOT_DIR,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+console.log('🛡️  [Sovereign Guard] Auditing execution environment...');
+
+const pkg = readJson(PACKAGE_PATH);
+
+if (pkg) {
+  const expectedNode = pkg.engines?.node ?? '>=20.0.0';
+  const expectedPnpm = pkg.engines?.pnpm ?? '>=9.0.0';
+  const packageManager = pkg.packageManager ?? '';
+
+  const expectedNodeMajor = parseMajor(expectedNode);
+  const actualNodeMajor = parseMajor(process.versions.node);
+
+  if (expectedNodeMajor !== null && actualNodeMajor !== expectedNodeMajor) {
+    fail('NODE_VERSION_DRIFT', {
+      expected: expectedNode,
+      actual: process.version,
+      fix: `Use Node ${expectedNodeMajor}.x before running Santis OS.`
+    });
+  }
+
+  const pnpmVersion = getPnpmVersion();
+  const expectedPnpmMajor = parseMajor(expectedPnpm);
+  const actualPnpmMajor = pnpmVersion ? parseMajor(pnpmVersion) : null;
+
+  if (!pnpmVersion) {
+    fail('PNPM_UNAVAILABLE', {
+      expected: expectedPnpm,
+      actual: 'pnpm command not found',
+      fix: 'Run corepack enable, then retry.'
+    });
+  } else if (expectedPnpmMajor !== null && actualPnpmMajor !== expectedPnpmMajor) {
+    fail('PNPM_VERSION_DRIFT', {
+      expected: expectedPnpm,
+      actual: pnpmVersion,
+      fix: `Use pnpm ${expectedPnpmMajor}.x via Corepack.`
+    });
+  }
+
+  if (!packageManager.startsWith('pnpm@')) {
+    fail('PACKAGE_MANAGER_DRIFT', {
+      expected: 'packageManager must start with pnpm@',
+      actual: packageManager || '(missing)',
+      fix: 'Set packageManager to the pinned pnpm version.'
+    });
+  }
+}
+
+for (const lockfile of FOREIGN_LOCKFILES) {
+  const lockfilePath = path.join(ROOT_DIR, lockfile);
+  if (existsSync(lockfilePath)) {
+    fail('FOREIGN_LOCKFILE_DETECTED', {
+      path: lockfile,
+      expected: 'Only pnpm-lock.yaml is allowed.',
+      fix: `Remove ${lockfile} and regenerate dependencies with pnpm only.`
+    });
+  }
+}
+
+if (!existsSync(path.join(ROOT_DIR, 'pnpm-lock.yaml'))) {
+  fail('PNPM_LOCKFILE_MISSING', {
+    path: 'pnpm-lock.yaml',
+    expected: 'A committed pnpm lockfile is required for frozen installs.',
+    fix: 'Run pnpm install and commit pnpm-lock.yaml.'
+  });
+}
+
+if (process.exitCode) {
+  console.error('\n🚨 [Sovereign Guard] Environment audit failed.');
+  process.exit(process.exitCode);
+}
+
+console.log('✅ [Sovereign Guard] Environment aligned.');

--- a/scripts/active/audit-workspace-scripts.mjs
+++ b/scripts/active/audit-workspace-scripts.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+
+console.log('🛡️  [Sovereign Guard] Auditing workspace scripts...');
+
+const data = JSON.parse(execSync('pnpm list -r --json').toString());
+
+for (const pkg of data) {
+  const scripts = pkg.scripts || {};
+  for (const name of Object.keys(scripts)) {
+    const allowed = name.startsWith('santis:') || name.startsWith('audit:') || ['dev','build','start','test','lint','typecheck'].includes(name);
+    if (!allowed) {
+      console.error(`❌ Script violation in ${pkg.name}: ${name}`);
+      process.exit(1);
+    }
+  }
+}
+
+console.log('✅ Workspace script contract valid.');

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,10 @@
     "test:quality:runtime": {
       "dependsOn": ["^build"],
       "outputs": ["playwright-report/**", "test-results/**"]
+    },
+    "audit:contract": {
+      "cache": false,
+      "inputs": ["scripts/active/*.mjs", "package.json"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Seals the first physical Sovereign Guard layer for Santis OS.

This PR moves the repository from advisory discipline to enforced contract by adding environment/workspace audits and a mandatory CI guard.

## Changes

- Wires root `build` through `pnpm run audit:all`
- Adds `scripts/active/audit-environment.mjs`
- Adds `scripts/active/audit-workspace-scripts.mjs`
- Adds Turbo `audit:contract` task
- Adds `.github/workflows/sovereign-guard.yml`

## Enforcement

The guard hard-fails on:

- Node major version drift
- pnpm major version drift
- non-pnpm package manager declaration
- foreign lockfiles (`package-lock.json`, `npm-shrinkwrap.json`, `yarn.lock`)
- missing `pnpm-lock.yaml`
- workspace script contract violations

## Scope Boundary

This is separate from PR #38.

PR #38 = Public Interface / SEO Boundary.

This PR = Existence Layer / Engineering Hardening.

## Runtime Note

This PR seals build-time sovereignty only.

Runtime Guard should follow as Phase 2 in a separate PR covering API/SSE/CoreState integrity validation.

## Final Law

Santis OS is no longer merely runnable.

It is becoming impossible to run incorrectly.