### PR TITLE
docs(audit): add Phase F build warning zero baseline

### DIFF
--- a/docs/audits/phase-f-build-warning-zero-baseline.md
+++ b/docs/audits/phase-f-build-warning-zero-baseline.md
@@ -1,49 +1,136 @@
-# SANTIS OS - Phase F Build Warning Zero Baseline
+# SANTIS OS — Phase F Build Warning Zero Baseline
 
-> Branch: `phase-f-build-warning-zero-baseline`  
-> Scope: Build-time warning elimination & bundle optimization  
-> Status: BASELINE AUDIT COMPLETE
+## Status
 
----
+Baseline capture only.  
+No delete. No archive. No refactor.
 
-## F1 — HTML Parse & Module Warnings
+## Branch
 
-### HTML Parse Errors
-- **404.html (L98):** `parse5 error code end-tag-without-matching-open-element`. OG meta etiketleri arasında kapatılmamış veya yanlış hiyerarşide bir element tespit edildi.
+`phase-f-build-warning-zero-baseline`
 
-### Module Attribute Missing
-Vite build sürecinde aşağıdaki dosyalar `type="module"` niteliği eksik olduğu için bundle edilemiyor:
-- **bronz-masaji.html:** 10+ script (core, engine, app.js)
-- **cilt-bakimi.html:** GSAP, Lenis ve Bridge scriptleri
-- **hakkimizda.html:** Three.js, GSAP ve app.js
-- **ritueller.html / masaj.html:** Vitals ve UI engine scriptleri
-- **service-detail.html:** I18n routes ve engine scriptleri
+## Command
 
-## F2 — CSS @import Ordering Warnings
-- **gallery.css & style.css:** 26 adet `@import` kuralı hatası. `@import` kuralları, CSS dosyalarının en başında (charset/layer haricinde) yer almalıdır. Mevcut yapıda kural ihlalleri bundle optimizasyonunu engelliyor.
+```powershell
+pnpm build
+```
 
-## F3 — Bundle Size Warnings
-- **MPA Bundle:** `tests_reports_html_index.js` (412.45 kB) limitleri zorluyor.
-- **Admin Panel:** `vendor-3d-calendar.js` (780.27 kB) kritik seviyede (600 kB limitini aştı). `manualChunks` optimizasyonu gerekiyor.
+## Result
 
-## F4 — Generated Reports Leaking into Dist
-Aşağıdaki dinamik raporlar ve test çıktıları `dist/` klasörüne (production bundle) sızıyor:
-- `dist/reports/link_audit_report_*.html` (30+ dosya)
-- `dist/tests/reports/html/index.html`
-- `dist/santis-audit/` altındaki admin araçları.
+Build completed successfully.
 
-## F5 — Root MPA Exclusion Policy Hardening
-Production bundle'da bulunmaması gereken "demo/lab" dosyaları tespit edildi:
-- `v18-demo.html`
-- `3d-lab.html`
-- `ws-simulator.html`
-- `santis-pitch-deck.html`
+```text
+Root MPA: PASS
+Turbo build: PASS
+Tasks: 3 successful, 3 total
+```
 
----
+## Warning Inventory
 
-## Kapanış Hükmü
-Bu rapor, Phase F operasyonunun düzeltme listesidir. 
-**Kural 5 Gereği:** Hiçbir dosya direkt silinmeyecek; F4 ve F5 kapsamındaki dosyalar önce karantinaya alınacak, F1 ve F2 için ise kod seviyesinde müdahale edilecektir.
+### F1 — HTML Parse Warning
 
-Validate main: **GREEN**
-Phase F Baseline: **LOCKED**
+`404.html` has a parse5 warning:
+
+```text
+Unable to parse HTML; parse5 error code end-tag-without-matching-open-element
+404.html:98
+```
+
+Likely malformed metadata / OpenGraph line.
+
+### F2 — Legacy Script Module Warnings
+
+Multiple HTML entrypoints include classic scripts that Vite cannot bundle without `type="module"`.
+
+Examples:
+
+```text
+bronz-masaji.html
+bio.html
+booking.html
+checkout.html
+cilt-bakimi.html
+hakkimizda.html
+masaj.html
+service-detail.html
+```
+
+This is not a deletion issue.
+It is a runtime contract and bundler compatibility issue.
+
+### F3 — CSS Import Ordering Warnings
+
+`assets/css/style.css` emits repeated warnings:
+
+```text
+@import rules must precede all rules aside from @charset and @layer statements
+```
+
+The `santis-v6/*` chain is ALIVE and must not be archived.
+Fix must preserve active CSS behavior.
+
+### F4 — Bundle Size Warnings
+
+Root build warning:
+
+```text
+dist/assets/js/tests_reports_html_index-*.js > 400 kB
+```
+
+Admin Panel warning:
+
+```text
+vendor-3d-calendar-*.js > 600 kB
+```
+
+These require classification before optimization.
+
+### F5 — Generated/Test Report Leakage Into Build Output
+
+Build output includes:
+
+```text
+dist/tests/reports/html/index.html
+dist/assets/js/tests_reports_html_index-*.js
+```
+
+This indicates test report surfaces are being picked up by the root MPA build graph.
+
+Rule 5 applies before any removal or archive.
+
+### F6 — Turbo Stale PID Warning
+
+Turbo reports:
+
+```text
+WARNING stale pid file at ...\turbod.pid
+```
+
+This is local tooling hygiene, not application failure.
+
+## Phase F Proposed Order
+
+1. F0 — Baseline document commit only.
+2. F1 — Fix `404.html` malformed metadata.
+3. F2 — Exclude generated test reports from root MPA input graph.
+4. F3 — Normalize CSS import ordering without touching `santis-v6` semantics.
+5. F4 — Classify legacy script module warnings.
+6. F5 — Bundle size review and chunk strategy.
+
+## Gates Required After Every Fix
+
+```powershell
+pnpm build
+pnpm run stitch:enforce
+pnpm run lint
+pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts
+git status --short
+```
+
+## Governance
+
+This baseline is not a fix PR.
+It records the exact warning surface before intervention.
+
+Rule 5 remains active:
+No direct delete. Quarantine first.

--- a/docs/audits/phase-f-build-warning-zero-baseline.md
+++ b/docs/audits/phase-f-build-warning-zero-baseline.md
@@ -1,0 +1,49 @@
+# SANTIS OS - Phase F Build Warning Zero Baseline
+
+> Branch: `phase-f-build-warning-zero-baseline`  
+> Scope: Build-time warning elimination & bundle optimization  
+> Status: BASELINE AUDIT COMPLETE
+
+---
+
+## F1 — HTML Parse & Module Warnings
+
+### HTML Parse Errors
+- **404.html (L98):** `parse5 error code end-tag-without-matching-open-element`. OG meta etiketleri arasında kapatılmamış veya yanlış hiyerarşide bir element tespit edildi.
+
+### Module Attribute Missing
+Vite build sürecinde aşağıdaki dosyalar `type="module"` niteliği eksik olduğu için bundle edilemiyor:
+- **bronz-masaji.html:** 10+ script (core, engine, app.js)
+- **cilt-bakimi.html:** GSAP, Lenis ve Bridge scriptleri
+- **hakkimizda.html:** Three.js, GSAP ve app.js
+- **ritueller.html / masaj.html:** Vitals ve UI engine scriptleri
+- **service-detail.html:** I18n routes ve engine scriptleri
+
+## F2 — CSS @import Ordering Warnings
+- **gallery.css & style.css:** 26 adet `@import` kuralı hatası. `@import` kuralları, CSS dosyalarının en başında (charset/layer haricinde) yer almalıdır. Mevcut yapıda kural ihlalleri bundle optimizasyonunu engelliyor.
+
+## F3 — Bundle Size Warnings
+- **MPA Bundle:** `tests_reports_html_index.js` (412.45 kB) limitleri zorluyor.
+- **Admin Panel:** `vendor-3d-calendar.js` (780.27 kB) kritik seviyede (600 kB limitini aştı). `manualChunks` optimizasyonu gerekiyor.
+
+## F4 — Generated Reports Leaking into Dist
+Aşağıdaki dinamik raporlar ve test çıktıları `dist/` klasörüne (production bundle) sızıyor:
+- `dist/reports/link_audit_report_*.html` (30+ dosya)
+- `dist/tests/reports/html/index.html`
+- `dist/santis-audit/` altındaki admin araçları.
+
+## F5 — Root MPA Exclusion Policy Hardening
+Production bundle'da bulunmaması gereken "demo/lab" dosyaları tespit edildi:
+- `v18-demo.html`
+- `3d-lab.html`
+- `ws-simulator.html`
+- `santis-pitch-deck.html`
+
+---
+
+## Kapanış Hükmü
+Bu rapor, Phase F operasyonunun düzeltme listesidir. 
+**Kural 5 Gereği:** Hiçbir dosya direkt silinmeyecek; F4 ve F5 kapsamındaki dosyalar önce karantinaya alınacak, F1 ve F2 için ise kod seviyesinde müdahale edilecektir.
+
+Validate main: **GREEN**
+Phase F Baseline: **LOCKED**


### PR DESCRIPTION
## Summary

Adds the Phase F Build Warning Zero baseline.

This PR is documentation-only. It does not delete, archive, refactor, or fix code.

## Captured Warning Classes

- F1: 404.html parse5 warning
- F2: legacy script module warnings
- F3: CSS import ordering warnings
- F4: bundle size warnings
- F5: test report leakage into root MPA build output
- F6: Turbo stale PID warning

## Verification

- pnpm build — PASS with warnings
- pnpm run stitch:enforce — PASS
- pnpm run lint — PASS

## Governance

This PR establishes the warning inventory before intervention. Fixes must happen in separate small PRs with gates.