### PR TITLE
docs(governance): Phase G.5-A archive retirement readiness audit

### DIFF
--- a/docs/audits/phase-g5-a-archive-retirement-readiness-audit.md
+++ b/docs/audits/phase-g5-a-archive-retirement-readiness-audit.md
@@ -1,0 +1,41 @@
+# Phase G.5-A Archive Retirement Readiness Audit Report
+
+## Overview
+This audit was conducted to verify if `SANTIS_SITE` is ready for the permanent deletion of the `_archive/private-infra/` directory. The goal was to ensure that no active code, scripts, or configurations depend on this directory.
+
+## Audit Methodology
+- **Deep Scan:** Performed a recursive search for `_archive/private-infra` and `private-infra` across the entire `SANTIS_SITE` repository.
+- **Dependency Review:** Inspected root and package-level `package.json` files for any path-based references.
+- **Execution Policy Check:** Verified that all governance gates for `SANTIS_CORE` (G.1 through G.4-F) are closed and validated.
+
+## Audit Findings
+
+### 1. Code References
+- **Result:** **CLEAN**.
+- **Details:** No references to `_archive/private-infra/` were found in active source code (`src/`, `server/`, `packages/`).
+- **Residual Documentation:** References found in `docs/audits/*.md` are historical and expected. They do not constitute a functional dependency. ✅
+
+### 2. Dependency Analysis
+- **Result:** **DECOUPLED**.
+- **Details:** No `link:`, `file:`, or workspace references point to the archive directory. The system is architecturally ready to consume these components via GitHub Packages or as a separate repository. ✅
+
+### 3. CI/CD & Scripts
+- **Result:** **SAFE**.
+- **Details:** No scripts in `package.json` or GitHub Actions workflows utilize the archive path. ✅
+
+### 4. SANTIS_CORE Status Check
+- **G.3 (Security Audit):** COMPLETE & MERGED. ✅
+- **G.4-E (CI Baseline):** COMPLETE & MERGED. ✅
+- **G.4-F (Enforcement):** COMPLETE & MERGED. ✅
+- **Branch Protection:** Established and confirmed. ✅
+
+## Risk Assessment
+- **Data Loss Risk:** LOW. The contents of `_archive/private-infra/` are fully preserved in the `SANTIS_CORE` repository (main branch).
+- **Operational Risk:** LOW. No lingering dependencies detected.
+- **Governance Risk:** LOW. All safety gates have been cleared.
+
+## Conclusion
+`SANTIS_SITE` is **READY** for Phase G.5-B (Controlled Archive Retirement). The `_archive/private-infra/` directory is now officially a "zombie" directory with zero operational value to this repository.
+
+## Recommendation
+Proceed to **Phase G.5-B** to delete the `_archive/private-infra/` directory and perform a final repository-wide audit.


### PR DESCRIPTION
## Phase G.5-A — Archive Retirement Readiness Audit

Docs-only readiness audit for retiring `_archive/private-infra/` from SANTIS_SITE after SANTIS_CORE extraction and hardening.

### Scope
- Adds `docs/audits/phase-g5-a-archive-retirement-readiness-audit.md`.
- Documents repo-wide reference scans.
- Documents dependency/script/CI decoupling checks.
- Confirms SANTIS_CORE G.3/G.4-E/G.4-F status.
- Recommends controlled archive retirement as a separate future phase.

### Non-Actions
- No archive deletion.
- No source changes.
- No config changes.
- No CI/CD changes.

G.5-B remains blocked until this readiness report is reviewed and merged.