### PR TITLE
fix(html): add module type to rituals scripts (F2.1 pilot)

### DIFF
--- a/tr/rituals/deluxe-imperial/index.html
+++ b/tr/rituals/deluxe-imperial/index.html
@@ -20,8 +20,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="bg-[#050505] text-white selection:bg-[#D4AF37] selection:text-black overflow-x-hidden antialiased">

--- a/tr/rituals/derin-detoks-paketi.html
+++ b/tr/rituals/derin-detoks-paketi.html
@@ -7,7 +7,7 @@
     <title>Santis Club | Derin Detoks Paketi</title>
     <!-- CSS & Core System -->
     <link rel="stylesheet" href="/assets/css/style.css">
-    <script src="/assets/js/santis-vitals.js" async></script>
+    <script type="module" src="/assets/js/santis-vitals.js" async></script>
     <script type="speculationrules">
     {
       "prerender": [
@@ -70,7 +70,7 @@
 
     <!-- JS Yüklemeleri -->
     <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
     if (typeof GhostConcierge !== 'undefined') {
@@ -78,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 </script>
-<script src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
+<script type="module" src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/rituals/index.html
+++ b/tr/rituals/index.html
@@ -54,7 +54,7 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
 <link href="https://santis-club.com/tr/rituals/index.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/rituals/index.html" hreflang="x-default" rel="alternate"/>
 <!-- RUM: Core Web Vitals Gözlemcisi -->
-<script src="/assets/js/santis-vitals.js" async></script>
+<script type="module" src="/assets/js/santis-vitals.js" async></script>
 
 <!-- Phase 6: Fluid Space Engine (Speculation Rules API) -->
 <script type="speculationrules">
@@ -76,8 +76,8 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode" data-page="rituals">
@@ -137,7 +137,7 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
       <p style="color:#666;font-size:.875rem;line-height:1.8">
         Santis Club Sovereign Ritüelleri, Antalya'nın en lüks spa deneyimini sunar.
         Hamam, masaj ve cilt bakımını tek bir bütüncül yolculukta birleştiren journey paketlerimiz,
-        gerçek bir dönüşüm için tasarlanmıştır. Uzman terapistlerimiz ve özel Sothys Paris ürünleriyle
+        gerçek bir dönüşüm için tasarlandı. Uzman terapistlerimiz ve özel Sothys Paris ürünleriyle
         bedeninizi ve zihninizi yeniden keşfedin.
       </p>
     </div>
@@ -172,10 +172,10 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
 <div id="footer-container"></div>
 
 <!-- CORE SCRIPTS -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
-<script src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
+<script type="module" src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V18 KERNEL) -->
 

--- a/tr/rituals/sovereign-purification/index.html
+++ b/tr/rituals/sovereign-purification/index.html
@@ -20,8 +20,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="bg-[#050505] text-white selection:bg-[#D4AF37] selection:text-black overflow-x-hidden antialiased">

--- a/tr/rituals/sultan-ritueli-paketi.html
+++ b/tr/rituals/sultan-ritueli-paketi.html
@@ -7,8 +7,8 @@
     <title>Santis Club | Sultan Ritüeli Paketi</title>
     <!-- CSS & Core System -->
     <link rel="stylesheet" href="/assets/css/style.css">
-    <script src="/assets/js/santis-vitals.js" async></script>
-    <script src="/assets/js/core/santis-speculation.js" defer></script>
+    <script type="module" src="/assets/js/santis-vitals.js" async></script>
+    <script type="module" src="/assets/js/core/santis-speculation.js" defer></script>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
 <script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
@@ -55,7 +55,7 @@
 
     <!-- JS Yüklemeleri -->
     <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
     if (typeof GhostConcierge !== 'undefined') {
@@ -63,7 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 </script>
-<script src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
+<script type="module" src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/rituals/zen-zihin-paketi.html
+++ b/tr/rituals/zen-zihin-paketi.html
@@ -56,7 +56,7 @@
 
     <!-- JS Yüklemeleri -->
     <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
     if (typeof GhostConcierge !== 'undefined') {
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 </script>
-<script src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
+<script type="module" src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>


### PR DESCRIPTION
﻿## Summary

Adds type="module" to local Santis script tags in the tr/rituals pilot batch.

## Scope

- tr/rituals/index.html
- tr/rituals/zen-zihin-paketi.html
- tr/rituals/sultan-ritueli-paketi.html
- tr/rituals/derin-detoks-paketi.html
- tr/rituals/deluxe-imperial/index.html
- tr/rituals/sovereign-purification/index.html

No bulk rollout.
No public/admin changes.
No delete.
No archive.
No refactor.

## Verification

- pnpm build:mpa — PASS
- pnpm run stitch:enforce — PASS
- pnpm run lint — PASS
- pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts — 24/24 PASS

## Governance

This is the F2.1 pilot only. Wider F2 rollout requires a separate authorization after this PR is reviewed and merged.
