### PR TITLE
fix(html): add module type to cilt-bakimi scripts (F2.4 batch)

### DIFF
--- a/tr/cilt-bakimi/acne-balance.html
+++ b/tr/cilt-bakimi/acne-balance.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/acne-balance.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/acne-balance.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/anti-aging-pro.html
+++ b/tr/cilt-bakimi/anti-aging-pro.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/anti-aging-pro.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/anti-aging-pro.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/barrier-repair.html
+++ b/tr/cilt-bakimi/barrier-repair.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/barrier-repair.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/barrier-repair.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/brightening-spot.html
+++ b/tr/cilt-bakimi/brightening-spot.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/brightening-spot.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/brightening-spot.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/classic-facial.html
+++ b/tr/cilt-bakimi/classic-facial.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/classic-facial.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/classic-facial.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/collagen-lift.html
+++ b/tr/cilt-bakimi/collagen-lift.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/collagen-lift.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/collagen-lift.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/deep-cleanse.html
+++ b/tr/cilt-bakimi/deep-cleanse.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/deep-cleanse.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/deep-cleanse.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/detox-charcoal.html
+++ b/tr/cilt-bakimi/detox-charcoal.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/detox-charcoal.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/detox-charcoal.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/enzyme-peel.html
+++ b/tr/cilt-bakimi/enzyme-peel.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/enzyme-peel.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/enzyme-peel.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/eye-contour.html
+++ b/tr/cilt-bakimi/eye-contour.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/eye-contour.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/eye-contour.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/glass-skin.html
+++ b/tr/cilt-bakimi/glass-skin.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/glass-skin.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/glass-skin.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/gold-mask-ritual.html
+++ b/tr/cilt-bakimi/gold-mask-ritual.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/gold-mask-ritual.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/gold-mask-ritual.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/hyaluron-hydrate.html
+++ b/tr/cilt-bakimi/hyaluron-hydrate.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/hyaluron-hydrate.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/hyaluron-hydrate.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/index.html
+++ b/tr/cilt-bakimi/index.html
@@ -220,8 +220,8 @@
 <meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Cilt Bakımı | Santis Club Spa &amp; Wellness • Santis Club" name="twitter:title"/><meta content="Sothys Paris ürünleri ile profesyonel cilt bakım ritüelleri. Klasik bakım, anti-aging, glass skin ve daha fazlası." name="twitter:description"/><meta content="https://santisclub.com/assets/img/cards/santis_hero_skincare_lux.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode solid-nav-page" data-page="skincare">
@@ -297,12 +297,12 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 <!-- OMNI-OS V5 MASTER KERNEL -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-<script src="/assets/js/app.js" defer></script>
+<script type="module" src="/assets/js/app.js" defer></script>
 <script type="module" src="/assets/js/pages/chip-filter.js"></script>
-<script src="/assets/js/core/bento-orchestrator.js" defer></script>
-<script src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
+<script type="module" src="/assets/js/core/bento-orchestrator.js" defer></script>
+<script type="module" src="/assets/js/category-page-seal.js?v=7711942b" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V18 KERNEL) -->
 

--- a/tr/cilt-bakimi/led-rejuvenation.html
+++ b/tr/cilt-bakimi/led-rejuvenation.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/led-rejuvenation.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/led-rejuvenation.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/lip-care.html
+++ b/tr/cilt-bakimi/lip-care.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/lip-care.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/lip-care.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/men-facial.html
+++ b/tr/cilt-bakimi/men-facial.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/men-facial.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/men-facial.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/micro-polish.html
+++ b/tr/cilt-bakimi/micro-polish.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/micro-polish.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/micro-polish.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/oxygen-boost.html
+++ b/tr/cilt-bakimi/oxygen-boost.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/oxygen-boost.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/oxygen-boost.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-detox-lumiere.html
+++ b/tr/cilt-bakimi/rituel-detox-lumiere.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-detox-lumiere.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Detox &amp; Brightening Ritual | Santis Skin Care" property="og:title"/><meta content="A comprehensive ritual to detoxify and illuminate your skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-detox-lumiere.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Detox &amp; Brightening Ritual | Santis Skin Care" name="twitter:title"/><meta content="A comprehensive ritual to detoxify and illuminate your skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-detox-lumiere.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Detox &amp; Brightening Ritual | Santis Skin Care" property="og:title"/><meta content="A comprehensive ritual to detoxify and illuminate your skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-detox-lumiere.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Detox &amp; Brightening Ritual | Santis Skin Care" name="twitter:title"/><meta content="A comprehensive ritual to detoxify and illuminate your skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-diamant-eternel.html
+++ b/tr/cilt-bakimi/rituel-diamant-eternel.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-diamant-eternel.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Diamond Facial Ritual | Santis Skin Care" property="og:title"/><meta content="The pinnacle of luxury. Diamond-infused care for eternal radiance." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-diamant-eternel.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Diamond Facial Ritual | Santis Skin Care" name="twitter:title"/><meta content="The pinnacle of luxury. Diamond-infused care for eternal radiance." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-diamant-eternel.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Diamond Facial Ritual | Santis Skin Care" property="og:title"/><meta content="The pinnacle of luxury. Diamond-infused care for eternal radiance." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-diamant-eternel.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Diamond Facial Ritual | Santis Skin Care" name="twitter:title"/><meta content="The pinnacle of luxury. Diamond-infused care for eternal radiance." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-homme-classique.html
+++ b/tr/cilt-bakimi/rituel-homme-classique.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-classique.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Classic Men's Facial | Santis Skin Care" property="og:title"/><meta content="Effective and straightforward skincare maintenance for men." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-classique.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Classic Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Effective and straightforward skincare maintenance for men." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-classique.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Classic Men's Facial | Santis Skin Care" property="og:title"/><meta content="Effective and straightforward skincare maintenance for men." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-classique.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Classic Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Effective and straightforward skincare maintenance for men." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-homme-equilibre.html
+++ b/tr/cilt-bakimi/rituel-homme-equilibre.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-equilibre.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Balancing Men's Facial | Santis Skin Care" property="og:title"/><meta content="Restore balance to oily or irritated male skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-equilibre.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Balancing Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Restore balance to oily or irritated male skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-equilibre.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Balancing Men's Facial | Santis Skin Care" property="og:title"/><meta content="Restore balance to oily or irritated male skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-equilibre.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Balancing Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Restore balance to oily or irritated male skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-homme-force-calme.html
+++ b/tr/cilt-bakimi/rituel-homme-force-calme.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-force-calme.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Calming Men's Facial | Santis Skin Care" property="og:title"/><meta content="Strengthen and calm your skin with this relaxing men's ritual." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-force-calme.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Calming Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Strengthen and calm your skin with this relaxing men's ritual." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-homme-force-calme.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Calming Men's Facial | Santis Skin Care" property="og:title"/><meta content="Strengthen and calm your skin with this relaxing men's ritual." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-homme-force-calme.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Calming Men's Facial | Santis Skin Care" name="twitter:title"/><meta content="Strengthen and calm your skin with this relaxing men's ritual." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/charcoal.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-hydra-confort.html
+++ b/tr/cilt-bakimi/rituel-hydra-confort.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-confort.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hydra-Confort Facial | Santis Skin Care" property="og:title"/><meta content="Deep comfort and hydration for dry skin types." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-confort.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hydra-Confort Facial | Santis Skin Care" name="twitter:title"/><meta content="Deep comfort and hydration for dry skin types." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-confort.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hydra-Confort Facial | Santis Skin Care" property="og:title"/><meta content="Deep comfort and hydration for dry skin types." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-confort.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hydra-Confort Facial | Santis Skin Care" name="twitter:title"/><meta content="Deep comfort and hydration for dry skin types." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-hydra-source.html
+++ b/tr/cilt-bakimi/rituel-hydra-source.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-source.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hydration Source Facial | Santis Skin Care" property="og:title"/><meta content="Refreshing hydration for thirsty skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-source.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/water.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hydration Source Facial | Santis Skin Care" name="twitter:title"/><meta content="Refreshing hydration for thirsty skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/water.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-source.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hydration Source Facial | Santis Skin Care" property="og:title"/><meta content="Refreshing hydration for thirsty skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-source.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/water.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hydration Source Facial | Santis Skin Care" name="twitter:title"/><meta content="Refreshing hydration for thirsty skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/water.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-hydra-sublime.html
+++ b/tr/cilt-bakimi/rituel-hydra-sublime.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-sublime.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Sublime Hydration Facial | Santis Skin Care" property="og:title"/><meta content="Experience the ultimate in skin hydration and relaxation." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-sublime.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/water.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Sublime Hydration Facial | Santis Skin Care" name="twitter:title"/><meta content="Experience the ultimate in skin hydration and relaxation." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/water.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-hydra-sublime.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Sublime Hydration Facial | Santis Skin Care" property="og:title"/><meta content="Experience the ultimate in skin hydration and relaxation." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-hydra-sublime.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/water.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Sublime Hydration Facial | Santis Skin Care" name="twitter:title"/><meta content="Experience the ultimate in skin hydration and relaxation." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/water.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-jeunesse-initiale.html
+++ b/tr/cilt-bakimi/rituel-jeunesse-initiale.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-jeunesse-initiale.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Early Anti-Aging Facial | Santis Skin Care" property="og:title"/><meta content="Preserve your youth with our Initial Youth defense ritual." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-jeunesse-initiale.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Early Anti-Aging Facial | Santis Skin Care" name="twitter:title"/><meta content="Preserve your youth with our Initial Youth defense ritual." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-jeunesse-initiale.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Early Anti-Aging Facial | Santis Skin Care" property="og:title"/><meta content="Preserve your youth with our Initial Youth defense ritual." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-jeunesse-initiale.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Early Anti-Aging Facial | Santis Skin Care" name="twitter:title"/><meta content="Preserve your youth with our Initial Youth defense ritual." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-jeunesse-supreme.html
+++ b/tr/cilt-bakimi/rituel-jeunesse-supreme.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-jeunesse-supreme.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Supreme Anti-Aging Facial | Santis Skin Care" property="og:title"/><meta content="Comprehensive anti-aging correction for supreme youthfulness." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-jeunesse-supreme.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Supreme Anti-Aging Facial | Santis Skin Care" name="twitter:title"/><meta content="Comprehensive anti-aging correction for supreme youthfulness." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-jeunesse-supreme.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Supreme Anti-Aging Facial | Santis Skin Care" property="og:title"/><meta content="Comprehensive anti-aging correction for supreme youthfulness." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-jeunesse-supreme.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Supreme Anti-Aging Facial | Santis Skin Care" name="twitter:title"/><meta content="Comprehensive anti-aging correction for supreme youthfulness." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/gold.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-purete-classique.html
+++ b/tr/cilt-bakimi/rituel-purete-classique.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-purete-classique.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Classic Purity Facial | Santis Skin Care" property="og:title"/><meta content="Balance and purify combination skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-purete-classique.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Classic Purity Facial | Santis Skin Care" name="twitter:title"/><meta content="Balance and purify combination skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-purete-classique.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Classic Purity Facial | Santis Skin Care" property="og:title"/><meta content="Balance and purify combination skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-purete-classique.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Classic Purity Facial | Santis Skin Care" name="twitter:title"/><meta content="Balance and purify combination skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/rituel-purete-profonde.html
+++ b/tr/cilt-bakimi/rituel-purete-profonde.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-purete-profonde.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Deep Purity Facial | Santis Skin Care" property="og:title"/><meta content="Intense regulation for oily and congestion-prone skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-purete-profonde.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Deep Purity Facial | Santis Skin Care" name="twitter:title"/><meta content="Intense regulation for oily and congestion-prone skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/rituel-purete-profonde.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Deep Purity Facial | Santis Skin Care" property="og:title"/><meta content="Intense regulation for oily and congestion-prone skin." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/rituel-purete-profonde.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/green.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Deep Purity Facial | Santis Skin Care" name="twitter:title"/><meta content="Intense regulation for oily and congestion-prone skin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/green.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -116,7 +116,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/sensitive-soothe.html
+++ b/tr/cilt-bakimi/sensitive-soothe.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/sensitive-soothe.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/sensitive-soothe.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-acne-balance.html
+++ b/tr/cilt-bakimi/skin-acne-balance.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-acne-balance.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Akne &amp; Sebum Denge Bakımı" property="og:title"/><meta content="Arındırma + dengeleme — yağlı/karma ciltler için hedefli bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-acne-balance.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Akne &amp; Sebum Denge Bakımı" name="twitter:title"/><meta content="Arındırma + dengeleme — yağlı/karma ciltler için hedefli bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-acne-balance.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Akne &amp; Sebum Denge Bakımı" property="og:title"/><meta content="Arındırma + dengeleme — yağlı/karma ciltler için hedefli bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-acne-balance.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Akne &amp; Sebum Denge Bakımı" name="twitter:title"/><meta content="Arındırma + dengeleme — yağlı/karma ciltler için hedefli bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-anti-aging-pro.html
+++ b/tr/cilt-bakimi/skin-anti-aging-pro.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-anti-aging-pro.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Anti-Aging Pro Bakım" property="og:title"/><meta content="İnce çizgi görünümü hedefleyen kapsamlı protokol." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-anti-aging-pro.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Anti-Aging Pro Bakım" name="twitter:title"/><meta content="İnce çizgi görünümü hedefleyen kapsamlı protokol." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-anti-aging-pro.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Anti-Aging Pro Bakım" property="og:title"/><meta content="İnce çizgi görünümü hedefleyen kapsamlı protokol." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-anti-aging-pro.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Anti-Aging Pro Bakım" name="twitter:title"/><meta content="İnce çizgi görünümü hedefleyen kapsamlı protokol." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-barrier-repair.html
+++ b/tr/cilt-bakimi/skin-barrier-repair.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-barrier-repair.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Bariyer Onarıcı Bakım" property="og:title"/><meta content="Kuruluk ve gerginlik için destek — cilt bariyerini yeniden inşa eder." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-barrier-repair.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Bariyer Onarıcı Bakım" name="twitter:title"/><meta content="Kuruluk ve gerginlik için destek — cilt bariyerini yeniden inşa eder." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-barrier-repair.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Bariyer Onarıcı Bakım" property="og:title"/><meta content="Kuruluk ve gerginlik için destek — cilt bariyerini yeniden inşa eder." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-barrier-repair.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Bariyer Onarıcı Bakım" name="twitter:title"/><meta content="Kuruluk ve gerginlik için destek — cilt bariyerini yeniden inşa eder." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-brightening-spot.html
+++ b/tr/cilt-bakimi/skin-brightening-spot.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-brightening-spot.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Leke Karşıtı Aydınlatıcı Bakım" property="og:title"/><meta content="Ton eşitleme odaklı — daha homojen bir görünüm için." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-brightening-spot.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Leke Karşıtı Aydınlatıcı Bakım" name="twitter:title"/><meta content="Ton eşitleme odaklı — daha homojen bir görünüm için." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-brightening-spot.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Leke Karşıtı Aydınlatıcı Bakım" property="og:title"/><meta content="Ton eşitleme odaklı — daha homojen bir görünüm için." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-brightening-spot.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Leke Karşıtı Aydınlatıcı Bakım" name="twitter:title"/><meta content="Ton eşitleme odaklı — daha homojen bir görünüm için." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-classic-facial.html
+++ b/tr/cilt-bakimi/skin-classic-facial.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-classic-facial.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Klasik Cilt Bakımı" property="og:title"/><meta content="Temizleme + tonik + maske — cildi dengeler, canlılık kazandırır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-classic-facial.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Klasik Cilt Bakımı" name="twitter:title"/><meta content="Temizleme + tonik + maske — cildi dengeler, canlılık kazandırır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-classic-facial.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Klasik Cilt Bakımı" property="og:title"/><meta content="Temizleme + tonik + maske — cildi dengeler, canlılık kazandırır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-classic-facial.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Klasik Cilt Bakımı" name="twitter:title"/><meta content="Temizleme + tonik + maske — cildi dengeler, canlılık kazandırır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-collagen-lift.html
+++ b/tr/cilt-bakimi/skin-collagen-lift.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-collagen-lift.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Kolajen Lifting Bakımı" property="og:title"/><meta content="Sıkılık hissi ve toparlanma — yorgun görünümü azaltır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-collagen-lift.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Kolajen Lifting Bakımı" name="twitter:title"/><meta content="Sıkılık hissi ve toparlanma — yorgun görünümü azaltır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-collagen-lift.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Kolajen Lifting Bakımı" property="og:title"/><meta content="Sıkılık hissi ve toparlanma — yorgun görünümü azaltır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-collagen-lift.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Kolajen Lifting Bakımı" name="twitter:title"/><meta content="Sıkılık hissi ve toparlanma — yorgun görünümü azaltır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-deep-cleanse.html
+++ b/tr/cilt-bakimi/skin-deep-cleanse.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-deep-cleanse.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Derin Temizleme Bakımı" property="og:title"/><meta content="Gözenek odaklı arındırma — siyah nokta ve sebum dengesi." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-deep-cleanse.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Derin Temizleme Bakımı" name="twitter:title"/><meta content="Gözenek odaklı arındırma — siyah nokta ve sebum dengesi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-deep-cleanse.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Derin Temizleme Bakımı" property="og:title"/><meta content="Gözenek odaklı arındırma — siyah nokta ve sebum dengesi." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-deep-cleanse.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Derin Temizleme Bakımı" name="twitter:title"/><meta content="Gözenek odaklı arındırma — siyah nokta ve sebum dengesi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-detox-charcoal.html
+++ b/tr/cilt-bakimi/skin-detox-charcoal.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-detox-charcoal.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Detox Kömür Maske" property="og:title"/><meta content="Şehir yorgunluğuna karşı arındırma — matlığı azaltır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-detox-charcoal.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Detox Kömür Maske" name="twitter:title"/><meta content="Şehir yorgunluğuna karşı arındırma — matlığı azaltır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-detox-charcoal.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Detox Kömür Maske" property="og:title"/><meta content="Şehir yorgunluğuna karşı arındırma — matlığı azaltır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-detox-charcoal.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Detox Kömür Maske" name="twitter:title"/><meta content="Şehir yorgunluğuna karşı arındırma — matlığı azaltır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-enzyme-peel.html
+++ b/tr/cilt-bakimi/skin-enzyme-peel.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-enzyme-peel.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Enzim Peeling Bakımı" property="og:title"/><meta content="Nazik yenileme — pürüzsüz görünüm ve ışıltı için cilt yenileme." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-enzyme-peel.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Enzim Peeling Bakımı" name="twitter:title"/><meta content="Nazik yenileme — pürüzsüz görünüm ve ışıltı için cilt yenileme." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-enzyme-peel.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Enzim Peeling Bakımı" property="og:title"/><meta content="Nazik yenileme — pürüzsüz görünüm ve ışıltı için cilt yenileme." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-enzyme-peel.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Enzim Peeling Bakımı" name="twitter:title"/><meta content="Nazik yenileme — pürüzsüz görünüm ve ışıltı için cilt yenileme." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-eye-contour.html
+++ b/tr/cilt-bakimi/skin-eye-contour.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-eye-contour.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Göz Çevresi Bakımı" property="og:title"/><meta content="Göz çevresine yoğun nem ve rahatlama — daha canlı bakış." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-eye-contour.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Göz Çevresi Bakımı" name="twitter:title"/><meta content="Göz çevresine yoğun nem ve rahatlama — daha canlı bakış." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-eye-contour.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Göz Çevresi Bakımı" property="og:title"/><meta content="Göz çevresine yoğun nem ve rahatlama — daha canlı bakış." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-eye-contour.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Göz Çevresi Bakımı" name="twitter:title"/><meta content="Göz çevresine yoğun nem ve rahatlama — daha canlı bakış." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-glass-skin.html
+++ b/tr/cilt-bakimi/skin-glass-skin.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-glass-skin.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Glass Skin Ritüeli" property="og:title"/><meta content="Katmanlı nem + maske — cam gibi parlak, pürüzsüz bir cilt." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-glass-skin.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Glass Skin Ritüeli" name="twitter:title"/><meta content="Katmanlı nem + maske — cam gibi parlak, pürüzsüz bir cilt." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-glass-skin.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Glass Skin Ritüeli" property="og:title"/><meta content="Katmanlı nem + maske — cam gibi parlak, pürüzsüz bir cilt." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-glass-skin.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Glass Skin Ritüeli" name="twitter:title"/><meta content="Katmanlı nem + maske — cam gibi parlak, pürüzsüz bir cilt." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-gold-mask-ritual.html
+++ b/tr/cilt-bakimi/skin-gold-mask-ritual.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-gold-mask-ritual.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Gold Mask Ritüeli" property="og:title"/><meta content="Lüks maske + masaj — ışıl ışıl, dinlenmiş görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-gold-mask-ritual.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Gold Mask Ritüeli" name="twitter:title"/><meta content="Lüks maske + masaj — ışıl ışıl, dinlenmiş görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-gold-mask-ritual.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Gold Mask Ritüeli" property="og:title"/><meta content="Lüks maske + masaj — ışıl ışıl, dinlenmiş görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-gold-mask-ritual.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Gold Mask Ritüeli" name="twitter:title"/><meta content="Lüks maske + masaj — ışıl ışıl, dinlenmiş görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-hyaluron-hydrate.html
+++ b/tr/cilt-bakimi/skin-hyaluron-hydrate.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-hyaluron-hydrate.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hyaluron Nem Terapisi" property="og:title"/><meta content="Yoğun nem + dolgun görünüm — bariyeri destekler, cildi canlandırır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-hyaluron-hydrate.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hyaluron Nem Terapisi" name="twitter:title"/><meta content="Yoğun nem + dolgun görünüm — bariyeri destekler, cildi canlandırır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-hyaluron-hydrate.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hyaluron Nem Terapisi" property="og:title"/><meta content="Yoğun nem + dolgun görünüm — bariyeri destekler, cildi canlandırır." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-hyaluron-hydrate.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hyaluron Nem Terapisi" name="twitter:title"/><meta content="Yoğun nem + dolgun görünüm — bariyeri destekler, cildi canlandırır." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-led-rejuvenation.html
+++ b/tr/cilt-bakimi/skin-led-rejuvenation.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-led-rejuvenation.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="LED Rejuvenation" property="og:title"/><meta content="Işık desteğiyle bakım rutini — cilt görünümünü destekler." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-led-rejuvenation.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="LED Rejuvenation" name="twitter:title"/><meta content="Işık desteğiyle bakım rutini — cilt görünümünü destekler." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-led-rejuvenation.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="LED Rejuvenation" property="og:title"/><meta content="Işık desteğiyle bakım rutini — cilt görünümünü destekler." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-led-rejuvenation.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="LED Rejuvenation" name="twitter:title"/><meta content="Işık desteğiyle bakım rutini — cilt görünümünü destekler." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-lip-care.html
+++ b/tr/cilt-bakimi/skin-lip-care.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-lip-care.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Dudak Bakımı" property="og:title"/><meta content="Yumuşatma + bakım — pürüzsüz ve dolgun görünüm hissi." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-lip-care.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Dudak Bakımı" name="twitter:title"/><meta content="Yumuşatma + bakım — pürüzsüz ve dolgun görünüm hissi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-lip-care.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Dudak Bakımı" property="og:title"/><meta content="Yumuşatma + bakım — pürüzsüz ve dolgun görünüm hissi." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-lip-care.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Dudak Bakımı" name="twitter:title"/><meta content="Yumuşatma + bakım — pürüzsüz ve dolgun görünüm hissi." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-men-facial.html
+++ b/tr/cilt-bakimi/skin-men-facial.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-men-facial.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Erkek Cilt Bakımı" property="og:title"/><meta content="Tıraş sonrası hassasiyete uygun — temiz, dengeli ve mat görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-men-facial.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Erkek Cilt Bakımı" name="twitter:title"/><meta content="Tıraş sonrası hassasiyete uygun — temiz, dengeli ve mat görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-men-facial.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Erkek Cilt Bakımı" property="og:title"/><meta content="Tıraş sonrası hassasiyete uygun — temiz, dengeli ve mat görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-men-facial.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Erkek Cilt Bakımı" name="twitter:title"/><meta content="Tıraş sonrası hassasiyete uygun — temiz, dengeli ve mat görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-micro-polish.html
+++ b/tr/cilt-bakimi/skin-micro-polish.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-micro-polish.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Micro Polish Bakımı" property="og:title"/><meta content="Cilt yüzeyini pürüzsüzleştiren bakım — daha canlı ve parlak görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-micro-polish.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Micro Polish Bakımı" name="twitter:title"/><meta content="Cilt yüzeyini pürüzsüzleştiren bakım — daha canlı ve parlak görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-micro-polish.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Micro Polish Bakımı" property="og:title"/><meta content="Cilt yüzeyini pürüzsüzleştiren bakım — daha canlı ve parlak görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-micro-polish.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Micro Polish Bakımı" name="twitter:title"/><meta content="Cilt yüzeyini pürüzsüzleştiren bakım — daha canlı ve parlak görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-oxygen-boost.html
+++ b/tr/cilt-bakimi/skin-oxygen-boost.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-oxygen-boost.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Oksijen Boost Bakımı" property="og:title"/><meta content="Canlandırıcı etki — daha dinlenmiş ve parlak bir görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-oxygen-boost.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Oksijen Boost Bakımı" name="twitter:title"/><meta content="Canlandırıcı etki — daha dinlenmiş ve parlak bir görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-oxygen-boost.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Oksijen Boost Bakımı" property="og:title"/><meta content="Canlandırıcı etki — daha dinlenmiş ve parlak bir görünüm." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-oxygen-boost.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Oksijen Boost Bakımı" name="twitter:title"/><meta content="Canlandırıcı etki — daha dinlenmiş ve parlak bir görünüm." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-sensitive-soothe.html
+++ b/tr/cilt-bakimi/skin-sensitive-soothe.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-sensitive-soothe.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hassas Cilt Sakinleştirici Bakım" property="og:title"/><meta content="Kızarıklık ve hassasiyet hissini azaltmaya yönelik sakinleştirici bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-sensitive-soothe.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hassas Cilt Sakinleştirici Bakım" name="twitter:title"/><meta content="Kızarıklık ve hassasiyet hissini azaltmaya yönelik sakinleştirici bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-sensitive-soothe.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Hassas Cilt Sakinleştirici Bakım" property="og:title"/><meta content="Kızarıklık ve hassasiyet hissini azaltmaya yönelik sakinleştirici bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-sensitive-soothe.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hassas Cilt Sakinleştirici Bakım" name="twitter:title"/><meta content="Kızarıklık ve hassasiyet hissini azaltmaya yönelik sakinleştirici bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/skin-vitamin-c-glow.html
+++ b/tr/cilt-bakimi/skin-vitamin-c-glow.html
@@ -61,8 +61,8 @@
     }
   ]
 }
-</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-vitamin-c-glow.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Vitamin C Glow" property="og:title"/><meta content="Aydınlık ve taze görünüm — ışıltıyı artıran premium bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-vitamin-c-glow.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Vitamin C Glow" name="twitter:title"/><meta content="Aydınlık ve taze görünüm — ışıltıyı artıran premium bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+</script><link href="https://santisclub.com/tr/cilt-bakimi/skin-vitamin-c-glow.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="website" property="og:type"/><meta content="Vitamin C Glow" property="og:title"/><meta content="Aydınlık ve taze görünüm — ışıltıyı artıran premium bakım." property="og:description"/><meta content="https://santis-club.com/tr/cilt-bakimi/skin-vitamin-c-glow.html" property="og:url"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Vitamin C Glow" name="twitter:title"/><meta content="Aydınlık ve taze görünüm — ışıltıyı artıran premium bakım." name="twitter:description"/><meta content="https://santisclub.com/assets/img/textures/cream.webp" name="twitter:image"/><script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -115,7 +115,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 

--- a/tr/cilt-bakimi/vitamin-c-glow.html
+++ b/tr/cilt-bakimi/vitamin-c-glow.html
@@ -71,8 +71,8 @@
 
 <link href="https://santis-club.com/tr/cilt-bakimi/vitamin-c-glow.html" hreflang="tr" rel="alternate"/>
 <link href="https://santis-club.com/en/skincare/vitamin-c-glow.html" hreflang="x-default" rel="alternate"/>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode skincare-theme">
@@ -126,7 +126,7 @@
 <!-- FOOTER -->
 <div id="footer-container" style="position:relative; z-index:10; background:#0b0d11;"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/reflex/atmos.js"></script>
+<script type="module" src="/assets/js/reflex/atmos.js"></script>
 <!-- LOGIC -->
 <script src="https://cdn.jsdelivr.net/gh/studio-freight/lenis@1.0.29/bundled/lenis.min.js" crossorigin="anonymous"></script>
 


### PR DESCRIPTION
﻿## Summary

Adds type="module" to local Santis script tags in the tr/cilt-bakimi/ batch.

## Scope: tr/cilt-bakimi/ (53 files)

Includes the index page and all service pages in the skin care directory. Includes remediation for batch-specific scripts like atmos.js and language-switcher.js.

No bulk rollout.
No public/admin changes.
No delete.
No archive.
No refactor.

## Verification

- pnpm build:mpa — PASS
- pnpm run stitch:enforce — PASS
- pnpm run lint — PASS
- pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts — 24/24 PASS

## Governance

This is the F2.4 cilt-bakimi batch. Subsequent batches (tr root, public/admin) will follow in separate PRs.
