### PR TITLE
fix(html): resolve 404.html parse warning (F1)

### DIFF
--- a/404.html
+++ b/404.html
@@ -95,7 +95,7 @@
 <meta content="https://santis-club.com/assets/img/og-standard.webp" property="og:image"/>
 <meta content="https://santis-club.com/404.html" property="og:url"/>
 <meta content="website" property="og:type"/>
-</meta></meta><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Santis Club • 404" name="twitter:title"/><meta content="Santis Club • 404 — Santis Club Spa &amp; Wellness deneyimi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/logo-santis.webp" name="twitter:image"/>
+<meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Santis Club • 404" name="twitter:title"/><meta content="Santis Club • 404 — Santis Club Spa &amp; Wellness deneyimi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/logo-santis.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
 </head>


### PR DESCRIPTION
## Summary

Fixes the HTML parsing warning in 404.html identified in the Phase F baseline audit (F1).

The issue was caused by stray </meta> tags which are invalid for void elements in HTML.

## Scope

- 404.html only
- Isolated syntax fix

## Verification

- pnpm build:mpa (parse5 warning gone)
- stitch:enforce (PASS)
- lint (PASS)
- test:e2e reservation (24/24 PASS)

## Governance

- No delete
- No archive
- No refactor