### PR TITLE
fix(admin-panel): improve navbar a11y and css ownership

### DIFF
--- a/admin-panel/src/components/Navbar.jsx
+++ b/admin-panel/src/components/Navbar.jsx
@@ -12,31 +12,52 @@ const Navbar = () => {
         : "text-gray-400 hover:text-white";
 
     return (
-        <nav className="bg-sovereign-obsidian border-b border-sovereign-line px-8 py-4 flex justify-between items-center mb-8">
-            <div className="flex items-center space-x-8">
-                <div className="text-xl font-bold text-white tracking-widest">SANTIS <span className="text-santis-gold">OS</span></div>
-                <div className="flex space-x-6 text-sm font-medium">
-                    <Link to="/" className={`py-2 transition-colors ${isActive('/')}`}>
-                        Dashboard
+        <header id="nv-header">
+            <nav id="nv-main-nav" aria-label="Main Navigation" className="nv-navbar-container">
+                <div className="flex items-center space-x-8">
+                    <Link to="/" className="nv-logo" aria-label="SANTIS OS Home">
+                        SANTIS <span className="text-santis-gold">OS</span>
                     </Link>
-                    <Link to="/operations" className={`py-2 transition-colors ${isActive('/operations')}`}>
-                        Operations
-                    </Link>
-                    <Link to="/services" className={`py-2 transition-colors ${isActive('/services')}`}>
-                        Services
-                    </Link>
-                    <Link to="/finance" className={`py-2 transition-colors ${isActive('/finance')}`}>
-                        Finance
-                    </Link>
+                    <div className="flex space-x-6">
+                        <Link 
+                            to="/" 
+                            className={`nv-nav-link ${isActive('/') ? 'nv-nav-link-active' : 'nv-nav-link-inactive'}`}
+                            aria-current={isActive('/') ? 'page' : undefined}
+                        >
+                            Dashboard
+                        </Link>
+                        <Link 
+                            to="/operations" 
+                            className={`nv-nav-link ${isActive('/operations') ? 'nv-nav-link-active' : 'nv-nav-link-inactive'}`}
+                            aria-current={isActive('/operations') ? 'page' : undefined}
+                        >
+                            Operations
+                        </Link>
+                        <Link 
+                            to="/services" 
+                            className={`nv-nav-link ${isActive('/services') ? 'nv-nav-link-active' : 'nv-nav-link-inactive'}`}
+                            aria-current={isActive('/services') ? 'page' : undefined}
+                        >
+                            Services
+                        </Link>
+                        <Link 
+                            to="/finance" 
+                            className={`nv-nav-link ${isActive('/finance') ? 'nv-nav-link-active' : 'nv-nav-link-inactive'}`}
+                            aria-current={isActive('/finance') ? 'page' : undefined}
+                        >
+                            Finance
+                        </Link>
+                    </div>
                 </div>
-            </div>
-            <button
-                onClick={logout}
-                className="text-xs text-red-400 hover:text-red-300 transition-colors uppercase tracking-wider"
-            >
-                Logout
-            </button>
-        </nav>
+                <button
+                    onClick={logout}
+                    className="text-xs text-red-400 hover:text-red-300 transition-colors uppercase tracking-wider"
+                    aria-label="Log out of application"
+                >
+                    Logout
+                </button>
+            </nav>
+        </header>
     );
 };
 

--- a/admin-panel/src/index.css
+++ b/admin-panel/src/index.css
@@ -96,6 +96,27 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
+  /* --- NV Navbar (Quiet Luxury Ownership) --- */
+  .nv-navbar-container {
+    @apply bg-sovereign-obsidian border-b border-sovereign-line px-8 py-4 flex justify-between items-center mb-8 sticky top-0 z-50 backdrop-blur-md;
+  }
+
+  .nv-nav-link {
+    @apply py-2 transition-colors text-sm font-medium;
+  }
+
+  .nv-nav-link-active {
+    @apply text-sovereign-gold border-b-2 border-sovereign-gold;
+  }
+
+  .nv-nav-link-inactive {
+    @apply text-sovereign-muted hover:text-white;
+  }
+
+  .nv-logo {
+    @apply text-xl font-bold text-white tracking-widest cursor-pointer hover:opacity-80 transition-opacity;
+  }
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Summary

This PR applies the separate admin-panel navbar accessibility and CSS ownership cleanup after PR #198 was merged.

## Scope

Committed files only:

- `admin-panel/src/components/Navbar.jsx`
- `admin-panel/src/index.css`

## Changes

- Improves admin-panel navbar semantics and accessibility.
- Keeps admin-panel navbar presentation in CSS rather than inline/component-level styling where appropriate.
- Keeps this React/admin-panel work isolated from the static navbar PR #198 and from future Performance Guard / scroll orchestration work.

## Local Verification

Commands run locally after rebasing on `main`:

```bash
pnpm run build:vercel-admin-sim
pnpm run lint
pnpm run build
```

Observed result:

- `build:vercel-admin-sim` PASS
- `lint` PASS
- `build` PASS

## Known Non-Blocking Warnings

Existing build warnings remain outside this patch scope:

- chunk-size warnings
- existing mixed async/defer warnings

## Governance

- Based on merged `main` after PR #198.
- No static navbar files included.
- No Performance Guard changes included.
- No test artifact cleanup included.

Doctrine:

```txt
CSS owns presentation.
JS/React owns behavior.
Markup owns semantics.
```