### PR TITLE
fix: refine Sovereign Guard enforcement scope

### DIFF
--- a/.github/workflows/sovereign-guard.yml
+++ b/.github/workflows/sovereign-guard.yml
@@ -37,8 +37,14 @@ jobs:
 
       - name: Enforce pnpm exclusivity
         run: |
-          if [ -f package-lock.json ] || [ -f yarn.lock ]; then
+          forbidden_lockfiles=$(find . \
+            -path './node_modules' -prune -o \
+            -path './.git' -prune -o \
+            -name 'package-lock.json' -print -o \
+            -name 'yarn.lock' -print)
+          if [ -n "$forbidden_lockfiles" ]; then
             echo "Only pnpm lockfile is allowed in Santis OS."
+            echo "$forbidden_lockfiles"
             exit 1
           fi
 
@@ -70,14 +76,19 @@ jobs:
           const ignoredDirs = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
           const patterns = [
             { label: 'Wildcard CORS origin detected', regex: /origin\s*:\s*['"]\*['"]/ },
-            { label: 'Wildcard Access-Control-Allow-Origin detected', regex: /Access-Control-Allow-Origin['"]?\s*[:,]\s*['"]\*/ },
-            { label: 'Unsafe Zod passthrough detected', regex: /\.passthrough\(\)/ }
+            { label: 'Wildcard Access-Control-Allow-Origin detected', regex: /Access-Control-Allow-Origin['"]?\s*[:,]\s*['"]\*/ }
           ];
+          const passthroughRestrictedRoots = ['packages/event-dictionary/src'];
+          const passthroughPattern = /\.passthrough\(\)/;
           const violations = [];
 
           function extensionOf(filePath) {
             const match = filePath.match(/\.[^.]+$/);
             return match ? match[0] : '';
+          }
+
+          function isWithinRestrictedPassthroughRoot(filePath) {
+            return passthroughRestrictedRoots.some((root) => filePath.startsWith(root));
           }
 
           function walk(path) {
@@ -100,6 +111,10 @@ jobs:
                 if (pattern.regex.test(line)) {
                   violations.push(`${path}:${index + 1}: ${pattern.label}`);
                 }
+              }
+
+              if (isWithinRestrictedPassthroughRoot(path) && passthroughPattern.test(line)) {
+                violations.push(`${path}:${index + 1}: Unsafe Zod passthrough detected`);
               }
             });
           }

--- a/.github/workflows/sovereign-guard.yml
+++ b/.github/workflows/sovereign-guard.yml
@@ -38,12 +38,18 @@ jobs:
       - name: Enforce pnpm exclusivity
         run: |
           forbidden_lockfiles=$(find . \
-            -path './node_modules' -prune -o \
-            -path './.git' -prune -o \
-            -name 'package-lock.json' -print -o \
-            -name 'yarn.lock' -print)
+            \( -path './node_modules' -o \
+               -path './.git' -o \
+               -path './_archive' -o \
+               -path './dist' -o \
+               -path './build' -o \
+               -path './.next' -o \
+               -path './coverage' \) -prune -o \
+            \( -name 'package-lock.json' -o -name 'yarn.lock' -o -name 'bun.lockb' \) -print)
           if [ -n "$forbidden_lockfiles" ]; then
-            echo "Only pnpm lockfile is allowed in Santis OS."
+            echo "SOVEREIGN GUARD VIOLATION: Dependency Detox failed."
+            echo "Only pnpm-lock.yaml is allowed in active Santis OS workspaces."
+            echo "Forbidden lockfiles detected:"
             echo "$forbidden_lockfiles"
             exit 1
           fi


### PR DESCRIPTION
## Why

Follow-up fixes after automated review feedback on PR #174.

## Fixes included

### pnpm exclusivity

The original implementation only checked the repository root.

This PR now scans the full monorepo tree for:

- package-lock.json
- yarn.lock

while ignoring `.git` and `node_modules`.

### passthrough governance

The original implementation globally blocked `.passthrough()`.

That immediately conflicts with existing runtime-guard code already present in the repository.

This PR restores deterministic enforcement scope:

- `.passthrough()` is blocked only inside:
  - `packages/event-dictionary/src`

This preserves existing runtime compatibility while still enforcing strict schemas in canonical contract layers.

## Santis Governance

Truth Layer enforcement must be strict, but also reality-aware.
