### PR TITLE
fix(boardroom): replace hex colors with sovereign tokens in ConfidenceHeatmap

### DIFF
--- a/admin-panel/src/features/boardroom/components/overlays/ConfidenceHeatmap.tsx
+++ b/admin-panel/src/features/boardroom/components/overlays/ConfidenceHeatmap.tsx
@@ -7,13 +7,33 @@ export function ConfidenceHeatmap({ confidence }: ConfidenceHeatmapProps) {
 
   // Renk skalası: düşük (kırmızı) → orta (sarı) → yüksek (altın/yeşil)
   const getColor = () => {
-    if (pct >= 85) return { bar: "#d4af37", glow: "rgba(212,175,55,0.35)", label: "HIGH CONFIDENCE" };
-    if (pct >= 65) return { bar: "#f0c040", glow: "rgba(240,192,64,0.3)", label: "MODERATE" };
-    if (pct >= 45) return { bar: "#e8964a", glow: "rgba(232,150,74,0.3)", label: "LOW" };
-    return { bar: "#e05c5c", glow: "rgba(224,92,92,0.3)", label: "CRITICAL LOW" };
+    if (pct >= 85) return {
+      bar: "var(--color-sovereign-gold-strong)",
+      glow: "rgba(212,175,55,0.35)",
+      barBorder: "rgba(212,175,55,0.25)",
+      label: "HIGH CONFIDENCE",
+    };
+    if (pct >= 65) return {
+      bar: "var(--color-sovereign-signal-hesitation)",
+      glow: "rgba(240,192,64,0.3)",
+      barBorder: "rgba(240,192,64,0.25)",
+      label: "MODERATE",
+    };
+    if (pct >= 45) return {
+      bar: "var(--color-sovereign-warning)",
+      glow: "rgba(232,150,74,0.3)",
+      barBorder: "rgba(232,150,74,0.25)",
+      label: "LOW",
+    };
+    return {
+      bar: "var(--color-sovereign-danger)",
+      glow: "rgba(224,92,92,0.3)",
+      barBorder: "rgba(224,92,92,0.25)",
+      label: "CRITICAL LOW",
+    };
   };
 
-  const { bar, glow, label } = getColor();
+  const { bar, glow, barBorder, label } = getColor();
 
   const segments = Array.from({ length: 20 }, (_, i) => {
     const segPct = (i + 1) * 5;
@@ -39,13 +59,13 @@ export function ConfidenceHeatmap({ confidence }: ConfidenceHeatmapProps) {
               background: seg.filled ? bar : "rgba(255,255,255,0.04)",
               boxShadow: seg.filled ? `0 0 6px ${glow}` : "none",
               opacity: seg.partial ? 0.5 : 1,
-              border: seg.filled ? `1px solid ${bar}40` : "1px solid rgba(255,255,255,0.06)",
+              border: seg.filled ? `1px solid ${barBorder}` : "1px solid rgba(255,255,255,0.06)",
             }}
           />
         ))}
       </div>
 
-      <div className="nv-heatmap__badge" style={{ color: bar, borderColor: `${bar}40`, background: `${glow}` }}>
+      <div className="nv-heatmap__badge" style={{ color: bar, borderColor: barBorder, background: glow }}>
         {label}
       </div>
     </div>


### PR DESCRIPTION
## Summary

Replaces raw hex color usage in `ConfidenceHeatmap` with sovereign design tokens.

## Why

Keeps Boardroom overlay styling aligned with the design-token governance established after Tailwind v4 stabilization.

## Validation

- `pnpm run build`

Note: local branch was prepared after PR #143 was merged; this PR should contain only the ConfidenceHeatmap token cleanup.