### PR TITLE
fix(visual-truth): Phase 3B boardroom component token seal

### DIFF
--- a/assets/css/boardroom-tokens.css
+++ b/assets/css/boardroom-tokens.css
@@ -1,0 +1,74 @@
+/* boardroom-tokens.css — Phase 3B Visual Truth Seal
+ * Canonical kaynak: packages/design-system/theme-manifest.json
+ * Bu dosya GodsEye.css ile paralel token köprüsüdür.
+ * Boardroom component yüzeyi için sovereign-gold renk ailesi.
+ */
+
+/* ── CSS Custom Properties (Boardroom Token Registry) ─────────────────────── */
+:root {
+  /* Boardroom surface family */
+  --sbr-dark:        #141416;   /* sovereign-dark */
+  --sbr-surface:     #1c1c1f;   /* sovereign-surface variant */
+  --sbr-gold:        #c6a96b;   /* sovereign-gold */
+  --sbr-gold-hover:  #d4bc8d;   /* sovereign-gold-deep */
+  --sbr-danger:      #ff4d4d;   /* sovereign-danger variant */
+  --sbr-neutral:     #4d4d4d;   /* sovereign-neutral-800 */
+  --sbr-grid:        #2a2a2d;   /* chart grid color */
+}
+
+/* ── Background tokens ────────────────────────────────────────────────────── */
+.bg-sbr-dark    { background-color: var(--sbr-dark) !important; }
+.bg-sbr-surface { background-color: var(--sbr-surface) !important; }
+.bg-sbr-gold    { background-color: var(--sbr-gold) !important; }
+.bg-sbr-gold\/10 { background-color: rgba(198, 169, 107, 0.1) !important; }
+
+/* ── Text tokens ──────────────────────────────────────────────────────────── */
+.text-sbr-gold   { color: var(--sbr-gold) !important; }
+.text-sbr-danger { color: var(--sbr-danger) !important; }
+
+/* ── Border tokens ────────────────────────────────────────────────────────── */
+.border-sbr-gold       { border-color: var(--sbr-gold) !important; }
+.border-sbr-gold\/20   { border-color: rgba(198, 169, 107, 0.20) !important; }
+.border-sbr-gold\/30   { border-color: rgba(198, 169, 107, 0.30) !important; }
+.border-sbr-gold\/50   { border-color: rgba(198, 169, 107, 0.50) !important; }
+
+/* ── Gradient tokens ──────────────────────────────────────────────────────── */
+.via-sbr-gold\/5 { --tw-gradient-via: rgba(198, 169, 107, 0.05); }
+
+/* ── Shadow tokens ────────────────────────────────────────────────────────── */
+/* shadow-sbr-gold-selected → replaces shadow-[0_0_30px_rgba(198,169,107,0.1)] */
+.shadow-sbr-gold-selected {
+  box-shadow: 0 0 30px rgba(198, 169, 107, 0.1) !important;
+}
+/* shadow-sbr-gold-glow → replaces shadow-[0_0_20px_rgba(198,169,107,0.3)] */
+.shadow-sbr-gold-glow {
+  box-shadow: 0 0 20px rgba(198, 169, 107, 0.3) !important;
+}
+
+/* ── Hover variants ───────────────────────────────────────────────────────── */
+.hover\:bg-sbr-gold-hover:hover { background-color: var(--sbr-gold-hover) !important; }
+.hover\:border-sbr-gold:hover   { border-color: var(--sbr-gold) !important; }
+
+/* ── Size tokens (replaces Tailwind arbitrary) ────────────────────────────── */
+.h-boardroom-chart { height: 400px; }    /* h-[400px] */
+.min-h-offer-body  { min-height: 100px; } /* min-h-[100px] */
+
+/* ── Typography token ─────────────────────────────────────────────────────── */
+/* text-micro replaces text-[10px] (also defined in GodsEye.css context) */
+.text-micro { font-size: 10px; }
+
+/* tracking-boardroom replaces tracking-[0.3em] / tracking-[0.5em] */
+.tracking-boardroom  { letter-spacing: 0.3em; }
+.tracking-sovereign  { letter-spacing: 0.5em; }
+
+/* tracking-cta replaces tracking-[0.2em] */
+.tracking-cta { letter-spacing: 0.2em; }
+
+/* ── CRT Scanline animation (LiveFeedTicker) ─────────────────────────────── */
+@keyframes scanline {
+  0%   { transform: translateY(-100%); }
+  100% { transform: translateY(100%); }
+}
+.animate-scanline {
+  animation: scanline 8s linear infinite;
+}

--- a/components/BoardroomDashboard.jsx
+++ b/components/BoardroomDashboard.jsx
@@ -4,6 +4,7 @@ import {
     Cell, Legend, LineChart, Line
 } from 'recharts';
 import LiveFeedTicker from './LiveFeedTicker';
+import '../assets/css/boardroom-tokens.css';
 
 /**
  * BoardroomDashboard: Üst düzey yönetici analitik paneli
@@ -20,11 +21,11 @@ const BoardroomDashboard = ({ data }) => {
     const chartData = data || defaultData;
 
     return (
-        <div className="bg-[#141416] p-10 min-h-screen text-[#c6a96b]">
+        <div className="bg-sbr-dark p-10 min-h-screen text-sbr-gold">
             {/* Başlık Bölümü */}
-            <div className="flex justify-between items-end mb-12 border-b border-[#c6a96b]/20 pb-6">
+            <div className="flex justify-between items-end mb-12 border-b border-sbr-gold/20 pb-6">
                 <div>
-                    <h2 className="text-[10px] tracking-[0.5em] uppercase opacity-50">Sovereign Division</h2>
+                    <h2 className="text-micro tracking-sovereign uppercase opacity-50">Sovereign Division</h2>
                     <h1 className="text-3xl font-light tracking-tighter uppercase">Boardroom Shadow Analytics</h1>
                 </div>
                 <div className="text-right">
@@ -35,50 +36,50 @@ const BoardroomDashboard = ({ data }) => {
 
             {/* Ana Metrikler */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-                <div className="border border-[#c6a96b]/20 p-6 bg-[#1c1c1f]">
-                    <span className="text-[10px] uppercase opacity-50 tracking-widest">Toplam Oturum</span>
+                <div className="border border-sbr-gold/20 p-6 bg-sbr-surface">
+                    <span className="text-micro uppercase opacity-50 tracking-widest">Toplam Oturum</span>
                     <div className="text-4xl font-semibold mt-2">250</div>
                 </div>
-                <div className="border border-[#c6a96b]/20 p-6 bg-[#1c1c1f]">
-                    <span className="text-[10px] uppercase opacity-50 tracking-widest">Genel Dönüşüm Oranı</span>
+                <div className="border border-sbr-gold/20 p-6 bg-sbr-surface">
+                    <span className="text-micro uppercase opacity-50 tracking-widest">Genel Dönüşüm Oranı</span>
                     <div className="text-4xl font-semibold mt-2 text-white">%36.8</div>
                 </div>
-                <div className="border border-[#c6a96b]/20 p-6 bg-[#1c1c1f]">
-                    <span className="text-[10px] uppercase opacity-50 tracking-widest">En Yüksek Kapanış Eşiği</span>
+                <div className="border border-sbr-gold/20 p-6 bg-sbr-surface">
+                    <span className="text-micro uppercase opacity-50 tracking-widest">En Yüksek Kapanış Eşiği</span>
                     <div className="text-4xl font-semibold mt-2">%80+ STRES</div>
                 </div>
             </div>
 
             {/* Dönüşüm Isı Haritası (Grafik) */}
-            <div className="bg-[#1c1c1f] border border-[#c6a96b]/20 p-8">
+            <div className="bg-sbr-surface border border-sbr-gold/20 p-8">
                 <h3 className="text-sm tracking-widest uppercase mb-8 opacity-70">Stres vs. Satış Korelasyonu</h3>
-                <div className="h-[400px] w-full">
+                <div className="h-boardroom-chart w-full">
                     <ResponsiveContainer width="100%" height="100%">
                         <BarChart data={chartData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-                            <CartesianGrid strokeDasharray="3 3" stroke="#2a2a2d" vertical={false} />
+                            <CartesianGrid strokeDasharray="3 3" stroke="var(--sbr-grid)" vertical={false} />
                             <XAxis
                                 dataKey="category"
-                                stroke="#c6a96b"
+                                stroke="var(--sbr-gold)"
                                 fontSize={12}
                                 tickLine={false}
                                 axisLine={false}
                             />
                             <YAxis
-                                stroke="#c6a96b"
+                                stroke="var(--sbr-gold)"
                                 fontSize={12}
                                 tickLine={false}
                                 axisLine={false}
                                 tickFormatter={(val) => `%${val}`}
                             />
                             <Tooltip
-                                contentStyle={{ backgroundColor: '#1c1c1f', border: '1px solid #c6a96b', color: '#c6a96b' }}
+                                contentStyle={{ backgroundColor: 'var(--sbr-surface)', border: '1px solid var(--sbr-gold)', color: 'var(--sbr-gold)' }}
                                 itemStyle={{ color: '#fff' }}
                             />
                             <Bar dataKey="conversion" name="Dönüşüm Oranı" radius={[4, 4, 0, 0]}>
                                 {chartData.map((entry, index) => (
                                     <Cell
                                         key={`cell-${index}`}
-                                        fill={entry.conversion > 70 ? '#ff4d4d' : entry.conversion > 40 ? '#c6a96b' : '#4d4d4d'}
+                                        fill={entry.conversion > 70 ? 'var(--sbr-danger)' : entry.conversion > 40 ? 'var(--sbr-gold)' : 'var(--sbr-neutral)'}
                                     />
                                 ))}
                             </Bar>

--- a/components/LiveFeedTicker.jsx
+++ b/components/LiveFeedTicker.jsx
@@ -57,17 +57,8 @@ const LiveFeedTicker = () => {
 
   return (
     <>
-    <style>{`
-      @keyframes scanline {
-        0% { transform: translateY(-100%); }
-        100% { transform: translateY(100%); }
-      }
-      .animate-scanline {
-        animation: scanline 8s linear infinite;
-      }
-    `}</style>
-    <div className="bg-black border-t border-[#c6a96b]/30 p-4 font-mono text-[10px] h-48 overflow-hidden relative">
-      <div className="absolute top-0 left-4 bg-black px-2 -translate-y-1/2 text-[#c6a96b] tracking-widest border border-[#c6a96b]/30 z-10">
+    <div className="bg-black border-t border-sbr-gold/30 p-4 font-mono text-micro h-48 overflow-hidden relative">
+      <div className="absolute top-0 left-4 bg-black px-2 -translate-y-1/2 text-sbr-gold tracking-widest border border-sbr-gold/30 z-10">
         LIVE_TELEMETRY_STREAM
       </div>
       
@@ -76,7 +67,7 @@ const LiveFeedTicker = () => {
           <div 
             key={log.id} 
             className={`flex items-center space-x-2 animate-in fade-in slide-in-from-left-2 duration-500 ${
-              log.isCritical ? 'text-[#ff4d4d]' : 'text-[#c6a96b]/70'
+              log.isCritical ? 'text-sbr-danger' : 'text-sbr-gold opacity-70'
             }`}
           >
             <span className="opacity-50">[{new Date(log.id).toLocaleTimeString()}]</span>
@@ -87,7 +78,7 @@ const LiveFeedTicker = () => {
       </div>
 
       {/* Tarama Efekti (CRT Scanline) */}
-      <div className="absolute inset-0 pointer-events-none bg-gradient-to-b from-transparent via-[#c6a96b]/5 to-transparent opacity-20 h-full w-full animate-scanline z-20"></div>
+      <div className="absolute inset-0 pointer-events-none bg-gradient-to-b from-transparent via-sbr-gold/5 to-transparent opacity-20 h-full w-full animate-scanline z-20"></div>
     </div>
     </>
   );

--- a/components/SantisDynamicOffer.jsx
+++ b/components/SantisDynamicOffer.jsx
@@ -46,25 +46,25 @@ const SantisDynamicOffer = ({ stressLevel }) => {
     }, [stressLevel]);
 
     return (
-        <div className="bg-[#1c1c1f] border border-[#c6a96b]/30 p-6 font-mono text-xs md:text-sm">
+        <div className="bg-sbr-surface border border-sbr-gold/30 p-6 font-mono text-xs md:text-sm">
             <div className="flex items-center mb-4">
                 <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse mr-2"></div>
-                <span className="text-[#c6a96b] tracking-widest uppercase">Kuantum Analiz Raporu</span>
+                <span className="text-sbr-gold tracking-widest uppercase">Kuantum Analiz Raporu</span>
             </div>
 
-            <div className="text-zinc-300 leading-relaxed min-h-[100px] mb-6">
+            <div className="text-zinc-300 leading-relaxed min-h-offer-body mb-6">
                 {displayText}
                 <span className="animate-ping">|</span>
             </div>
 
             {isComplete && (
                 <div className="animate-in fade-in slide-in-from-bottom-4 duration-1000">
-                    <div className="bg-[#c6a96b]/10 border border-[#c6a96b]/50 p-4 mb-6">
-                        <span className="text-[#c6a96b] block font-bold mb-1">HEDİYE TANIMLANDI:</span>
+                    <div className="bg-sbr-gold/10 border border-sbr-gold/50 p-4 mb-6">
+                        <span className="text-sbr-gold block font-bold mb-1">HEDİYE TANIMLANDI:</span>
                         <span className="text-white uppercase tracking-tighter">{offer.module}</span>
                     </div>
 
-                    <button className="w-full bg-[#c6a96b] text-black font-bold py-4 tracking-[0.2em] uppercase hover:bg-[#d4bc8d] transition-colors shadow-[0_0_20px_rgba(198,169,107,0.3)]">
+                    <button className="w-full bg-sbr-gold text-black font-bold py-4 tracking-cta uppercase hover:bg-sbr-gold-hover transition-colors shadow-sbr-gold-glow">
                         Analizi Onayla ve Planı Mühürle
                     </button>
                 </div>

--- a/components/SantisPricingMatrix.jsx
+++ b/components/SantisPricingMatrix.jsx
@@ -32,9 +32,9 @@ const SantisPricingMatrix = () => {
     const [selected, setSelected] = useState('sovereign');
 
     return (
-        <div className="bg-[#141416] py-20 px-10 min-h-screen text-white font-sans">
+        <div className="bg-sbr-dark py-20 px-10 min-h-screen text-white font-sans">
             <div className="max-w-6xl mx-auto text-center mb-16">
-                <h2 className="text-[#c6a96b] text-sm tracking-[0.3em] uppercase mb-4">Longevity Architecture</h2>
+                <h2 className="text-sbr-gold text-sm tracking-boardroom uppercase mb-4">Longevity Architecture</h2>
                 <h1 className="text-4xl md:text-5xl font-light tracking-tight">Geleceğinizi Mühürleyin.</h1>
             </div>
 
@@ -44,12 +44,12 @@ const SantisPricingMatrix = () => {
                         key={plan.id}
                         onClick={() => setSelected(plan.id)}
                         className={`relative cursor-pointer transition-all duration-500 p-8 border ${selected === plan.id
-                                ? 'border-[#c6a96b] bg-[#1c1c1f] scale-105 shadow-[0_0_30px_rgba(198,169,107,0.1)]'
+                                ? 'border-sbr-gold bg-sbr-surface scale-105 shadow-sbr-gold-selected'
                                 : 'border-zinc-800 bg-transparent opacity-70 scale-100 hover:opacity-100'
                             }`}
                     >
                         {plan.badge && (
-                            <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-[#c6a96b] text-black text-[10px] font-bold px-3 py-1 tracking-widest">
+                            <span className="absolute -top-3 left-1/2 -translate-x-1/2 bg-sbr-gold text-black text-micro font-bold px-3 py-1 tracking-widest">
                                 {plan.badge}
                             </span>
                         )}
@@ -63,15 +63,15 @@ const SantisPricingMatrix = () => {
                         <ul className="space-y-4 mb-10 text-sm text-zinc-400">
                             {plan.features.map((feature, idx) => (
                                 <li key={idx} className="flex items-center">
-                                    <span className="w-1.5 h-1.5 bg-[#c6a96b] rounded-full mr-3"></span>
+                                    <span className="w-1.5 h-1.5 bg-sbr-gold rounded-full mr-3"></span>
                                     {feature}
                                 </li>
                             ))}
                         </ul>
 
                         <button className={`w-full py-4 tracking-widest text-xs uppercase transition-all ${selected === plan.id
-                                ? 'bg-[#c6a96b] text-black font-bold'
-                                : 'border border-zinc-700 hover:border-[#c6a96b] text-zinc-400'
+                                ? 'bg-sbr-gold text-black font-bold'
+                                : 'border border-zinc-700 hover:border-sbr-gold text-zinc-400'
                             }`}>
                             {plan.cta}
                         </button>

--- a/packages/design-system/theme-manifest.lock.json
+++ b/packages/design-system/theme-manifest.lock.json
@@ -1,4 +1,4 @@
 {
   "hash": "89ed958e02ecdea9fdca4efc42d6020928fc135feb8537890810aa0f9c79b283",
-  "lockedAt": "2026-05-09T05:30:46.263Z"
+  "lockedAt": "2026-05-09T05:58:26.683Z"
 }


### PR DESCRIPTION
## Summary

Phase 3B seals React root boardroom/admin-surface Visual Truth violations by replacing raw hex colors, Tailwind arbitrary values, and inline visual styles with canonical `sbr-*` token-backed classes.

## Scope

- `components/BoardroomDashboard.jsx`
- `components/SantisDynamicOffer.jsx`
- `components/SantisPricingMatrix.jsx`
- `components/LiveFeedTicker.jsx`
- `assets/css/boardroom-tokens.css`
- `packages/design-system/theme-manifest.lock.json`

## Changes

- Replaced raw hex color usage with canonical boardroom token bridge classes.
- Replaced Tailwind arbitrary values such as `bg-[#...]`, `text-[#...]`, `border-[#...]`, `shadow-[...]`, `h-[400px]`, and `min-h-[100px]` with named token classes.
- Moved `LiveFeedTicker` inline scanline style into `assets/css/boardroom-tokens.css`.
- Added Phase 3B token bridge using `--sbr-*` CSS custom properties.

## Verification

- `pnpm run stitch:enforce` — PASS
- `pnpm run lint` — PASS, 0 warnings
- `pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts` — PASS, 24/24

## Governance

Canonical branch: `phase-3b-react-root-visual-truth-seal`
Depends on: PR #150 merged

No archive/delete operation included. No runtime route/API behavior changed.