### PR TITLE
chore(foundation): seal pnpm CI and workspace guard

### DIFF
--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -1,0 +1,45 @@
+name: "Santis OS — Sovereign CI/CD"
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  seal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout Sovereign Source"
+        uses: actions/checkout@v4
+
+      - name: "Initialize Node & Corepack"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: "Enable Corepack"
+        run: corepack enable
+
+      - name: "Resolve pnpm version"
+        run: corepack prepare pnpm@9.1.0 --activate
+
+      - name: "Sovereign Dependency Fetch"
+        run: pnpm fetch
+
+      - name: "Install Dependencies (Offline/Frozen)"
+        run: pnpm install --offline --frozen-lockfile
+
+      - name: "🧠 Boardroom Intelligence — Telemetry Bridge"
+        env:
+          SANTIS_TELEMETRY_KEY: ${{ secrets.SANTIS_TELEMETRY_KEY }}
+          SANTIS_API_URL: ${{ secrets.SANTIS_API_URL }}
+        run: node scripts/ci-telemetry-bridge.js
+
+      - name: "🛡️ Execute Sovereign Guards"
+        run: pnpm run audit:all
+
+      - name: "Build Sovereign Artifacts"
+        run: pnpm run build


### PR DESCRIPTION
## Summary

This PR starts the Foundation/CI-Guard extraction from PR #76.

It currently adds the pnpm-native Sovereign CI workflow as the first isolated infrastructure slice.

## Included in this PR

- `.github/workflows/sovereign-ci.yml`
- Node 20 setup
- Corepack enablement
- pnpm 9.1.0 activation
- `pnpm fetch`
- `pnpm install --offline --frozen-lockfile`
- non-blocking CI telemetry bridge step
- `pnpm run audit:all`
- `pnpm run build`

## Intentionally excluded from this first remote commit

The remaining Foundation files should be added from a local terminal extraction to avoid GitHub contents API SHA drift and preserve deterministic monorepo state:

- `Dockerfile.frontend`
- `package.json`
- `scripts/active/audit-environment.js`
- `scripts/active/audit-workspace-scripts.js`
- `scripts/ci-telemetry-bridge.js`

Also intentionally excluded:

- `scripts/production-signature-guard.js`
- tenant contracts
- technical-debt API
- Boardroom UI
- override token flow
- intent/pricing kernel

## Required local completion before merge

```bash
git fetch origin
git checkout foundation/ci-guard
git checkout origin/chore/architectural-sovereignty-seal -- \
  Dockerfile.frontend \
  package.json \
  scripts/active/audit-environment.js \
  scripts/active/audit-workspace-scripts.js \
  scripts/ci-telemetry-bridge.js

pnpm install --frozen-lockfile
pnpm run audit:all
pnpm run build

git add .
git commit -m "chore(foundation): complete pnpm workspace guard extraction"
git push
```

## Governance

This PR must remain infrastructure-only. No domain schema, tenant isolation, Boardroom UI, pricing, runtime API, or production override logic should enter this branch.