### PR TITLE
fix(runtime): Phase 4C runtime render contract seal

### DIFF
--- a/assets/js/modules/safe-render.js
+++ b/assets/js/modules/safe-render.js
@@ -1,0 +1,18 @@
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function setText(node, value) {
+  if (!node) return;
+  node.textContent = String(value ?? '');
+}
+
+export function toSafeNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}

--- a/assets/js/modules/santis-boardroom-mfe.js
+++ b/assets/js/modules/santis-boardroom-mfe.js
@@ -4,6 +4,8 @@
  * Distributed Cognitive Admin OS
  */
 
+import { escapeHtml, setText, toSafeNumber } from './safe-render.js';
+
 const BOOT_TIME = performance.now();
 const BOARDROOM_MFE_COLORS = {
     ink: 'rgb(226, 232, 240)',
@@ -140,7 +142,7 @@ class CommandPalette {
         } else {
             this.overlay.style.opacity = "0";
             this.input.value = "";
-            this.resultArea.innerText = "";
+            setText(this.resultArea, "");
             setTimeout(() => this.overlay.style.display = "none", 300);
         }
     }
@@ -157,7 +159,7 @@ class CommandPalette {
     // AI Intent Layer Simülasyonu
     analyzeIntent(query) {
         if (!query.trim()) {
-            this.resultArea.innerText = "";
+            setText(this.resultArea, "");
             return;
         }
 
@@ -177,7 +179,7 @@ class CommandPalette {
             setTimeout(() => this.triggerGodMode(), 1000);
         }
 
-        this.resultArea.innerHTML = `🧠 <b>Niyet Saptanıyor:</b> <span style="color: ${BOARDROOM_MFE_COLORS.success};">[${intent}]</span> - ${actionStr}`;
+        this.resultArea.innerHTML = `🧠 <b>Niyet Saptanıyor:</b> <span style="color: ${BOARDROOM_MFE_COLORS.success};">[${escapeHtml(intent)}]</span> - ${escapeHtml(actionStr)}`;
     }
 
     triggerGodMode() {
@@ -243,13 +245,13 @@ class TelemetryHUD {
         const now = performance.now();
         this.frames++;
         if (now >= this.lastTime + 1000) {
-            this.fps = this.frames;
+            this.fps = toSafeNumber(this.frames);
             this.frames = 0;
             this.lastTime = now;
             
             // Renk Kodlaması (Yeşil, Sarı, Kırmızı)
             const color = this.fps >= 50 ? BOARDROOM_MFE_COLORS.success : (this.fps > 30 ? BOARDROOM_MFE_COLORS.warn : BOARDROOM_MFE_COLORS.danger);
-            this.fpsEl.innerHTML = `FPS: <b style="color:${color}">${this.fps}</b>`;
+            this.fpsEl.innerHTML = `FPS: <b style="color:${color}">${escapeHtml(Math.round(this.fps))}</b>`;
 
             // Bellek Okuması (Destekleyen Tarayıcılar İçin)
             if (performance.memory) {
@@ -322,8 +324,8 @@ class OmniverseSync {
         
         // Telemetry HUD varsa son sinyali oraya da yaz
         if (window.SovereignHUD && window.SovereignHUD.busEl) {
-            window.SovereignHUD.busEl.innerHTML = `BUS: <span style="color:${BOARDROOM_MFE_COLORS.bus}">${topic}</span>`;
-            setTimeout(() => { if (window.SovereignHUD) window.SovereignHUD.busEl.innerHTML = "BUS: SLEEP"; }, 2000);
+            window.SovereignHUD.busEl.innerHTML = `BUS: <span style="color:${BOARDROOM_MFE_COLORS.bus}">${escapeHtml(topic)}</span>`;
+            setTimeout(() => { if (window.SovereignHUD) setText(window.SovereignHUD.busEl, "BUS: SLEEP"); }, 2000);
         }
 
         return true;
@@ -396,7 +398,7 @@ function injectMockMFE() {
     const cLog = document.getElementById('crm-log');
 
     const appendLog = (el, text, color) => {
-        el.innerHTML += `<div style="color:${color}; border-bottom:1px dashed ${BOARDROOM_MFE_COLORS.logLine}; padding:3px 0;">> ${text}</div>`;
+        el.innerHTML += `<div style="color:${color}; border-bottom:1px dashed ${BOARDROOM_MFE_COLORS.logLine}; padding:3px 0;">  ${escapeHtml(text)}</div>`;
         el.scrollTop = el.scrollHeight;
     };
 

--- a/assets/js/modules/santis-boardroom-pro-live.js
+++ b/assets/js/modules/santis-boardroom-pro-live.js
@@ -4,6 +4,7 @@
  */
 import { SantisCoreStateStreamClient } from './santis-corestate-stream-client.js';
 import { SantisBoardroomProCoreStateAdapter } from './santis-boardroom-pro-corestate-adapter.js';
+import { escapeHtml, setText, toSafeNumber } from './safe-render.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   console.log('🚀 Bootstrapping Boardroom PRO Live Nervous System...');
@@ -372,9 +373,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 const timestamp = new Date(state.lastOperatorAction.timestamp).toLocaleTimeString('tr-TR');
                 
                 actionCard.innerHTML = `
-                  <div style="font-size: 11px; color: ${BOARDROOM_RUNTIME_COLORS.muted}; margin-bottom: 4px;">${timestamp} • ID: ${state.lastOperatorAction.id.substring(0, 8)}</div>
-                  <strong style="color: ${BOARDROOM_RUNTIME_COLORS.gold}; font-size: 14px; text-transform: uppercase;">${state.lastOperatorAction.intent}</strong>
-                  <div style="font-size: 13px; color: ${BOARDROOM_RUNTIME_COLORS.neutral}; margin-top: 4px;">Operator: ${state.lastOperatorAction.operatorId}</div>
+                  <div style="font-size: 11px; color: ${BOARDROOM_RUNTIME_COLORS.muted}; margin-bottom: 4px;">${escapeHtml(timestamp)} • ID: ${escapeHtml(state.lastOperatorAction.id.substring(0, 8))}</div>
+                  <strong style="color: ${BOARDROOM_RUNTIME_COLORS.gold}; font-size: 14px; text-transform: uppercase;">${escapeHtml(state.lastOperatorAction.intent)}</strong>
+                  <div style="font-size: 13px; color: ${BOARDROOM_RUNTIME_COLORS.neutral}; margin-top: 4px;">Operator: ${escapeHtml(state.lastOperatorAction.operatorId)}</div>
                 `;
 
                 // Add to top of rail
@@ -489,8 +490,8 @@ document.addEventListener('DOMContentLoaded', () => {
           else entry.classList.add('log-telemetry');
 
           entry.innerHTML = `
-              <div class="log-time">[${log.time}]</div>
-              <div class="log-message">${log.message}</div>
+              <div class="log-time">[${escapeHtml(log.time)}]</div>
+              <div class="log-message">${escapeHtml(log.message)}</div>
           `;
           
           // Re-hydration sırasında animasyon yapmıyoruz (0-Jank)
@@ -516,8 +517,8 @@ document.addEventListener('DOMContentLoaded', () => {
       else entry.classList.add('log-telemetry');
 
       entry.innerHTML = `
-          <div class="log-time">[${time}]</div>
-          <div class="log-message">${message}</div>
+          <div class="log-time">[${escapeHtml(time)}]</div>
+          <div class="log-message">${escapeHtml(message)}</div>
       `;
 
       // Listenin en üstüne ekle
@@ -567,15 +568,6 @@ document.addEventListener('DOMContentLoaded', () => {
       pending.button.innerHTML = pending.originalHtml;
   }
 
-  function escapeHtml(value) {
-      return String(value ?? '')
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&apos;');
-  }
-
   function createStrategyQueueId() {
       if (window.crypto && typeof window.crypto.randomUUID === 'function') {
           return window.crypto.randomUUID();
@@ -585,13 +577,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function formatDeltaPct(value) {
-      const numeric = Number(value) || 0;
+      const numeric = toSafeNumber(value);
       const rounded = Math.round(numeric * 100);
       return rounded > 0 ? `+${rounded}%` : `${rounded}%`;
   }
 
   function formatRevenueDelta(value) {
-      const numeric = Number(value) || 0;
+      const numeric = toSafeNumber(value);
       const prefix = numeric > 0 ? '+' : '';
       return `${prefix}${formatCurrency(Math.abs(numeric))}`;
   }
@@ -611,17 +603,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
       btn.disabled = !(recommendationId && sessionId) || Boolean(queued && queued.status !== 'rejected');
       btn.classList.toggle('is-queued', Boolean(queued && queued.status !== 'rejected'));
-      if (label) {
-          label.innerText = queued && queued.status !== 'rejected' ? 'Queued' : 'Queue Strategy';
-      }
+      setText(label, queued && queued.status !== 'rejected' ? 'Queued' : 'Queue Strategy');
   }
 
   function createStrategyQueueItemFromButton(button) {
       const recommendationId = button.dataset.recommendationId;
       const sessionId = button.dataset.sessionId;
-      const simulatedDeltaPct = parseFloat(button.dataset.delta);
-      const expectedRevenueDelta = parseFloat(button.dataset.expectedRevenueDelta);
-      const confidence = parseFloat(button.dataset.confidence);
+      const simulatedDeltaPct = toSafeNumber(button.dataset.delta);
+      const expectedRevenueDelta = toSafeNumber(button.dataset.expectedRevenueDelta);
+      const confidence = toSafeNumber(button.dataset.confidence);
 
       if (!recommendationId || !sessionId) {
           throw new Error('Strategy queue requires recommendationId and sessionId');
@@ -633,9 +623,9 @@ document.addEventListener('DOMContentLoaded', () => {
           sessionId,
           traceId: button.dataset.traceId || '',
           simulatedAction: button.dataset.action || 'strategy',
-          simulatedDeltaPct: Number.isFinite(simulatedDeltaPct) ? simulatedDeltaPct : 0,
-          expectedRevenueDelta: Number.isFinite(expectedRevenueDelta) ? expectedRevenueDelta : 0,
-          confidence: Number.isFinite(confidence) ? confidence : 0,
+          simulatedDeltaPct,
+          expectedRevenueDelta,
+          confidence,
           trigger: button.dataset.trigger || 'shadow_pricing',
           status: 'pending',
           createdAt: new Date().toISOString(),
@@ -648,7 +638,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!queueList) return;
 
       const activeCount = strategyApprovalQueue.filter((item) => item.status === 'pending' || item.status === 'applying').length;
-      if (queueCount) queueCount.innerText = String(activeCount);
+      setText(queueCount, activeCount);
 
       if (strategyApprovalQueue.length === 0) {
           queueList.innerHTML = '<div class="strategy-queue-empty">No queued strategy decisions.</div>';
@@ -677,7 +667,7 @@ document.addEventListener('DOMContentLoaded', () => {
                       <div class="strategy-queue-meta">
                           <span>${escapeHtml(formatDeltaPct(item.simulatedDeltaPct))}</span>
                           <span>${escapeHtml(formatRevenueDelta(item.expectedRevenueDelta))}</span>
-                          <span>${Math.round((Number(item.confidence) || 0) * 100)}% confidence</span>
+                          <span>${escapeHtml(Math.round(toSafeNumber(item.confidence) * 100))}% confidence</span>
                       </div>
                   </div>
                   <div class="strategy-queue-actions">
@@ -876,7 +866,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!overlay || !modalTitle || !modalBody) return;
       
       // Modal başlığını ayarla
-      modalTitle.innerText = `ORACLE KARARI: ${eventData.type}`;
+      setText(modalTitle, `ORACLE KARARI: ${eventData.type}`);
       
       // Akıllı Karar Motoru (Dinamik Logic için temel)
       let actionHtml = '';
@@ -885,7 +875,7 @@ document.addEventListener('DOMContentLoaded', () => {
           : ["Özel İndirim Tanımla", "Genişletilmiş Oda Servisi Sun", "Bir Sonraki Ziyaret Notu Ekle"];
 
       recommendations.forEach(rec => {
-          actionHtml += `<div class="action-card" style="cursor:pointer; padding:12px; margin:8px 0; background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1); border-radius:4px; transition:all 0.3s ease;"><span>⚡</span> ${rec}</div>`;
+          actionHtml += `<div class="action-card" style="cursor:pointer; padding:12px; margin:8px 0; background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1); border-radius:4px; transition:all 0.3s ease;"><span>⚡</span> ${escapeHtml(rec)}</div>`;
       });
 
       modalBody.innerHTML = actionHtml;

--- a/docs/audits/phase4c-runtime-render-contract.md
+++ b/docs/audits/phase4c-runtime-render-contract.md
@@ -1,0 +1,294 @@
+# SANTIS OS - Phase 4C Runtime Render Contract
+
+> Branch: `phase-4c-runtime-render-contract-seal`  
+> Scope: live-data render safety for JS runtime modules  
+> Rule: no broad legacy rewrite, no frozen admin refactor, no speculative DOM migration
+
+---
+
+## 1. Purpose
+
+Phase 4C introduces a bounded runtime render contract for dynamic HTML surfaces.
+
+The goal is not to rewrite the legacy runtime.  
+The goal is to separate:
+
+```text
+trusted static template
+vs
+escaped dynamic value
+```
+
+This phase exists to reduce XSS and runtime DOM drift risk in live-data render paths.
+
+---
+
+## 2. In Scope
+
+Initial Phase 4C implementation targets:
+
+```text
+assets/js/modules/santis-boardroom-mfe.js
+assets/js/modules/santis-boardroom-pro-live.js
+```
+
+Reason:
+
+- Both files render live boardroom / action / pricing data.
+- Both use `innerHTML` in runtime surfaces.
+- Both include dynamic labels, queue entries, action cards, or modal body content.
+- Both are small enough to seal without converting the whole runtime layer.
+
+---
+
+## 3. Initial Candidate Evidence
+
+### 3.1 `santis-boardroom-mfe.js`
+
+Observed surfaces:
+
+```text
+resultArea.innerHTML
+fpsEl.innerHTML
+busEl.innerHTML
+```
+
+Risk profile:
+
+- intent/action result rendering
+- runtime HUD rendering
+- MFE shell has both static template and dynamic value injection
+
+Decision:
+
+```text
+Phase 4C candidate: YES
+First migration batch: YES
+```
+
+---
+
+### 3.2 `santis-boardroom-pro-live.js`
+
+Observed surfaces:
+
+```text
+pricing/action label render
+action card render
+stream/queue/modal render
+modalBody.innerHTML = actionHtml
+```
+
+Risk profile:
+
+- live action card data
+- pricing/action labels
+- queue and stream render
+- modal body render from generated HTML string
+
+Decision:
+
+```text
+Phase 4C candidate: YES
+First migration batch: YES
+```
+
+---
+
+## 4. Second Wave Candidates
+
+These are in scope for later Phase 4C batches, not the first migration commit:
+
+```text
+assets/js/modules/santis-boardroom-oracle-v2.js
+assets/js/modules/santis-concierge.js
+assets/js/modules/sovereign-boutique.js
+assets/js/modules/admin-bookings-list.js
+assets/js/modules/boardroom-incident-feed.js
+```
+
+Reason:
+
+- They may contain dynamic template rendering.
+- Some already received localized escaping hardening in Phase 4B.
+- They need separate review to avoid broad PR scope.
+
+---
+
+## 5. Out of Scope
+
+The following are intentionally excluded from the first Phase 4C implementation:
+
+```text
+admin-panel/src/components/dashboard/SantisBoardroom.jsx
+assets/js/core/*
+admin/*
+hq-dashboard/*
+tenant-dashboard/*
+static-only template injection with no dynamic value
+```
+
+### Notes
+
+`admin-panel/src/components/dashboard/SantisBoardroom.jsx` uses React `dangerouslySetInnerHTML`, but it belongs to the React/admin-panel surface and should not be mixed with the JS module runtime helper.
+
+`assets/js/core/*` is a wider legacy runtime layer and should be inventoried separately before any migration.
+
+Frozen admin surfaces belong to Phase B archive governance, not Phase 4C.
+
+---
+
+## 6. Runtime Render Contract
+
+### Rule 1 - Dynamic values must be escaped
+
+Any user, API, pricing, queue, intent, action, label, description, status, or telemetry value inserted into HTML must pass through an escape helper.
+
+```text
+dynamic value -> escapeHtml(value) -> HTML string
+```
+
+### Rule 2 - Prefer textContent for pure text
+
+If a node only needs text, use:
+
+```text
+node.textContent = value
+```
+
+not:
+
+```text
+node.innerHTML = value
+```
+
+### Rule 3 - Static templates may remain static
+
+Trusted static shell templates may use `innerHTML` only if no dynamic runtime values are interpolated.
+
+### Rule 4 - Mixed templates must isolate dynamic values
+
+Allowed pattern:
+
+```js
+container.innerHTML = `
+  <article class="static-class">
+    <h3>${escapeHtml(title)}</h3>
+    <p>${escapeHtml(description)}</p>
+  </article>
+`;
+```
+
+Forbidden pattern:
+
+```js
+container.innerHTML = `
+  <article>
+    <h3>${title}</h3>
+    <p>${description}</p>
+  </article>
+`;
+```
+
+### Rule 5 - No broad rewrite
+
+Do not convert the full runtime to React or rebuild the entire DOM system in Phase 4C.
+
+---
+
+## 7. Proposed Helper
+
+Initial helper path:
+
+```text
+assets/js/modules/safe-render.js
+```
+
+Initial API:
+
+```js
+export function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function setText(node, value) {
+  if (!node) return;
+  node.textContent = String(value ?? '');
+}
+```
+
+Optional later API:
+
+```js
+export function html(parts, ...values) {
+  return parts.reduce((output, part, index) => {
+    const value = index < values.length ? escapeHtml(values[index]) : '';
+    return output + part + value;
+  }, '');
+}
+```
+
+---
+
+## 8. Verification Gate
+
+Every Phase 4C migration batch must pass:
+
+```powershell
+node --check <changed-js-files>
+pnpm run stitch:enforce
+pnpm run lint
+pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts
+git restore tests/artifacts tests/reports
+git status --short
+```
+
+Targeted smoke should be added when a changed module has a deterministic page/runtime entry.
+
+---
+
+## 9. Non-Goals
+
+```text
+No frozen admin cleanup
+No broad assets/js/core rewrite
+No visual redesign
+No routing changes
+No pricing behavior changes
+No action semantics changes
+No git add .
+```
+
+---
+
+## 10. First Implementation Plan
+
+Commit 1:
+
+```text
+docs(audit): add Phase 4C runtime render contract
+```
+
+Commit 2:
+
+```text
+feat(runtime): add safe render helper for JS modules
+```
+
+Commit 3:
+
+```text
+fix(runtime): apply safe render contract to boardroom module templates
+```
+
+Initial migration files:
+
+```text
+assets/js/modules/santis-boardroom-mfe.js
+assets/js/modules/santis-boardroom-pro-live.js
+```


### PR DESCRIPTION
## Summary

Introduces the Phase 4C Runtime Render Contract and applies it to the first high-risk JS module render surfaces.

This PR does not attempt a broad legacy rewrite. It creates a bounded contract for separating trusted static templates from escaped dynamic runtime values.

## Scope

### Added

- `docs/audits/phase4c-runtime-render-contract.md`
- `assets/js/modules/safe-render.js`

### Migrated

- `assets/js/modules/santis-boardroom-mfe.js`
- `assets/js/modules/santis-boardroom-pro-live.js`

## Contract

Dynamic values now flow through one of the following helpers:

- `escapeHtml(value)`
- `setText(node, value)`
- `toSafeNumber(value, fallback)`

Static shell templates may remain as `innerHTML` only when they do not interpolate unescaped live/runtime values.

## Verification

- `node --check assets/js/modules/santis-boardroom-mfe.js` — PASS
- `node --check assets/js/modules/santis-boardroom-pro-live.js` — PASS
- `pnpm run stitch:enforce` — PASS
- `pnpm run lint` — PASS
- `pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts` — PASS, 24/24
- test artifacts restored
- working tree clean

## Deferred

Second-wave Phase 4C candidates remain intentionally out of scope:

- `assets/js/modules/santis-boardroom-oracle-v2.js`
- `assets/js/modules/santis-concierge.js`
- `assets/js/modules/sovereign-boutique.js`
- `assets/js/modules/admin-bookings-list.js`
- `assets/js/modules/boardroom-incident-feed.js`

Runtime DOM / live-data architecture beyond the two migrated boardroom modules is intentionally deferred to later Phase 4C batches.