### PR TITLE
fix(html): add module type to hamam scripts (F2.2 batch)

### DIFF
--- a/tr/hamam/bal-masaji.html
+++ b/tr/hamam/bal-masaji.html
@@ -71,8 +71,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -124,7 +124,7 @@
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/hamam/cikolata-bakimi.html
+++ b/tr/hamam/cikolata-bakimi.html
@@ -74,8 +74,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -123,7 +123,7 @@
 </div>
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hamam/index.html
+++ b/tr/hamam/index.html
@@ -229,7 +229,7 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
     </script>
     <!-- /SCHEMA SYNC -->
     <!-- RUM: Core Web Vitals Gözlemcisi -->
-    <script src="/assets/js/santis-vitals.js" async></script>
+    <script type="module" src="/assets/js/santis-vitals.js" async></script>
 
     <!-- Phase 6: Fluid Space Engine (Speculation Rules API) -->
     <script type="speculationrules">
@@ -251,8 +251,8 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-hydro solid-nav-page" data-page="hamam">
@@ -428,13 +428,14 @@ a:focus-visible, button:focus-visible { outline: 2px solid #d4af37; outline-offs
 </footer>
 
 <!-- CORE SCRIPTS -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
-<script src="/assets/js/core/bento-orchestrator.js" defer></script>
-<script src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
+<script type="module" src="/assets/js/core/bento-orchestrator.js" defer></script>
+<script type="module" src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>
 </body>
 </html>
+

--- a/tr/hamam/kahve-detox.html
+++ b/tr/hamam/kahve-detox.html
@@ -63,8 +63,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="cinematic-mode">
@@ -166,8 +166,8 @@
 <div id="footer-container"></div>
 <!-- SCRIPTS -->
 <!-- Page Specific Engines -->
-<script src="/assets/js/santis-accordion.js"></script>
-<script src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
+<script type="module" src="/assets/js/santis-accordion.js"></script>
+<script type="module" src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
 <script type="module" src="/assets/js/core/santis-core.js"></script>
     <script defer="" src="/assets/js/app.js"></script>
 

--- a/tr/hamam/kahve-peeling.html
+++ b/tr/hamam/kahve-peeling.html
@@ -58,8 +58,8 @@
 </script><link href="https://santisclub.com/tr/hamam/kahve-peeling.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Kahve Detox &amp; Peeling | Santis Club" property="og:title"/><meta content="Türk kahvesinin canlandırıcı etkisiyle cildinizi uyandırın. Selülit karşıtı ve sıkılaştırıcı bakım." property="og:description"/><meta content="https://santis-club.com/tr/hamam/kahve-peeling.html" property="og:url"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hamam_kese_v2.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Kahve Detox &amp; Peeling | Santis Club" name="twitter:title"/><meta content="Türk kahvesinin canlandırıcı etkisiyle cildinizi uyandırın. Selülit karşıtı ve sıkılaştırıcı bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hamam_kese_v2.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -111,7 +111,7 @@
 </div>
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hamam/kese-kopuk.html
+++ b/tr/hamam/kese-kopuk.html
@@ -63,8 +63,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="cinematic-mode">
@@ -166,8 +166,8 @@
 <div id="footer-container"></div>
 <!-- SCRIPTS -->
 <!-- Page Specific Engines -->
-<script src="/assets/js/santis-accordion.js"></script>
-<script src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
+<script type="module" src="/assets/js/santis-accordion.js"></script>
+<script type="module" src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
 <script type="module" src="/assets/js/core/santis-core.js"></script>
     <script defer="" src="/assets/js/app.js"></script>
 

--- a/tr/hamam/kese-ve-kopuk-masaji.html
+++ b/tr/hamam/kese-ve-kopuk-masaji.html
@@ -63,8 +63,8 @@
 </script><link href="https://santisclub.com/tr/hamam/kese-ve-kopuk-masaji.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Geleneksel Kese &amp; Köpük | Santis Club" property="og:title"/><meta content="Santis Club hamamında asırlık arınma ritüeli. Derinlemesine kese ve ipeksi köpük masajı ile yenilenin." property="og:description"/><meta content="https://santis-club.com/tr/hamam/kese-ve-kopuk-masaji.html" property="og:url"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hammam_lux.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Geleneksel Kese &amp; Köpük | Santis Club" name="twitter:title"/><meta content="Santis Club hamamında asırlık arınma ritüeli. Derinlemesine kese ve ipeksi köpük masajı ile yenilenin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hammam_lux.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -168,9 +168,9 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/page-init.js"></script> <!-- TELEMETRY & INIT -->
+<script type="module" src="/assets/js/page-init.js"></script> <!-- TELEMETRY & INIT -->
 <!-- PAGE SPECIFIC LOGIC -->
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 <!-- SMOOTH SCROLL -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/hamam/kopuk-masaji.html
+++ b/tr/hamam/kopuk-masaji.html
@@ -73,8 +73,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -121,7 +121,7 @@
 </div>
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hamam/osmanli-hamam-gelenegi.html
+++ b/tr/hamam/osmanli-hamam-gelenegi.html
@@ -63,8 +63,8 @@
 </script><link href="https://santisclub.com/tr/hamam/osmanli-hamam-gelenegi.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Osmanlı Ritüeli | Santis Club" property="og:title"/><meta content="Sultanlara layık bir deneyim. Geleneksel kese, köpük ve özel kil maskesi ile tam bir arınma yolculuğu." property="og:description"/><meta content="https://santis-club.com/tr/hamam/osmanli-ritueli.html" property="og:url"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hammam_v1.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Osmanlı Ritüeli | Santis Club" name="twitter:title"/><meta content="Sultanlara layık bir deneyim. Geleneksel kese, köpük ve özel kil maskesi ile tam bir arınma yolculuğu." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/santis_card_hammam_v1.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -157,7 +157,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hamam/osmanli-ritueli.html
+++ b/tr/hamam/osmanli-ritueli.html
@@ -63,8 +63,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="cinematic-mode">
@@ -166,8 +166,8 @@
 <div id="footer-container"></div>
 <!-- SCRIPTS -->
 <!-- Page Specific Engines -->
-<script src="/assets/js/santis-accordion.js"></script>
-<script src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
+<script type="module" src="/assets/js/santis-accordion.js"></script>
+<script type="module" src="/assets/js/pages/service-detail-init.js"></script> <!-- CONTROLLER -->
 <script type="module" src="/assets/js/core/santis-core.js"></script>
     <script defer="" src="/assets/js/app.js"></script>
 

--- a/tr/hamam/santis-pasa.html
+++ b/tr/hamam/santis-pasa.html
@@ -105,8 +105,8 @@ body { margin: 0; background-color: #f4f3f1; font-family: 'Cormorant Garamond', 
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -192,7 +192,7 @@ body { margin: 0; background-color: #f4f3f1; font-family: 'Cormorant Garamond', 
 </div>
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
-<script src="/assets/js/pages/hammam-detail.js" defer></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js" defer></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hamam/tuz-peeling.html
+++ b/tr/hamam/tuz-peeling.html
@@ -73,8 +73,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -122,7 +122,7 @@
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/hamam/yosun-bakimi.html
+++ b/tr/hamam/yosun-bakimi.html
@@ -14,7 +14,7 @@
 <link href="/assets/css/atmospheres.css" rel="stylesheet"/>
 <link href="/assets/css/service-detail.css" rel="stylesheet"/>
 <link href="/favicon.ico" rel="icon"/>
-<script src="/assets/js/santis-api.js"></script>
+<script type="module" src="/assets/js/santis-api.js"></script>
 <link href="https://santis-club.com/tr/hamam/yosun-bakimi.html" rel="canonical"/>
 <script type="application/ld+json">
 {
@@ -56,8 +56,8 @@
 </script><link href="https://santisclub.com/tr/hamam/yosun-bakimi.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Yosun Bakımı (Algae) | Santis Club" property="og:title"/><meta content="Detoks etkili deniz yosunu sargılama ile derinlemesine arınma ve sıkılaşma." property="og:description"/><meta content="https://santis-club.com/tr/hamam/yosun-bakimi.html" property="og:url"/><meta content="https://santisclub.com/assets/img/cards/santis_card_skincare_clay_v2.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Yosun Bakımı (Algae) | Santis Club" name="twitter:title"/><meta content="Detoks etkili deniz yosunu sargılama ile derinlemesine arınma ve sıkılaşma." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/santis_card_skincare_clay_v2.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode world-standard">
@@ -105,7 +105,7 @@
 </main>
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
-<script src="/assets/js/pages/hammam-detail.js"></script>
+<script type="module" src="/assets/js/pages/hammam-detail.js"></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>


### PR DESCRIPTION
﻿## Summary

Adds type="module" to local Santis script tags in the tr/hamam/ pilot-extension batch.

## Scope: tr/hamam/ (13 files)

- bal-masaji.html
- cikolata-bakimi.html
- index.html
- kahve-detox.html
- kahve-peeling.html
- kese-kopuk.html
- kese-ve-kopuk-masaji.html
- kopuk-masaji.html
- osmanli-hamam-gelenegi.html
- osmanli-ritueli.html
- santis-pasa.html
- tuz-peeling.html
- yosun-bakimi.html

No bulk rollout.
No public/admin changes.
No delete.
No archive.
No refactor.

## Verification

- pnpm build:mpa — PASS
- pnpm run stitch:enforce — PASS
- pnpm run lint — PASS
- pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts — 24/24 PASS

## Governance

This is the F2.2 hamam batch. Subsequent batches (masajlar, cilt-bakimi) will follow in separate PRs.
