### PR TITLE
docs: establish conventional commit message standard

### DIFF
--- a/.github/workflows/sovereign-guard.yml
+++ b/.github/workflows/sovereign-guard.yml
@@ -65,7 +65,7 @@ jobs:
           import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
           import { join } from 'node:path';
 
-          const roots = ['apps', 'packages', 'src'];
+          const roots = ['apps', 'packages', 'src', 'core'];
           const allowedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']);
           const ignoredDirs = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
           const patterns = [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ All AI agents (Antigravity, Copilot, Codex, or any future agent) must declare an
 | Rule Area | Document |
 | :--- | :--- |
 | Git Flow | `docs/governance/git-flow.md` |
+| Commit Policy | `docs/governance/commit-policy.md` |
 | Branch Policy | `docs/governance/branch-policy.md` |
 | Deletion Policy | `docs/governance/deletion-policy.md` |
 | Branch Audit | `docs/audits/branch-governance-audit.md` |

--- a/core/guardian/schemas.ts
+++ b/core/guardian/schemas.ts
@@ -102,6 +102,6 @@ export const GodModeTelemetrySchema = z.object({
   price: z.number().nonnegative().optional(),
   original_price: z.number().nonnegative().optional(),
   event: z.string().optional(),
-}).passthrough(); // Sık sık değişen stream paketleri için esneklik
+}); // Sık sık değişen stream paketleri için esneklik
 
 export type GodModeTelemetry = z.infer<typeof GodModeTelemetrySchema>;

--- a/docs/governance/commit-policy.md
+++ b/docs/governance/commit-policy.md
@@ -1,0 +1,45 @@
+# SANTIS OS — Commit Message Standard (Conventional Commits)
+
+This document formalizes the commit message standard for Santis OS. Adherence to this standard is mandatory for all contributors and AI agents.
+
+## 1. Core Principles
+- **Clarity**: Messages must clearly explain *what* changed and *why*.
+- **Consistency**: Use lowercase for the type and a concise summary.
+- **Convention**: Follow the `<type>: <description>` format.
+
+## 2. Canonical Types
+
+| Type | Description | Example |
+| :--- | :--- | :--- |
+| `feat` | New application features or architectural components. | `feat: add sovereign booking flow shell` |
+| `fix` | Bug fixes or defect resolutions. | `fix: repair pnpm lock mismatch on vercel` |
+| `chore` | Tooling, cleanup, dependencies, or maintenance. | `chore: archive legacy navbar engines` |
+| `refactor` | Code changes that neither fix a bug nor add a feature. | `refactor: isolate corestate boundary validation` |
+| `docs` | Documentation, rules, and audit reports. | `docs: add phase 0 reality lock audit` |
+| `test` | Adding missing tests or correcting existing tests. | `test: add booking flow smoke test` |
+| `perf` | A code change that improves performance. | `perf: reduce layout shift in hero frame` |
+| `security` | Security-related changes or hardening. | `security: restrict ingestion api cors origins` |
+
+## 3. Phase 0 Examples
+
+### Documentation Audits
+```bash
+git add docs/audits/phase-0-reality-lock.md
+git commit -m "docs: add phase 0 reality lock audit"
+```
+
+### Quarantining Legacy Code
+```bash
+git add .
+git commit -m "chore: quarantine legacy dead code candidates"
+```
+
+### Governance Establishment
+```bash
+git add .
+git commit -m "chore: establish git flow governance"
+```
+
+## 4. Integration with PRs
+- All commits in a PR should follow this standard.
+- The PR title itself should also follow the conventional format to ensure clean merge histories.

--- a/packages/runtime-guard/src/state-validator.ts
+++ b/packages/runtime-guard/src/state-validator.ts
@@ -25,7 +25,7 @@ export const CoreStateRuntimeSchema = z.object({
     hesitationAlerts: z.number().min(0).optional(),
     demandLevel: z.enum(['low', 'normal', 'high']).optional()
   }).partial().optional()
-}).passthrough();
+});
 
 export type CoreStateRuntime = z.infer<typeof CoreStateRuntimeSchema>;
 

--- a/scripts/debug-security-gate.mjs
+++ b/scripts/debug-security-gate.mjs
@@ -1,0 +1,53 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const roots = ['apps', 'packages', 'src', 'admin-panel', 'docs', 'core'];
+const allowedExtensions = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.md']);
+const ignoredDirs = new Set(['node_modules', '.git', 'dist', 'build', '.next', 'coverage']);
+const patterns = [
+  { label: 'Wildcard CORS origin detected', regex: /origin\s*:\s*['"]\*['"]/ },
+  { label: 'Wildcard Access-Control-Allow-Origin detected', regex: /Access-Control-Allow-Origin['"]?\s*[:,]\s*['"]\*/ },
+  { label: 'Unsafe Zod passthrough detected', regex: /\.passthrough\(\)/ }
+];
+const violations = [];
+
+function extensionOf(filePath) {
+  const match = filePath.match(/\.[^.]+$/);
+  return match ? match[0] : '';
+}
+
+function walk(path) {
+  const stats = statSync(path);
+  if (stats.isDirectory()) {
+    const dirName = path.split(/[\\/]/).pop();
+    if (ignoredDirs.has(dirName)) return;
+    for (const entry of readdirSync(path)) {
+      walk(join(path, entry));
+    }
+    return;
+  }
+
+  if (!stats.isFile() || !allowedExtensions.has(extensionOf(path))) return;
+
+  const content = readFileSync(path, 'utf8');
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, index) => {
+    for (const pattern of patterns) {
+      if (pattern.regex.test(line)) {
+        violations.push(`${path}:${index + 1}: ${pattern.label}`);
+      }
+    }
+  });
+}
+
+for (const root of roots) {
+  if (existsSync(root)) walk(root);
+}
+
+if (violations.length > 0) {
+  console.error('Sovereign Guard security checks failed.');
+  console.error(violations.join('\n'));
+  process.exit(1);
+}
+
+console.log('Sovereign Guard security checks passed.');


### PR DESCRIPTION
## Summary

Establishes the Santis OS conventional commit message standard and hardens the Sovereign Guard security baseline.

## Scope

- Adds docs/governance/commit-policy.md
- Updates AGENTS.md with governance reference
- Removes forbidden Zod .passthrough() usage
- Expands Sovereign Guard audit scope to include core/

## Verification

- pnpm run typecheck
- pnpm run audit:all
- pnpm run build
- pnpm run build:vercel-admin-sim
- pnpm --filter admin-panel run build
- pnpm --filter admin-panel run lint
- Local security gate reproduction: PASS

## Governance

No delete.
No archive.
Rule 5: ACTIVE.