### PR TITLE
fix(ci): align engines.pnpm constraint to >=10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=10.0.0"
   },
   "packageManager": "pnpm@10.24.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Aligns the root `engines.pnpm` constraint with the workspace `packageManager` version to resolve `PNPM_VERSION_DRIFT` in the environment audit.

## Why

`audit-environment.mjs` uses `parseMajor()` against the `engines.pnpm` string. The previous constraint resolved to major version 9, while the installed/package-managed pnpm version is `10.24.0`, causing the audit to report drift.

## Change

- Updates `package.json` `engines.pnpm` to `>=10.0.0`.
- Keeps the workflow/runtime expectation aligned with `packageManager: pnpm@10.24.0`.

## Validation

- Single-line dependency/runtime constraint fix.
- No workflow changes required for this patch.