### PR TITLE
fix: phase F F4 bundle budget optimization - exclude tests/reports

### DIFF
--- a/docs/audits/phase-f4-implementation-plan.md
+++ b/docs/audits/phase-f4-implementation-plan.md
@@ -1,0 +1,19 @@
+# Phase F4 - Bundle Budget Baseline & Optimization Plan
+
+## Current State (Baseline)
+- **Largest Chunk:** `tests_reports_html_index-*.js` (402.78 KB) - ⚠️ CRITICAL (Incorrectly bundled test report)
+- **Core Kernel:** `santis-kernel-*.js` (61.75 KB) - ✅ OK
+- **Booking Flow:** `booking-*.js` (41.09 KB) - ✅ OK
+
+## Identified Issue
+The Vite entry discovery logic is picking up `tests/reports/html/index.html`, which leads to a ~400KB chunk that shouldn't be in the production assets.
+
+## Remediation Steps
+1. **Exclude Test Artifacts:** Add `tests` and `reports` to the `EXCLUDE_DIRS` set in `vite.config.ts`.
+2. **Verify Bundle Size:** Re-run the build to confirm the 400KB chunk is removed.
+3. **Threshold Check:** Ensure no other business-critical chunk exceeds 400KB.
+
+## Validation Gate
+- `pnpm run build:mpa`
+- No warnings about chunks > 400KB.
+- Workspace Clean.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ const EXCLUDE_DIRS = new Set([
     'visual_checkpoints', 'test-results', '_deploy_stage',
     'demo', 'trends', 'print', 'sr', 'clinic-kiosk', 'guest-zen', 'tr', 'en',
     'tools', 'templates', 'packages', 'apps', 'admin-panel',
-    'app', 'api', 'alembic',
+    'app', 'api', 'alembic', 'tests', 'reports',
 ]);
 
 const EXCLUDE_FILES = new Set([


### PR DESCRIPTION
SANTIS OS — F4 BUNDLE BUDGET SEALED
- Scope: vite.config.ts
- Action: Excluded 'tests' and 'reports' directories from MPA discovery.
- Result: Removed 402KB non-production chunk. Largest chunk is now 61KB.
- Warnings: 0 chunks > 400KB.
- Rule 5: ACTIVE