### PR TITLE
fix(vh): mobile dynamic card scaling (remediation PR_VH_02)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -475,7 +475,7 @@ body::after {
 }
 .santis-stack-card {
     position: absolute;
-    width: 340px;
+    width: clamp(280px, 85vw, 340px);
     height: 440px;
     --santis-tilt-x: 0deg;
     --santis-tilt-y: 0deg;


### PR DESCRIPTION
## Summary

Resolves the P0 Visual Hierarchy violation identified in VH-0: Mobile Negative Space Collapse.

## Scope

- Modifies `assets/css/style.css`
- - Replaces fixed `340px` card width with `clamp(280px, 85vw, 340px)`.
- - Preserves 1.25rem "Safe-X" breathing room on narrow viewports.
- - Maintains desktop visual stability.
## Governance

- **One VH violation per PR:** YES
- - **Runtime Impact:** LOW
- - **Blast Radius:** CSS (Stack-card component only)
- - **Validation Gates Passed:** audit:all, lint, stitch:enforce, build
## Linked Issue

Closes part of #230.