### PR TITLE
fix(html): add module type to core entry scripts (F2.5a batch)

### DIFF
--- a/tr/bilgelik/index.html
+++ b/tr/bilgelik/index.html
@@ -211,8 +211,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="journal-mode">
@@ -253,7 +253,7 @@
 <!-- FOOTER -->
 <div id="footer-container"></div>
 <!-- SCRIPTS -->
-<script src="/assets/js/blog-data.js"></script>
+<script type="module" src="/assets/js/blog-data.js"></script>
 <script>
         // JOURNAL RENDERER
         document.addEventListener('DOMContentLoaded', () => {
@@ -327,9 +327,9 @@
     </script>
 
 <!-- CORE SCRIPTS (Sovereign V18 Matrix) -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/blog/index.html
+++ b/tr/blog/index.html
@@ -18,7 +18,7 @@
 <link href="/assets/css/fonts.css" rel="stylesheet"/>
 <!-- PERFORMANCE -->
 <!-- DATA SOURCES --> <!-- Fallback for File Protocol -->
-<script src="/assets/js/blog-data.js"></script> <!-- ADMIN PANEL SOURCE -->
+<script type="module" src="/assets/js/blog-data.js"></script> <!-- ADMIN PANEL SOURCE -->
 <!-- ENGINE -->
 <script type="module" src="/assets/js/core/santis-core.js"></script>
     <script defer="" src="/assets/js/app.js"></script>
@@ -115,8 +115,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode">
@@ -306,9 +306,9 @@
     </script>
 
 <!-- CORE SCRIPTS (Sovereign V18 Matrix) -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/ekibimiz/index.html
+++ b/tr/ekibimiz/index.html
@@ -105,8 +105,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode">
@@ -212,9 +212,9 @@
      </script>
 
 <!-- CORE SCRIPTS (Sovereign V18 Matrix) -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/galeri/index.html
+++ b/tr/galeri/index.html
@@ -96,8 +96,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode">
@@ -162,7 +162,7 @@
 </div>
 <!-- CORE SCRIPTS (V8 OMEGA — Tek Giriş Noktası) -->
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/guest-zen/index.html
+++ b/tr/guest-zen/index.html
@@ -14,8 +14,8 @@
         .bento-card-dark { background: rgba(30, 30, 30, 0.6); backdrop-filter: blur(10px); border: 1px solid rgba(212, 175, 55, 0.2); border-radius: 12px; padding: 2rem; transition: transform 0.4s ease; }
         .bento-card-dark:hover { transform: translateY(-5px); border-color: rgba(212, 175, 55, 0.5); }
     </style>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="solid-nav-page" data-page="guest-zen">
@@ -89,8 +89,8 @@
 
     <!-- CORE SCRIPTS -->
     <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/core/view-transition-handler.js" defer></script>
-    <script src="/assets/js/pages/guest-hub-init.js" defer></script>
+    <script type="module" src="/assets/js/core/view-transition-handler.js" defer></script>
+    <script type="module" src="/assets/js/pages/guest-hub-init.js" defer></script>
 
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->

--- a/tr/hakkimizda/index.html
+++ b/tr/hakkimizda/index.html
@@ -103,8 +103,8 @@
 
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body class="editorial-mode">
@@ -215,9 +215,9 @@
      </script>
 
 <!-- CORE SCRIPTS (Sovereign V18 Matrix) -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/hediye-karti/index.html
+++ b/tr/hediye-karti/index.html
@@ -179,8 +179,8 @@
 </meta></meta><link href="https://santisclub.com/tr/hediye-karti/index.html" hreflang="tr" rel="alternate"/><link href="https://santisclub.com/en/" hreflang="x-default" rel="alternate"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Hediye Kartı | Santis Club" name="twitter:title"/><meta content="Santis Club Hediye Kartı — Sevdiklerinize sessiz lüksün kapılarını açın. Hamam ritüelleri, masaj terapileri ve cilt bakımı deneyimleri için özel hediye kartları." name="twitter:description"/><meta content="https://santisclub.com/assets/img/logo-santis.webp" name="twitter:image"/>
 <meta name="theme-color" content="#000000">
 <link rel="manifest" href="/manifest.json">
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
 </head>
 <body>
@@ -270,9 +270,9 @@
     <script defer="" src="/assets/js/app.js"></script>
 
 <!-- CORE SCRIPTS (Sovereign V18 Matrix) -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js"></script>
-    <script src="/assets/js/app.js" defer></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
 
 <!-- SOVEREIGN OS BOOTLOADER (V35 KERNEL) -->
 <script type="module" src="/assets/js/boot/santis-bootloader.js?v=V35_OMEGA" defer></script>

--- a/tr/index.html
+++ b/tr/index.html
@@ -27,12 +27,12 @@ if (['127.0.0.1', 'localhost'].includes(window.location.hostname)) {
   }
 }
 </script>
-<script src="/assets/js/core/santis-runtime-resolver.js"></script>
-<script src="/assets/js/santis-config.js"></script>
-<script src="/assets/js/api-client.js"></script>
-<script src="/assets/js/santis-public-runtime-shim.js"></script>
-<script src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
-<script src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
+<script type="module" src="/assets/js/core/santis-runtime-resolver.js"></script>
+<script type="module" src="/assets/js/santis-config.js"></script>
+<script type="module" src="/assets/js/api-client.js"></script>
+<script type="module" src="/assets/js/santis-public-runtime-shim.js"></script>
+<script type="module" src="/assets/js/loader.js?v=nav-3a6f8730" defer></script>
+<script type="module" src="/assets/js/santis-nav.js?v=nav-inline-visible-2" defer></script>
 
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
@@ -162,7 +162,7 @@ html { font-display: optional; }
 <link rel="alternate" hreflang="x-default" href="https://santis.club/" />
 
 <!-- RUM: Core Web Vitals Gözlemcisi -->
-<script src="/assets/js/santis-vitals.js" async></script>
+<script type="module" src="/assets/js/santis-vitals.js" async></script>
 
 <script type="speculationrules">
 {
@@ -650,18 +650,18 @@ html { font-display: optional; }
 <!-- CINEMATIC ENGINE (Local GSAP + Observer, single init) -->
 <script src="/assets/vendor/gsap.min.js" defer></script>
 <script src="/assets/vendor/Observer.min.js" defer></script>
-<script src="/assets/js/santis-cinematic-engine.js" defer></script>
+<script type="module" src="/assets/js/santis-cinematic-engine.js" defer></script>
 <script src="/assets/vendor/core.js" defer></script>
 
 <!-- CORE SCRIPTS -->
-<script src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
-<script src="/assets/js/sovereign-cart.js" defer></script>
-<script src="/assets/js/sovereign-cart-ui.js" defer></script>
-<script src="/assets/js/sovereign-cards.js" defer></script>
-<script src="/assets/js/home-page-seal.js?v=e4e6e10b" defer></script>
-<!-- <script src="/assets/js/core/sovereign-scroll.js" defer></script> -->
-<script src="/assets/js/santis-data-bridge.js" defer></script>
-<script src="/assets/js/santis-quantum-nexus.js" defer></script>
+<script type="module" src="/assets/js/ghost-concierge.js?v=V21_GHOST_2" defer></script>
+<script type="module" src="/assets/js/sovereign-cart.js" defer></script>
+<script type="module" src="/assets/js/sovereign-cart-ui.js" defer></script>
+<script type="module" src="/assets/js/sovereign-cards.js" defer></script>
+<script type="module" src="/assets/js/home-page-seal.js?v=e4e6e10b" defer></script>
+<!-- <script type="module" src="/assets/js/core/sovereign-scroll.js" defer></script> -->
+<script type="module" src="/assets/js/santis-data-bridge.js" defer></script>
+<script type="module" src="/assets/js/santis-quantum-nexus.js" defer></script>
 <script src="/assets/vendor/swiper-bundle.min.js" defer></script>
 <script defer>
   document.addEventListener('DOMContentLoaded', function() {
@@ -678,9 +678,9 @@ html { font-display: optional; }
 </script>
 <script type="module" src="/assets/js/core/santis-lang.js" defer></script>
 <script type="module" src="/assets/js/core/santis-core.js" defer></script>
-    <script src="/assets/js/app.js" defer></script>
-<script src="/assets/js/modules/santis-revenue-tracker.js"></script>
-<script src="/assets/js/modules/santis-booking-funnel.js"></script>
+    <script type="module" src="/assets/js/app.js" defer></script>
+<script type="module" src="/assets/js/modules/santis-revenue-tracker.js"></script>
+<script type="module" src="/assets/js/modules/santis-booking-funnel.js"></script>
 
 <!-- Phase 42(B): Real-Time Art Director Personalization -->
 <script type="module" src="/assets/js/core/santis-art-director-client.js" defer></script>


### PR DESCRIPTION
﻿## Summary

Adds type="module" to local Santis script tags in the F2.5a Core & Info batch.

## Scope: Core & Info Entry Pages (8 files)

- tr/index.html
- tr/hakkimizda/index.html
- tr/galeri/index.html
- tr/blog/index.html
- tr/bilgelik/index.html
- tr/ekibimiz/index.html
- tr/guest-zen/index.html
- tr/hediye-karti/index.html

(tr/handoff/index.html was not found and skipped).

No bulk rollout.
No public/admin changes.
No delete.
No archive.
No refactor.

## Verification

- pnpm build:mpa — PASS
- pnpm run stitch:enforce — PASS
- pnpm run lint — PASS
- pnpm run test:e2e -- --project=chromium tests/e2e/reservation.spec.ts — 24/24 PASS

## Governance

This is the F2.5a batch. Transactional pages (booking, checkout, magaza, etc.) will be handled in F2.5b.
