### PR TITLE
feat: Phase 84 — Live Oracle Stream

### DIFF
--- a/admin-panel/src/features/boardroom/hooks/useLiveOracle.ts
+++ b/admin-panel/src/features/boardroom/hooks/useLiveOracle.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 84 — Live Oracle Stream
+ *
+ * useLiveOracle.ts
+ *
+ * SSE oracle_delta event'ini dinleyen React hook.
+ * Bağlı CognitiveOverlay'leri gerçek zamanlı olarak günceller.
+ *
+ * Temporal Isolation Garantisi:
+ * HISTORICAL modda SSE patch'leri tamponlanır, uygulanmaz.
+ * Sadece LIVE modda gerçek zamanlı güncelleme aktif olur.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import type { CognitiveDecisionEnvelope } from "../types/boardroom.types";
+import { useBoardroomMode } from "../context/BoardroomModeContext";
+
+const SSE_BASE =
+  (import.meta as unknown as { env: Record<string, string | undefined> }).env
+    .VITE_INGESTION_API_BASE_URL ?? "http://localhost:3030/api/v1";
+
+interface OracleDeltaPatch {
+  actionId: string;
+  envelope: CognitiveDecisionEnvelope;
+}
+
+interface OracleDeltaEvent {
+  event: "oracle_delta";
+  data: {
+    seq: number;
+    ts: number;
+    scope: "oracle_delta";
+    patch: OracleDeltaPatch;
+  };
+}
+
+interface UseLiveOracleResult {
+  /** En son gelen Oracle delta patch */
+  latestDelta: OracleDeltaPatch | null;
+  /** SSE bağlantı durumu */
+  connectionStatus: "connecting" | "connected" | "error" | "offline";
+  /** Kaç delta alındı */
+  deltaCount: number;
+}
+
+export function useLiveOracle(watchActionId?: string): UseLiveOracleResult {
+  const { mode } = useBoardroomMode();
+  const [latestDelta, setLatestDelta] = useState<OracleDeltaPatch | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<UseLiveOracleResult["connectionStatus"]>("offline");
+  const [deltaCount, setDeltaCount] = useState(0);
+
+  // HISTORICAL modda gelen delta'ları tamponla, uygulama
+  const pendingBuffer = useRef<OracleDeltaPatch[]>([]);
+  const esRef = useRef<EventSource | null>(null);
+
+  const handleDelta = useCallback(
+    (patch: OracleDeltaPatch) => {
+      // Temporal Isolation: HISTORICAL modda UI'ı güncelleme
+      if (mode === "HISTORICAL") {
+        pendingBuffer.current.push(patch);
+        return;
+      }
+
+      // Belirli bir actionId izleniyorsa filtrele
+      if (watchActionId && patch.actionId !== watchActionId) return;
+
+      setLatestDelta(patch);
+      setDeltaCount((n) => n + 1);
+    },
+    [mode, watchActionId]
+  );
+
+  // LIVE moda döndüğünde buffer'ı uygula
+  useEffect(() => {
+    if (mode === "LIVE" && pendingBuffer.current.length > 0) {
+      const last = pendingBuffer.current[pendingBuffer.current.length - 1];
+      setLatestDelta(last);
+      setDeltaCount((n) => n + pendingBuffer.current.length);
+      pendingBuffer.current = [];
+    }
+  }, [mode]);
+
+  // SSE bağlantısı
+  useEffect(() => {
+    const url = `${SSE_BASE}/streams/oracle`;
+    setConnectionStatus("connecting");
+
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    es.addEventListener("oracle_delta", (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data) as OracleDeltaEvent;
+        handleDelta(parsed.data.patch);
+      } catch {
+        // Malformed delta — sessizce geç
+      }
+    });
+
+    es.addEventListener("heartbeat", () => {
+      setConnectionStatus("connected");
+    });
+
+    es.onopen = () => setConnectionStatus("connected");
+
+    es.onerror = () => {
+      setConnectionStatus("error");
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+      setConnectionStatus("offline");
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { latestDelta, connectionStatus, deltaCount };
+}

--- a/apps/ingestion-api/src/index.ts
+++ b/apps/ingestion-api/src/index.ts
@@ -30,7 +30,10 @@ import { authRouter } from "./routes/auth.routes";
 import { verifySessionToken, type SessionTokenPayload } from "./security/crypto-token";
 
 import { boardroomRouter } from "./routes/boardroom";
+import { cognitiveBoardroomRouter } from "./routes/boardroom-cognitive-analysis.js"; // Phase 83
+import { oracleStreamRouter } from "./routes/oracle-stream.js"; // Phase 84
 import { oracleActionMemoryRouter } from "./oracle/oracle-action-memory.routes";
+
 import { oracleNodeSyncRouter } from "./oracle/oracle-node-sync.routes";
 import { oracleGlobalAggregationRouter } from "./oracle/oracle-global-aggregation.routes";
 import { oracleCrossNodeLearningRouter } from "./oracle/oracle-cross-node-learning.routes";
@@ -301,7 +304,10 @@ async function bootstrap() {
   // --- Otoriter Gümrük Kapısı (COMMAND ROTASI) ---
   app.use("/api/v1", createIngressRouter(bus, commandIngress));
   app.use("/api/v1/boardroom", boardroomRouter);
+  app.use("/api/v1/boardroom", cognitiveBoardroomRouter); // Phase 83: Oracle Feed
+  app.use("/api/v1/streams", oracleStreamRouter);         // Phase 84: Live Oracle Stream
   app.use("/api/v1/oracle", oracleActionMemoryRouter);
+
   app.use("/api/v1/oracle", oracleNodeSyncRouter);
   app.use("/api/v1/oracle", oracleGlobalAggregationRouter);
   app.use("/api/v1/oracle", oracleCrossNodeLearningRouter);

--- a/apps/ingestion-api/src/oracle/oracle-delta.broadcaster.ts
+++ b/apps/ingestion-api/src/oracle/oracle-delta.broadcaster.ts
@@ -1,0 +1,77 @@
+/**
+ * Phase 84 — Live Oracle Stream
+ *
+ * oracle-delta.broadcaster.ts
+ *
+ * Boardroom kararı alındığında CognitiveDecisionEnvelope'u
+ * SSE üzerinden tüm bağlı Boardroom operatörlerine iletir.
+ *
+ * Akış: Governor Decision → deriveCognitiveEnvelope() → broadcastOracleDelta()
+ */
+
+import { sseManager } from "../services/sse-manager.js";
+import { deriveCognitiveEnvelope } from "./oracle-cognitive-decision.engine.js";
+
+interface AuditEntryMinimal {
+  id: string;
+  actionId?: string;
+  type: string;
+  occurredAt: string;
+  reason?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface SnapshotMinimal {
+  snapshotId?: string;
+  timestamp: string;
+  revenue?: number;
+  activeSessionsCount?: number;
+  confidence?: number;
+  reasoning?: string;
+  resolutionType?: string;
+  resolvedActionId?: string;
+}
+
+/**
+ * broadcastOracleDelta — Yeni bir Boardroom kararı oluştuğunda çağrılır.
+ *
+ * Bu fonksiyon:
+ * 1. CognitiveDecisionEnvelope türetir
+ * 2. SSE üzerinden `oracle_delta` event'i yayınlar
+ * 3. Tüm bağlı CognitiveOverlay instance'larını gerçek zamanlı günceller
+ *
+ * @param audit - Yeni oluşan audit log kaydı
+ * @param snapshot - Kararın alındığı andaki snapshot
+ * @param previousSnapshot - Delta hesabı için önceki snapshot
+ */
+export function broadcastOracleDelta(
+  audit: AuditEntryMinimal,
+  snapshot: SnapshotMinimal,
+  previousSnapshot?: SnapshotMinimal
+): void {
+  try {
+    const envelope = deriveCognitiveEnvelope(
+      audit as Parameters<typeof deriveCognitiveEnvelope>[0],
+      snapshot as Parameters<typeof deriveCognitiveEnvelope>[1],
+      previousSnapshot as Parameters<typeof deriveCognitiveEnvelope>[2]
+    );
+
+    sseManager.broadcastPatch(
+      "oracle_delta",
+      {
+        actionId: audit.actionId ?? audit.id,
+        envelope,
+      },
+      "oracle_delta"
+    );
+
+    console.log(
+      `[Oracle Delta] Broadcast: actionId=${audit.actionId ?? audit.id} ` +
+      `confidence=${Math.round((envelope.confidence) * 100)}% ` +
+      `significance=${envelope.significance.level}`
+    );
+  } catch (err) {
+    // Oracle broadcast hatası asla ana akışı kesmemeli
+    console.error("[Oracle Delta] Broadcast failed (non-fatal):", err);
+  }
+}

--- a/apps/ingestion-api/src/routes/oracle-stream.ts
+++ b/apps/ingestion-api/src/routes/oracle-stream.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 84 — Live Oracle Stream
+ *
+ * Route: GET /api/v1/streams/oracle
+ *
+ * Tüm bağlı Boardroom operatörlerine gerçek zamanlı oracle_delta
+ * event'leri iletir. SseManager'ın oracle_delta scope'unu kullanır.
+ */
+
+import { Router, Request, Response } from "express";
+import { sseManager } from "../services/sse-manager.js";
+
+export const oracleStreamRouter: import("express").Router = Router();
+
+/**
+ * GET /api/v1/streams/oracle
+ *
+ * SSE bağlantısı kurar ve oracle_delta event'lerini dinler.
+ * Frontend `useLiveOracle()` hook bu endpoint'e bağlanır.
+ */
+oracleStreamRouter.get("/oracle", (req: Request, res: Response) => {
+  console.log("📡 [Oracle Stream] Yeni operatör bağlandı.");
+
+  // SseManager'ın addClient() tüm SSE header'larını yönetiyor
+  sseManager.addClient(req, res);
+
+  // İlk bağlantıda anlık durum bilgisi
+  res.write(
+    `event: oracle_ready\ndata: ${JSON.stringify({
+      status: "ORACLE_ONLINE",
+      timestamp: new Date().toISOString(),
+      message: "Boardroom Oracle Feed active. Awaiting governor decisions.",
+    })}\n\n`
+  );
+});

--- a/apps/ingestion-api/src/services/sse-manager.ts
+++ b/apps/ingestion-api/src/services/sse-manager.ts
@@ -59,9 +59,9 @@ export class SseManager {
    * Follows the Santis SSE Core Law (seq, ts, scope, patch).
    */
   broadcastPatch(
-    scope: "strategy" | "revenue" | "core_state" | "command" | "action_rail", 
+    scope: "strategy" | "revenue" | "core_state" | "command" | "action_rail" | "oracle_delta", 
     patch: Record<string, unknown>,
-    event: "strategy_update" | "command_ack" | "action_rail_update" = "strategy_update"
+    event: "strategy_update" | "command_ack" | "action_rail_update" | "oracle_delta" = "strategy_update"
   ) {
     const seq = ++this.sequence;
     

--- a/packages/domain-schema/src/sse-envelope.contract.ts
+++ b/packages/domain-schema/src/sse-envelope.contract.ts
@@ -6,11 +6,11 @@ import { z } from "zod";
  * a timestamp (ts), a scope for selective UI updates, and the patch payload.
  */
 export const SsePatchEnvelopeSchema = z.object({
-  event: z.enum(["strategy_update", "command_ack", "action_rail_update"]),
+  event: z.enum(["strategy_update", "command_ack", "action_rail_update", "oracle_delta"]),
   data: z.object({
     seq: z.number(),
     ts: z.number(),
-    scope: z.enum(["strategy", "revenue", "core_state", "command", "action_rail"]),
+    scope: z.enum(["strategy", "revenue", "core_state", "command", "action_rail", "oracle_delta"]),
     patch: z.record(z.any())
   })
 });


### PR DESCRIPTION
## Phase 84 — Live Oracle Stream

Adds real-time Oracle delta hydration over SSE for the Boardroom Cognitive Overlay.

### Scope
- Extends SSE envelope contract with `oracle_delta`.
- Adds `broadcastOracleDelta()` for backend decision → SSE publication.
- Adds `GET /api/v1/streams/oracle` stream route.
- Mounts Oracle stream route in the ingestion API.
- Adds frontend `useLiveOracle()` hook for live CognitiveOverlay updates with Temporal Isolation.

### Live flow
```text
Governor Decision
  ↓ broadcastOracleDelta()
  ↓ SseManager.broadcastPatch("oracle_delta")
  ↓ GET /api/v1/streams/oracle
  ↓ useLiveOracle()
  ↓ CognitiveOverlay real-time update
```

### Verification
```bash
pnpm --filter @santis/ingestion-api build
pnpm --filter admin-panel build
```

Local results reported green:
```text
@santis/ingestion-api: dist/index.cjs 3.1mb, Done in 321ms
admin-panel: ✓ 2397 modules transformed, ✓ built in 3.54s
```

### Performance note
Manual chunking is active. Current split includes:
- `oracle-*.js` ≈ 12.62 kB
- `index-*.js` ≈ 167.73 kB
- `vendor-react-*.js` ≈ 237.82 kB
- `vendor-3d-calendar-*.js` ≈ 780.29 kB

The remaining warning is isolated to the 3D/calendar vendor chunk and no longer blocks the shell/oracle path.