### PR TITLE
docs(governance): Phase G.2-B initial push report

### DIFF
--- a/docs/audits/phase-g2-b-initial-push-report.md
+++ b/docs/audits/phase-g2-b-initial-push-report.md
@@ -1,0 +1,41 @@
+# Phase G.2-B Initial Push Report
+
+## Overview
+This report confirms the successful creation of the `SANTIS_CORE` private repository and the initial push of the extracted infrastructure code.
+
+## Repository Details
+- **Name:** `SANTIS_CORE`
+- **Visibility:** **PRIVATE**
+- **Owner:** `bashasnoglu-jpg`
+- **URL:** [https://github.com/bashasnoglu-jpg/SANTIS_CORE](https://github.com/bashasnoglu-jpg/SANTIS_CORE)
+- **Description:** "Private Santis OS core runtime extracted from SANTIS_SITE"
+
+## Execution Summary
+- **Source:** Local dry-run repository (`c:\Users\tourg\Desktop\SANTIS_CORE_DRY_RUN`)
+- **Action:** Remote creation and initial push.
+- **Timestamp:** 2026-05-14 21:18 (Local)
+- **Branch Strategy:** `extraction-dry-run` branch was pushed as the new **`main`** branch.
+
+## Validation Results
+
+### 1. Repository Creation
+- [x] Repository exists on GitHub.
+- [x] Visibility is set to Private.
+- [x] Remote `origin` (in dry-run repo) and `core` (in SANTIS_SITE) configured correctly.
+
+### 2. Push Verification
+- [x] Initial push successful.
+- [x] Branch `main` tracking `origin/main`.
+- [x] `Everything up-to-date` confirmed on subsequent checks.
+
+### 3. Remote Content Check
+- [x] Structure matches the dry-run (apps, packages, server, etc. at root).
+- [x] History is preserved and visible via `git log`.
+
+## Post-Push Status
+- **Technical Status:** STANDBY
+- **Next Gate:** Phase G.3 Post-Push Credential & Security Audit.
+- **Archive Status:** `_archive/private-infra/` remains in `SANTIS_SITE` for safety (to be deleted in Phase G.5).
+
+## Conclusion
+Phase G.2-B is **COMPLETE**. The private core repository is established and synchronized with the extracted infrastructure code.


### PR DESCRIPTION
## Phase G.2-B Initial Push Report

Docs-only report confirming SANTIS_CORE private repository creation and initial push.

### Scope
- Adds docs/audits/phase-g2-b-initial-push-report.md
- Documents SANTIS_CORE creation
- Documents initial push and branch strategy
- Documents post-push status

### Non-Actions
- No archive deletion from SANTIS_SITE
- No CI/CD changes
- No dependency rewiring
- No source/config changes

### Gates
- audit:repo-boundary PASS
- audit:all PASS
- lint PASS
- stitch:enforce PASS

G.3 credential/security audit remains the next required phase.