### PR TITLE
feat: Phase 84.1 — Replay-Safe Temporal Oracle

### DIFF
--- a/admin-panel/src/features/boardroom/components/oracle/OracleTimelinePanel.tsx
+++ b/admin-panel/src/features/boardroom/components/oracle/OracleTimelinePanel.tsx
@@ -1,0 +1,217 @@
+import { useLiveOracle, useOracleTimeline } from "../hooks";
+import type { OracleDeltaPatch } from "../hooks/useLiveOracle";
+
+// ── Connection Status Badge ───────────────────────────────────────────────────
+const STATUS_CONFIG = {
+  connected: { color: "#7fffd4", label: "LIVE", pulse: true },
+  connecting: { color: "#f0c040", label: "CONNECTING", pulse: true },
+  gap_detected: { color: "#e8964a", label: "GAP", pulse: false },
+  error: { color: "#e05c5c", label: "ERROR", pulse: false },
+  offline: { color: "rgba(255,255,255,0.3)", label: "OFFLINE", pulse: false },
+} as const;
+
+// ── Confidence Sparkline ──────────────────────────────────────────────────────
+function ConfidenceSparkline({ patches }: { patches: OracleDeltaPatch[] }) {
+  if (patches.length < 2) return null;
+
+  const width = 200;
+  const height = 36;
+  const values = patches.map((p) => p.envelope.confidence);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 0.01;
+
+  const points = values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * width;
+      const y = height - ((v - min) / range) * (height - 4) - 2;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  const lastConf = values[values.length - 1];
+  const trend = values.length > 1 ? lastConf - values[values.length - 2] : 0;
+  const trendColor = trend >= 0 ? "#d4af37" : "#e05c5c";
+
+  return (
+    <div className="nv-oracle-sparkline">
+      <span className="nv-oracle-sparkline__label">CONFIDENCE TREND</span>
+      <svg width={width} height={height} className="nv-oracle-sparkline__svg">
+        <polyline
+          points={points}
+          fill="none"
+          stroke={trendColor}
+          strokeWidth="1.5"
+          strokeLinejoin="round"
+        />
+        {/* Last point dot */}
+        <circle
+          cx={(width)}
+          cy={height - ((lastConf - min) / range) * (height - 4) - 2}
+          r="3"
+          fill={trendColor}
+        />
+      </svg>
+      <span className="nv-oracle-sparkline__value" style={{ color: trendColor }}>
+        {trend >= 0 ? "▲" : "▼"} {Math.round(lastConf * 100)}%
+      </span>
+    </div>
+  );
+}
+
+// ── Timeline Scrubber ─────────────────────────────────────────────────────────
+interface TimelineScrubberProps {
+  firstSeq: number | null;
+  lastSeq: number | null;
+  scrubPosition: number | null;
+  isScrubbing: boolean;
+  onScrubToSeq: (seq: number) => void;
+  onExit: () => void;
+  onStepBack: () => void;
+  onStepForward: () => void;
+}
+
+function TimelineScrubber({
+  firstSeq, lastSeq, scrubPosition, isScrubbing,
+  onScrubToSeq, onExit, onStepBack, onStepForward,
+}: TimelineScrubberProps) {
+  if (firstSeq === null || lastSeq === null || firstSeq === lastSeq) return null;
+
+  const position = scrubPosition ?? lastSeq;
+  const pct = ((position - firstSeq) / (lastSeq - firstSeq)) * 100;
+
+  return (
+    <div className={`nv-oracle-scrubber ${isScrubbing ? "nv-oracle-scrubber--active" : ""}`}>
+      <div className="nv-oracle-scrubber__controls">
+        <button className="nv-oracle-scrubber__btn" onClick={onStepBack} title="Step back">‹</button>
+
+        <div className="nv-oracle-scrubber__track">
+          <div className="nv-oracle-scrubber__fill" style={{ width: `${pct}%` }} />
+          <input
+            type="range"
+            min={firstSeq}
+            max={lastSeq}
+            value={position}
+            onChange={(e) => onScrubToSeq(Number(e.target.value))}
+            className="nv-oracle-scrubber__range"
+          />
+        </div>
+
+        <button className="nv-oracle-scrubber__btn" onClick={onStepForward} title="Step forward">›</button>
+
+        {isScrubbing && (
+          <button className="nv-oracle-scrubber__live-btn" onClick={onExit}>
+            ● LIVE
+          </button>
+        )}
+      </div>
+
+      <div className="nv-oracle-scrubber__meta">
+        <span>seq {position}</span>
+        {isScrubbing && <span className="nv-oracle-scrubber__frozen">⏸ SCRUBBING</span>}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────────────────────────
+export function OracleTimelinePanel() {
+  const { latestDelta, connectionStatus, deltaCount, droppedCount, sequenceLog, lastSeq } =
+    useLiveOracle();
+
+  const {
+    viewedPatch, isScrubbing, scrubPosition, firstSeq, lastSeq: timelineLastSeq,
+    scrubToSeq, exitScrub, stepBack, stepForward,
+  } = useOracleTimeline(sequenceLog, latestDelta);
+
+  const statusCfg = STATUS_CONFIG[connectionStatus] ?? STATUS_CONFIG.offline;
+
+  return (
+    <div className="nv-oracle-timeline-panel">
+      {/* ── Header ──────────────────────────────────────── */}
+      <div className="nv-oracle-timeline-panel__header">
+        <div className="nv-oracle-timeline-panel__title">
+          <span className="nv-kicker">Phase 84.1 · Replay-Safe Oracle</span>
+          <h4>Oracle Timeline</h4>
+        </div>
+
+        <div className="nv-oracle-status">
+          <div
+            className={`nv-oracle-status__dot ${statusCfg.pulse ? "nv-pulse" : ""}`}
+            style={{ background: statusCfg.color }}
+          />
+          <span style={{ color: statusCfg.color }}>{statusCfg.label}</span>
+        </div>
+      </div>
+
+      {/* ── Stats Row ──────────────────────────────────── */}
+      <div className="nv-oracle-timeline-panel__stats">
+        <div className="nv-oracle-stat">
+          <span className="nv-oracle-stat__label">Deltas</span>
+          <span className="nv-oracle-stat__value">{deltaCount}</span>
+        </div>
+        <div className="nv-oracle-stat">
+          <span className="nv-oracle-stat__label">Dropped</span>
+          <span className="nv-oracle-stat__value" style={{ color: droppedCount > 0 ? "#e05c5c" : undefined }}>
+            {droppedCount}
+          </span>
+        </div>
+        <div className="nv-oracle-stat">
+          <span className="nv-oracle-stat__label">Last Seq</span>
+          <span className="nv-oracle-stat__value">{lastSeq}</span>
+        </div>
+        <div className="nv-oracle-stat">
+          <span className="nv-oracle-stat__label">Buffer</span>
+          <span className="nv-oracle-stat__value">{sequenceLog.length}</span>
+        </div>
+      </div>
+
+      {/* ── Confidence Sparkline ────────────────────────── */}
+      {sequenceLog.length > 1 && (
+        <ConfidenceSparkline patches={sequenceLog} />
+      )}
+
+      {/* ── Timeline Scrubber ────────────────────────────── */}
+      <TimelineScrubber
+        firstSeq={firstSeq}
+        lastSeq={timelineLastSeq}
+        scrubPosition={scrubPosition}
+        isScrubbing={isScrubbing}
+        onScrubToSeq={scrubToSeq}
+        onExit={exitScrub}
+        onStepBack={stepBack}
+        onStepForward={stepForward}
+      />
+
+      {/* ── Viewed Patch Summary ─────────────────────────── */}
+      {viewedPatch && (
+        <div className="nv-oracle-patch-card">
+          <div className="nv-oracle-patch-card__header">
+            <span className="nv-oracle-patch-card__label">
+              {isScrubbing ? `⏸ Seq ${viewedPatch.seq}` : "● Live"}
+            </span>
+            <span className="nv-oracle-patch-card__id">
+              {viewedPatch.actionId.slice(0, 10)}…
+            </span>
+          </div>
+          <div className="nv-oracle-patch-card__confidence">
+            <span>Confidence</span>
+            <strong style={{ color: "#d4af37" }}>
+              {Math.round(viewedPatch.envelope.confidence * 100)}%
+            </strong>
+          </div>
+          <p className="nv-oracle-patch-card__narrative">
+            {viewedPatch.envelope.significance.narrative.slice(0, 120)}…
+          </p>
+        </div>
+      )}
+
+      {sequenceLog.length === 0 && (
+        <div className="nv-oracle-timeline-panel__empty">
+          <div className="nv-spinner-pulse" />
+          <p>Awaiting first Oracle delta…</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-panel/src/features/boardroom/hooks/index.ts
+++ b/admin-panel/src/features/boardroom/hooks/index.ts
@@ -1,0 +1,3 @@
+export { useLiveOracle } from "./useLiveOracle";
+export { useOracleTimeline } from "./useOracleTimeline";
+export { useBoardroomChronos } from "./useBoardroomChronos";

--- a/admin-panel/src/features/boardroom/hooks/useLiveOracle.ts
+++ b/admin-panel/src/features/boardroom/hooks/useLiveOracle.ts
@@ -1,14 +1,15 @@
 /**
- * Phase 84 — Live Oracle Stream
+ * Phase 84.1 — Replay-Safe Temporal Oracle
  *
- * useLiveOracle.ts
+ * useLiveOracle.ts (v2)
  *
- * SSE oracle_delta event'ini dinleyen React hook.
- * Bağlı CognitiveOverlay'leri gerçek zamanlı olarak günceller.
+ * Phase 84'ten farklar:
+ * 1. seq monotonicity enforcement — stale/duplicate patch'ler drop edilir
+ * 2. LIVE ↔ HISTORICAL reconciliation — mode geçişinde buffer doğru uygulanır
+ * 3. Oracle sequence log — son N delta korunur (timeline scrubbing için)
+ * 4. Gap detection — seq atlama tespiti
  *
- * Temporal Isolation Garantisi:
- * HISTORICAL modda SSE patch'leri tamponlanır, uygulanmaz.
- * Sadece LIVE modda gerçek zamanlı güncelleme aktif olur.
+ * Prensip: "Temporal Oracle asla geri gitmez."
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
@@ -19,100 +20,191 @@ const SSE_BASE =
   (import.meta as unknown as { env: Record<string, string | undefined> }).env
     .VITE_INGESTION_API_BASE_URL ?? "http://localhost:3030/api/v1";
 
-interface OracleDeltaPatch {
+// Sequence log'da tutulacak maksimum delta sayısı
+const MAX_SEQUENCE_LOG = 50;
+
+export interface OracleDeltaPatch {
   actionId: string;
   envelope: CognitiveDecisionEnvelope;
+  seq: number;
+  ts: number;
 }
 
-interface OracleDeltaEvent {
+interface RawOracleDeltaPayload {
   event: "oracle_delta";
   data: {
     seq: number;
     ts: number;
     scope: "oracle_delta";
-    patch: OracleDeltaPatch;
+    patch: {
+      actionId: string;
+      envelope: CognitiveDecisionEnvelope;
+    };
   };
 }
 
-interface UseLiveOracleResult {
-  /** En son gelen Oracle delta patch */
+export type OracleConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "error"
+  | "offline"
+  | "gap_detected";
+
+export interface UseLiveOracleResult {
+  /** En son geçerli Oracle delta patch */
   latestDelta: OracleDeltaPatch | null;
   /** SSE bağlantı durumu */
-  connectionStatus: "connecting" | "connected" | "error" | "offline";
-  /** Kaç delta alındı */
+  connectionStatus: OracleConnectionStatus;
+  /** Alınan toplam delta sayısı (dropped dahil değil) */
   deltaCount: number;
+  /** Drop edilen stale/duplicate patch sayısı */
+  droppedCount: number;
+  /** Son N delta — timeline scrubbing için */
+  sequenceLog: OracleDeltaPatch[];
+  /** En son doğrulanan seq numarası */
+  lastSeq: number;
 }
 
 export function useLiveOracle(watchActionId?: string): UseLiveOracleResult {
   const { mode } = useBoardroomMode();
+
   const [latestDelta, setLatestDelta] = useState<OracleDeltaPatch | null>(null);
-  const [connectionStatus, setConnectionStatus] = useState<UseLiveOracleResult["connectionStatus"]>("offline");
+  const [connectionStatus, setConnectionStatus] = useState<OracleConnectionStatus>("offline");
   const [deltaCount, setDeltaCount] = useState(0);
+  const [droppedCount, setDroppedCount] = useState(0);
+  const [sequenceLog, setSequenceLog] = useState<OracleDeltaPatch[]>([]);
 
-  // HISTORICAL modda gelen delta'ları tamponla, uygulama
+  // ── Monotonicity state (mutable ref, re-render tetiklemez) ──
+  const lastSeqRef = useRef<number>(0);
+  const lastTsRef = useRef<number>(0);
+
+  // ── HISTORICAL mod tamponu ──
   const pendingBuffer = useRef<OracleDeltaPatch[]>([]);
-  const esRef = useRef<EventSource | null>(null);
 
-  const handleDelta = useCallback(
+  // ── Sequence log (mutable, setSequenceLog ile sync edilir) ──
+  const logRef = useRef<OracleDeltaPatch[]>([]);
+
+  const appendToLog = (patch: OracleDeltaPatch) => {
+    logRef.current = [...logRef.current, patch].slice(-MAX_SEQUENCE_LOG);
+    setSequenceLog([...logRef.current]);
+  };
+
+  const applyPatch = useCallback(
     (patch: OracleDeltaPatch) => {
-      // Temporal Isolation: HISTORICAL modda UI'ı güncelleme
-      if (mode === "HISTORICAL") {
-        pendingBuffer.current.push(patch);
+      // ── Monotonicity Gate: stale veya duplicate drop ──────────
+      if (patch.seq <= lastSeqRef.current) {
+        setDroppedCount((n) => n + 1);
+        console.debug(
+          `[OracleRail] DROP — stale seq=${patch.seq} (last=${lastSeqRef.current})`
+        );
         return;
       }
 
-      // Belirli bir actionId izleniyorsa filtrele
-      if (watchActionId && patch.actionId !== watchActionId) return;
+      // ── Gap Detection ─────────────────────────────────────────
+      if (patch.seq > lastSeqRef.current + 1 && lastSeqRef.current > 0) {
+        const gap = patch.seq - lastSeqRef.current - 1;
+        console.warn(
+          `[OracleRail] GAP DETECTED — missed ${gap} seq(s) between ` +
+          `${lastSeqRef.current} → ${patch.seq}`
+        );
+        setConnectionStatus("gap_detected");
+        // Gap tespiti akışı kesmez — devam edilir
+      }
 
+      // ── actionId filtresi ─────────────────────────────────────
+      if (watchActionId && patch.actionId !== watchActionId) {
+        // Takip edilmeyen actionId — seq güncelle ama UI'ı tetikleme
+        lastSeqRef.current = patch.seq;
+        lastTsRef.current = patch.ts;
+        return;
+      }
+
+      // ── State güncelle ────────────────────────────────────────
+      lastSeqRef.current = patch.seq;
+      lastTsRef.current = patch.ts;
       setLatestDelta(patch);
       setDeltaCount((n) => n + 1);
+      appendToLog(patch);
+
+      if (connectionStatus !== "connected") {
+        setConnectionStatus("connected");
+      }
     },
-    [mode, watchActionId]
+    [watchActionId, connectionStatus]
   );
 
-  // LIVE moda döndüğünde buffer'ı uygula
+  const handleIncoming = useCallback(
+    (patch: OracleDeltaPatch) => {
+      if (mode === "HISTORICAL") {
+        // Temporal Isolation: buffer'la, uygulama
+        pendingBuffer.current.push(patch);
+        return;
+      }
+      applyPatch(patch);
+    },
+    [mode, applyPatch]
+  );
+
+  // ── LIVE moduna dönüşte: buffer'daki son geçerli patch'i uygula ──
   useEffect(() => {
     if (mode === "LIVE" && pendingBuffer.current.length > 0) {
-      const last = pendingBuffer.current[pendingBuffer.current.length - 1];
-      setLatestDelta(last);
-      setDeltaCount((n) => n + pendingBuffer.current.length);
+      // Sadece son patch'i uygula (optimistic reconciliation)
+      // Ara patch'ler seq log'una eklenirken son durum UI'ya yansır
+      const buffered = [...pendingBuffer.current].sort((a, b) => a.seq - b.seq);
       pendingBuffer.current = [];
-    }
-  }, [mode]);
 
-  // SSE bağlantısı
+      // Tüm buffer'ı sıralı uygula
+      buffered.forEach(applyPatch);
+    }
+  }, [mode, applyPatch]);
+
+  // ── SSE bağlantısı ──────────────────────────────────────────────
   useEffect(() => {
     const url = `${SSE_BASE}/streams/oracle`;
     setConnectionStatus("connecting");
 
     const es = new EventSource(url);
-    esRef.current = es;
 
     es.addEventListener("oracle_delta", (e: MessageEvent) => {
       try {
-        const parsed = JSON.parse(e.data) as OracleDeltaEvent;
-        handleDelta(parsed.data.patch);
+        const raw = JSON.parse(e.data) as RawOracleDeltaPayload;
+        const patch: OracleDeltaPatch = {
+          actionId: raw.data.patch.actionId,
+          envelope: raw.data.patch.envelope,
+          seq: raw.data.seq,
+          ts: raw.data.ts,
+        };
+        handleIncoming(patch);
       } catch {
-        // Malformed delta — sessizce geç
+        // Malformed payload — sessizce geç
       }
     });
 
-    es.addEventListener("heartbeat", () => {
+    es.addEventListener("oracle_ready", () => {
       setConnectionStatus("connected");
     });
 
-    es.onopen = () => setConnectionStatus("connected");
+    es.addEventListener("heartbeat", () => {
+      if (connectionStatus !== "gap_detected") {
+        setConnectionStatus("connected");
+      }
+    });
 
-    es.onerror = () => {
-      setConnectionStatus("error");
-    };
+    es.onopen = () => setConnectionStatus("connected");
+    es.onerror = () => setConnectionStatus("error");
 
     return () => {
       es.close();
-      esRef.current = null;
       setConnectionStatus("offline");
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return { latestDelta, connectionStatus, deltaCount };
+  return {
+    latestDelta,
+    connectionStatus,
+    deltaCount,
+    droppedCount,
+    sequenceLog,
+    lastSeq: lastSeqRef.current,
+  };
 }

--- a/admin-panel/src/features/boardroom/hooks/useOracleTimeline.ts
+++ b/admin-panel/src/features/boardroom/hooks/useOracleTimeline.ts
@@ -1,0 +1,118 @@
+/**
+ * Phase 84.1 — Replay-Safe Temporal Oracle
+ *
+ * useOracleTimeline.ts
+ *
+ * Oracle sequence log üzerinde timeline scrubbing API'si.
+ *
+ * Scrubbing: Belirli bir seq veya timestamp'a "geri sarma" yapar.
+ * Replay-safe: HISTORICAL mod ile entegre — scrub ederken live patch gelmez.
+ *
+ * Prensip: "Timeline sadece geri sarar, geriye dönemez."
+ * (seq monotonicity korunur, scrubbing sadece görsel — state asla mutate edilmez)
+ */
+
+import { useState, useCallback, useMemo } from "react";
+import type { OracleDeltaPatch } from "./useLiveOracle";
+
+export interface OracleTimelineResult {
+  /** Aktif görüntülenen patch (scrub pozisyonu veya latestDelta) */
+  viewedPatch: OracleDeltaPatch | null;
+  /** Şu an scrubbing modunda mı? */
+  isScrubbing: boolean;
+  /** Scrub pozisyonu (seq numarası, null = live head) */
+  scrubPosition: number | null;
+  /** Timeline'daki ilk seq */
+  firstSeq: number | null;
+  /** Timeline'daki son seq */
+  lastSeq: number | null;
+  /** Scrub: belirli bir seq'e git */
+  scrubToSeq: (seq: number) => void;
+  /** Scrub: belirli bir ts'e en yakın patch'e git */
+  scrubToTimestamp: (ts: number) => void;
+  /** Scrub'ı bırak → live head'e dön */
+  exitScrub: () => void;
+  /** Bir önceki delta'ya git */
+  stepBack: () => void;
+  /** Bir sonraki delta'ya git */
+  stepForward: () => void;
+}
+
+export function useOracleTimeline(
+  sequenceLog: OracleDeltaPatch[],
+  latestDelta: OracleDeltaPatch | null
+): OracleTimelineResult {
+  const [scrubPosition, setScrubPosition] = useState<number | null>(null);
+  const isScrubbing = scrubPosition !== null;
+
+  // Seq'e göre sıralı log (defansif)
+  const sortedLog = useMemo(
+    () => [...sequenceLog].sort((a, b) => a.seq - b.seq),
+    [sequenceLog]
+  );
+
+  const firstSeq = sortedLog[0]?.seq ?? null;
+  const lastSeq = sortedLog[sortedLog.length - 1]?.seq ?? null;
+
+  // Aktif görüntülenen patch
+  const viewedPatch = useMemo<OracleDeltaPatch | null>(() => {
+    if (!isScrubbing) return latestDelta;
+    return sortedLog.find((p) => p.seq === scrubPosition) ?? null;
+  }, [isScrubbing, scrubPosition, sortedLog, latestDelta]);
+
+  const scrubToSeq = useCallback((seq: number) => {
+    setScrubPosition(seq);
+  }, []);
+
+  const scrubToTimestamp = useCallback(
+    (ts: number) => {
+      // En yakın (≤ ts) patch'i bul
+      const closest = [...sortedLog]
+        .reverse()
+        .find((p) => p.ts <= ts);
+      if (closest) setScrubPosition(closest.seq);
+    },
+    [sortedLog]
+  );
+
+  const exitScrub = useCallback(() => {
+    setScrubPosition(null);
+  }, []);
+
+  const stepBack = useCallback(() => {
+    if (sortedLog.length === 0) return;
+
+    const currentSeq = scrubPosition ?? (lastSeq ?? 0);
+    const idx = sortedLog.findIndex((p) => p.seq === currentSeq);
+    if (idx > 0) {
+      setScrubPosition(sortedLog[idx - 1].seq);
+    }
+  }, [scrubPosition, sortedLog, lastSeq]);
+
+  const stepForward = useCallback(() => {
+    if (sortedLog.length === 0) return;
+
+    if (!isScrubbing) return; // Live head'deyiz, ileri gidemeyiz
+
+    const idx = sortedLog.findIndex((p) => p.seq === scrubPosition);
+    if (idx >= 0 && idx < sortedLog.length - 1) {
+      setScrubPosition(sortedLog[idx + 1].seq);
+    } else if (idx === sortedLog.length - 1) {
+      // Log sonuna geldik → live head'e dön
+      setScrubPosition(null);
+    }
+  }, [isScrubbing, scrubPosition, sortedLog]);
+
+  return {
+    viewedPatch,
+    isScrubbing,
+    scrubPosition,
+    firstSeq,
+    lastSeq,
+    scrubToSeq,
+    scrubToTimestamp,
+    exitScrub,
+    stepBack,
+    stepForward,
+  };
+}

--- a/admin-panel/src/styles/boardroom-chronos.css
+++ b/admin-panel/src/styles/boardroom-chronos.css
@@ -682,4 +682,263 @@
   font-family: monospace;
 }
 
+/* ═══════════════════════════════════════════════════════════
+   PHASE 84.1 — ORACLE TIMELINE PANEL
+   ═══════════════════════════════════════════════════════════ */
 
+.nv-oracle-timeline-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+  background: rgba(212, 175, 55, 0.03);
+  border: 1px solid rgba(212, 175, 55, 0.1);
+  border-radius: 24px;
+}
+
+.nv-oracle-timeline-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.nv-oracle-timeline-panel__title h4 {
+  margin: 4px 0 0;
+  font-weight: 300;
+  font-size: 18px;
+  letter-spacing: 0.04em;
+}
+
+.nv-oracle-timeline-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 32px;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 13px;
+}
+
+/* ── Status indicator ────────────────────────── */
+.nv-oracle-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  font-weight: 600;
+}
+
+.nv-oracle-status__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.nv-pulse {
+  animation: oracle-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes oracle-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.5; transform: scale(0.8); }
+}
+
+/* ── Stats row ───────────────────────────────── */
+.nv-oracle-timeline-panel__stats {
+  display: flex;
+  gap: 20px;
+}
+
+.nv-oracle-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nv-oracle-stat__label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.nv-oracle-stat__value {
+  font-size: 20px;
+  font-weight: 300;
+  color: rgba(255, 255, 255, 0.85);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Sparkline ───────────────────────────────── */
+.nv-oracle-sparkline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+}
+
+.nv-oracle-sparkline__label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.3);
+  white-space: nowrap;
+}
+
+.nv-oracle-sparkline__svg {
+  flex: 1;
+  min-width: 0;
+}
+
+.nv-oracle-sparkline__value {
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ── Scrubber ────────────────────────────────── */
+.nv-oracle-scrubber {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.nv-oracle-scrubber--active {
+  border-color: rgba(212, 175, 55, 0.25);
+  background: rgba(212, 175, 55, 0.04);
+}
+
+.nv-oracle-scrubber__controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nv-oracle-scrubber__btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+}
+
+.nv-oracle-scrubber__btn:hover {
+  border-color: rgba(212, 175, 55, 0.35);
+  color: #d4af37;
+}
+
+.nv-oracle-scrubber__track {
+  position: relative;
+  flex: 1;
+  height: 6px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 3px;
+}
+
+.nv-oracle-scrubber__fill {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  background: rgba(212, 175, 55, 0.4);
+  border-radius: 3px;
+  pointer-events: none;
+}
+
+.nv-oracle-scrubber__range {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  transform: translateY(-50%);
+  opacity: 0;
+  cursor: pointer;
+  height: 100%;
+}
+
+.nv-oracle-scrubber__live-btn {
+  padding: 4px 12px;
+  border: 1px solid rgba(127, 255, 212, 0.35);
+  border-radius: 999px;
+  background: rgba(127, 255, 212, 0.06);
+  color: #7fffd4;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s;
+}
+
+.nv-oracle-scrubber__live-btn:hover {
+  background: rgba(127, 255, 212, 0.12);
+}
+
+.nv-oracle-scrubber__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.3);
+  font-family: monospace;
+}
+
+.nv-oracle-scrubber__frozen {
+  color: #d4af37;
+  letter-spacing: 0.1em;
+}
+
+/* ── Patch Card ──────────────────────────────── */
+.nv-oracle-patch-card {
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nv-oracle-patch-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nv-oracle-patch-card__label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  color: #7fffd4;
+}
+
+.nv-oracle-patch-card__id {
+  font-size: 10px;
+  font-family: monospace;
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.nv-oracle-patch-card__confidence {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.nv-oracle-patch-card__narrative {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  line-height: 1.6;
+  margin: 0;
+}


### PR DESCRIPTION
## Phase 84.1 — Replay-Safe Temporal Oracle

Adds deterministic replay safety to the live Oracle stream by enforcing sequence monotonicity, timeline buffering, and scrub-aware Oracle inspection.

### Scope
- Refactors `useLiveOracle.ts` with `seq` monotonicity gate.
- Drops stale/duplicate patches where `incoming.seq <= lastSeq`.
- Adds gap detection for skipped sequence numbers.
- Adds bounded sequence log for recent Oracle deltas.
- Adds `useOracleTimeline()` scrub API.
- Adds `OracleTimelinePanel.tsx` for confidence sparkline, timeline scrubber, live/scrub status, and patch inspection.
- Adds hook barrel export.
- Adds Phase 84.1 Oracle Timeline styling.

### Temporal rules
```ts
if (incoming.seq <= lastSeq.current) return;
lastSeq.current = incoming.seq;
```

### Replay isolation
```text
LIVE mode: apply monotonic deltas
HISTORICAL/SCRUB mode: freeze live application, inspect buffered timeline
LIVE return: resume from last accepted seq
```

### Verification
```bash
pnpm --filter admin-panel build
pnpm --filter @santis/ingestion-api build
```

Local results reported green:
```text
admin-panel: ✓ 2397 modules transformed, ✓ built in 3.52s
ingestion-api: dist/index.cjs 3.1mb, Done in 313ms
```

### Files
- `admin-panel/src/features/boardroom/hooks/useLiveOracle.ts`
- `admin-panel/src/features/boardroom/hooks/useOracleTimeline.ts`
- `admin-panel/src/features/boardroom/hooks/index.ts`
- `admin-panel/src/features/boardroom/components/oracle/OracleTimelinePanel.tsx`
- `admin-panel/src/styles/boardroom-chronos.css`

### Architecture principle
Live Oracle deltas are now replay-safe: stale patches are dropped, historical inspection is isolated, and the UI can scrub causal Oracle state without mutating live truth.