### PR TITLE
feat(experience): add Aurelia presence layer proximity and context states

### DIFF
--- a/assets/css/aurelia/orb.css
+++ b/assets/css/aurelia/orb.css
@@ -27,6 +27,17 @@
   will-change: transform;
 }
 
+/* 🌊 Ripple Layer */
+.aurelia-ripple {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 1px solid var(--color-base-gold);
+  opacity: 0;
+  pointer-events: none;
+}
+
 .aurelia-orb {
   position: relative;
   width: 100%;
@@ -88,6 +99,13 @@
 .is-relaxed { --nv-orb-anim-speed: 6s; }
 .is-alert { --nv-orb-anim-speed: 2s; }
 .is-listening { --nv-orb-anim-speed: 0.8s; }
+.is-thinking { --nv-orb-anim-speed: 1.5s; }
+
+/* Listening State: Cyan Core Pulse */
+#aurelia-orb-container.is-listening .aurelia-orb::before {
+  background: radial-gradient(circle, #00ced1 0%, transparent 70%);
+  opacity: 0.4;
+}
 
 /* 🎭 Contextual Page Identity (Presence Slice 2) */
 #aurelia-orb-container.is-page-hamam { --nv-orb-glow: radial-gradient(circle, var(--color-base-gold) 0%, transparent 70%); }

--- a/assets/css/aurelia/orb.css
+++ b/assets/css/aurelia/orb.css
@@ -1,7 +1,8 @@
-/* 
- * 🌌 AURELIA — SOVEREIGN ORB v1.0 (Passive State)
- * Governance: Phase H1-A
- * Performance: GPU Composited (Transform/Opacity only)
+/**
+ * ╔══════════════════════════════════════════════════════════════╗
+ * ║  🌌 AURELIA — SOVEREIGN ORB (PHASE H1-B: PRESENCE)           ║
+ * ║  Quiet Luxury Visual Shell · GPU-Composited · 120 FPS       ║
+ * ╚══════════════════════════════════════════════════════════════╝
  */
 
 :root {
@@ -27,17 +28,6 @@
   will-change: transform;
 }
 
-/* 🌊 Ripple Layer */
-.aurelia-ripple {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  border-radius: 50%;
-  border: 1px solid var(--color-base-gold);
-  opacity: 0;
-  pointer-events: none;
-}
-
 .aurelia-orb {
   position: relative;
   width: 100%;
@@ -49,7 +39,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  /* Glow is now handled by .aurelia-glow pseudo-layer */
 }
 
 /* 🌟 Compositor-Friendly Glow Layer */
@@ -95,18 +84,6 @@
   will-change: transform, opacity;
 }
 
-/* 🧠 Interaction States */
-.is-relaxed { --nv-orb-anim-speed: 6s; }
-.is-alert { --nv-orb-anim-speed: 2s; }
-.is-listening { --nv-orb-anim-speed: 0.8s; }
-.is-thinking { --nv-orb-anim-speed: 1.5s; }
-
-/* Listening State: Cyan Core Pulse */
-#aurelia-orb-container.is-listening .aurelia-orb::before {
-  background: radial-gradient(circle, #00ced1 0%, transparent 70%);
-  opacity: 0.4;
-}
-
 /* 🎭 Contextual Page Identity (Presence Slice 2) */
 #aurelia-orb-container.is-page-hamam { --nv-orb-glow: radial-gradient(circle, var(--color-base-gold) 0%, transparent 70%); }
 #aurelia-orb-container.is-page-massage { --nv-orb-glow: radial-gradient(circle, #00ced1 0%, transparent 70%); }
@@ -119,18 +96,8 @@
 }
 
 @keyframes orb-ring-pulse {
-  0% { transform: scale(1.05) rotate(0deg); opacity: 0.3; }
-  50% { transform: scale(1.15) rotate(180deg); opacity: 0.1; }
-  100% { transform: scale(1.05) rotate(360deg); opacity: 0.3; }
-}
-
-/* Hover Interaction (Token-Driven) */
-#aurelia-orb-container:hover {
-  transform: scale(1.1);
-}
-
-#aurelia-orb-container:hover .aurelia-orb {
-  box-shadow: 0 0 30px var(--color-composite-gold-glow);
+  0% { transform: scale(1.1) rotate(0deg); opacity: 0.3; }
+  100% { transform: scale(1.2) rotate(360deg); opacity: 0.1; }
 }
 
 /* ♿ Accessibility: Reduced Motion */

--- a/assets/js/modules/aurelia/adapters/event-bridge.ts
+++ b/assets/js/modules/aurelia/adapters/event-bridge.ts
@@ -1,0 +1,25 @@
+/**
+ * ╔══════════════════════════════════════════════════════════════╗
+ * ║  🧠 AURELIA — FUTURE SEALED ADAPTER (PHASE H1-D)             ║
+ * ║  Intelligence Bridge · Event-Bus Proxy · NOT ACTIVE         ║
+ * ╚══════════════════════════════════════════════════════════════╝
+ * 
+ * 🛑 GOVERNANCE NOTICE: This file is for architectural reference only.
+ * It is NOT imported by any module and is NOT part of the runtime.
+ */
+
+export function initSovereignBridge(orbInstance: any): void {
+    // Santis OS Kernel'in Event Bus'ını dinle
+    window.addEventListener('santis:intent', (e: any) => {
+        console.log(`🌌 [Aurelia Bridge] Intent detected: ${e.detail}`);
+        // future: orbInstance.setState('thinking');
+        
+        // Simüle edilmiş AI işlem süresi (Boundary Guarantee)
+        // future: setTimeout(() => orbInstance.setState('idle'), 2500);
+    });
+
+    window.addEventListener('santis:dataset_ready', () => {
+        console.log("🌌 [Aurelia Bridge] Sovereign Dataset hydrated.");
+        // future: orbInstance.pulse();
+    });
+}

--- a/assets/js/modules/aurelia/orb.ts
+++ b/assets/js/modules/aurelia/orb.ts
@@ -35,6 +35,7 @@ export class SovereignOrb {
         this.container = document.createElement('div');
         this.container.id = 'aurelia-orb-container';
         this.container.innerHTML = `
+            <div class="aurelia-ripple"></div>
             <div class="aurelia-glow"></div>
             <div class="aurelia-orb-ring"></div>
             <div class="aurelia-orb">
@@ -50,7 +51,6 @@ export class SovereignOrb {
 
     private initSetters(): void {
         if (typeof gsap === 'undefined') return;
-        // 🚀 High-performance setters (No layout thrashing)
         this.setters.scale = gsap.quickSetter(this.container, "scale");
         this.setters.glowOpacity = gsap.quickSetter(".aurelia-glow", "opacity");
         this.setters.glowScale = gsap.quickSetter(".aurelia-glow", "scale");
@@ -59,16 +59,46 @@ export class SovereignOrb {
     private bindEvents(): void {
         if (!this.container) return;
 
-        this.container.addEventListener('click', () => this.pulse(), { passive: true });
+        this.container.addEventListener('click', () => {
+            const currentState = this.container?.dataset.state || 'idle';
+            const nextState = currentState === 'idle' ? 'listening' : 'idle';
+            this.setState(nextState as any);
+            this.pulse();
+        }, { passive: true });
 
-        // Presence Layer: Proximity & Scroll
         window.addEventListener('mousemove', (e) => this.handleProximity(e), { passive: true });
         window.addEventListener('scroll', () => this.handleScroll(), { passive: true });
     }
 
-    private handleProximity(e: MouseEvent): void {
-        if (!this.container || !this.setters.scale) return;
+    /**
+     * Set the orb's visual state (idle, listening, thinking)
+     */
+    public setState(state: 'idle' | 'listening' | 'thinking'): void {
+        if (!this.container || typeof gsap === 'undefined') return;
 
+        console.log(`🌌 [Aurelia] Transitioning to state: ${state}`);
+        this.container.dataset.state = state;
+
+        // Reset classes
+        this.container.classList.remove('is-relaxed', 'is-alert', 'is-listening', 'is-thinking');
+
+        const tl = gsap.timeline();
+
+        if (state === 'listening') {
+            this.container.classList.add('is-listening');
+            tl.to('.aurelia-orb-ring', { scale: 1.5, opacity: 0.6, duration: 0.6, ease: "back.out(2)" });
+        } else if (state === 'thinking') {
+            this.container.classList.add('is-thinking');
+            tl.to('.aurelia-orb-ring', { scale: 1.2, opacity: 0.4, rotate: 360, repeat: -1, duration: 2, ease: "linear" });
+        } else {
+            this.container.classList.add('is-relaxed');
+            tl.to('.aurelia-orb-ring', { scale: 1.1, opacity: 0.3, rotate: 0, duration: 0.6, ease: "power2.inOut" });
+        }
+    }
+
+    private handleProximity(e: MouseEvent): void {
+        if (!this.container || !this.setters.scale || this.container.dataset.state === 'listening') return;
+        
         const rect = this.container.getBoundingClientRect();
         const orbX = rect.left + rect.width / 2;
         const orbY = rect.top + rect.height / 2;
@@ -76,18 +106,14 @@ export class SovereignOrb {
         const dist = Math.sqrt(Math.pow(e.clientX - orbX, 2) + Math.pow(e.clientY - orbY, 2));
         const proximity = Math.max(0, 1 - dist / 400); 
 
-        // Apply via quickSetters (120 FPS target)
         this.setters.scale(1 + (proximity * 0.2));
         this.setters.glowOpacity(0.3 + (proximity * 0.7));
         this.setters.glowScale(1 + (proximity * 0.8));
     }
 
     private handleScroll(): void {
-        if (typeof gsap === 'undefined') return;
-        
+        if (typeof gsap === 'undefined' || this.container?.dataset.state === 'listening') return;
         const scrollPercent = window.scrollY / (document.body.scrollHeight - window.innerHeight || 1);
-        
-        // Scroll-reactive aura (Subtle breathing shift)
         gsap.to('.aurelia-orb-ring', {
             scale: 1.1 + (scrollPercent * 0.3),
             opacity: 0.2 + (scrollPercent * 0.4),
@@ -96,14 +122,17 @@ export class SovereignOrb {
         });
     }
 
-    private applyContext(): void {
-        const page = document.body.dataset.page || 'index';
-        this.container?.classList.add(`is-page-${page}`);
-        console.log(`🌌 [Aurelia] Context applied: ${page}`);
-    }
-
     private pulse(): void {
         if (!this.container || typeof gsap === 'undefined') return;
+
+        // 🌊 Ripple Effect
+        const ripple = this.container.querySelector('.aurelia-ripple');
+        if (ripple) {
+            gsap.fromTo(ripple, 
+                { scale: 0.8, opacity: 0.8 },
+                { scale: 2.5, opacity: 0, duration: 0.8, ease: "power2.out" }
+            );
+        }
 
         gsap.to(this.container, {
             scale: 1.3,
@@ -112,15 +141,6 @@ export class SovereignOrb {
             yoyo: true,
             repeat: 1
         });
-    }
-
-    /**
-     * Set the orb's visual state (idle, listening, thinking)
-     * To be expanded in Phase H1-B
-     */
-    public setState(state: 'idle' | 'listening' | 'thinking'): void {
-        console.log(`🌌 [Aurelia] Transitioning to state: ${state}`);
-        // Visual state logic to be implemented with tokens
     }
 }
 

--- a/assets/js/modules/aurelia/orb.ts
+++ b/assets/js/modules/aurelia/orb.ts
@@ -1,12 +1,6 @@
-/**
- * 🌌 AURELIA — SOVEREIGN ORB ORCHESTRATOR v1.0
- * Governance: Phase H1-A (Passive State)
- * Responsibility: Visual Sovereignty & Experience Shell
- */
-
 export class SovereignOrb {
     private container: HTMLElement | null = null;
-    private orb: HTMLElement | null = null;
+    private setters: any = {};
 
     constructor() {
         if ((window as any).__AURELIA_ORB_ACTIVE__) {
@@ -16,11 +10,9 @@ export class SovereignOrb {
         this.init();
     }
 
-    private setters: any = {};
-
     private init(): void {
         (window as any).__AURELIA_ORB_ACTIVE__ = true;
-        console.log("🌌 [Aurelia] Initializing Presence Layer (H1-B)...");
+        console.log("🌌 [Aurelia] Initializing Presence Layer (H1-B - Sealed)...");
         
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', () => this.createElements());
@@ -35,7 +27,6 @@ export class SovereignOrb {
         this.container = document.createElement('div');
         this.container.id = 'aurelia-orb-container';
         this.container.innerHTML = `
-            <div class="aurelia-ripple"></div>
             <div class="aurelia-glow"></div>
             <div class="aurelia-orb-ring"></div>
             <div class="aurelia-orb">
@@ -59,46 +50,17 @@ export class SovereignOrb {
     private bindEvents(): void {
         if (!this.container) return;
 
-        this.container.addEventListener('click', () => {
-            const currentState = this.container?.dataset.state || 'idle';
-            const nextState = currentState === 'idle' ? 'listening' : 'idle';
-            this.setState(nextState as any);
-            this.pulse();
-        }, { passive: true });
-
+        // Presence Layer: Proximity & Scroll Only
         window.addEventListener('mousemove', (e) => this.handleProximity(e), { passive: true });
         window.addEventListener('scroll', () => this.handleScroll(), { passive: true });
     }
 
-    /**
-     * Set the orb's visual state (idle, listening, thinking)
-     */
-    public setState(state: 'idle' | 'listening' | 'thinking'): void {
-        if (!this.container || typeof gsap === 'undefined') return;
-
-        console.log(`🌌 [Aurelia] Transitioning to state: ${state}`);
-        this.container.dataset.state = state;
-
-        // Reset classes
-        this.container.classList.remove('is-relaxed', 'is-alert', 'is-listening', 'is-thinking');
-
-        const tl = gsap.timeline();
-
-        if (state === 'listening') {
-            this.container.classList.add('is-listening');
-            tl.to('.aurelia-orb-ring', { scale: 1.5, opacity: 0.6, duration: 0.6, ease: "back.out(2)" });
-        } else if (state === 'thinking') {
-            this.container.classList.add('is-thinking');
-            tl.to('.aurelia-orb-ring', { scale: 1.2, opacity: 0.4, rotate: 360, repeat: -1, duration: 2, ease: "linear" });
-        } else {
-            this.container.classList.add('is-relaxed');
-            tl.to('.aurelia-orb-ring', { scale: 1.1, opacity: 0.3, rotate: 0, duration: 0.6, ease: "power2.inOut" });
-        }
-    }
-
     private handleProximity(e: MouseEvent): void {
-        if (!this.container || !this.setters.scale || this.container.dataset.state === 'listening') return;
+        if (!this.container || !this.setters.scale) return;
         
+        // ♿ Accessibility: Respect reduced motion preference
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
         const rect = this.container.getBoundingClientRect();
         const orbX = rect.left + rect.width / 2;
         const orbY = rect.top + rect.height / 2;
@@ -112,7 +74,10 @@ export class SovereignOrb {
     }
 
     private handleScroll(): void {
-        if (typeof gsap === 'undefined' || this.container?.dataset.state === 'listening') return;
+        if (typeof gsap === 'undefined' || !this.container) return;
+        
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
         const scrollPercent = window.scrollY / (document.body.scrollHeight - window.innerHeight || 1);
         gsap.to('.aurelia-orb-ring', {
             scale: 1.1 + (scrollPercent * 0.3),
@@ -122,29 +87,13 @@ export class SovereignOrb {
         });
     }
 
-    private pulse(): void {
-        if (!this.container || typeof gsap === 'undefined') return;
-
-        // 🌊 Ripple Effect
-        const ripple = this.container.querySelector('.aurelia-ripple');
-        if (ripple) {
-            gsap.fromTo(ripple, 
-                { scale: 0.8, opacity: 0.8 },
-                { scale: 2.5, opacity: 0, duration: 0.8, ease: "power2.out" }
-            );
-        }
-
-        gsap.to(this.container, {
-            scale: 1.3,
-            duration: 0.2,
-            ease: "back.out(2)",
-            yoyo: true,
-            repeat: 1
-        });
+    private applyContext(): void {
+        const page = document.body.dataset.page || 'index';
+        this.container?.classList.add(`is-page-${page}`);
+        console.log(`🌌 [Aurelia] Context applied: ${page}`);
     }
 }
 
-// Auto-initialize if running in browser
-if (typeof window !== 'undefined') {
-    (window as any).AureliaOrb = new SovereignOrb();
+if (!window.__SANTIS_SYSTEM_INITIALIZED__) {
+    new SovereignOrb();
 }


### PR DESCRIPTION
## Phase H1-B — Presence Layer Recovery Seal

Adds the Aurelia Presence Layer after governance recovery from premature H1-D intelligence-boundary work.

### Scope
- Adds proximity response using GSAP quickSetter-style compositor-friendly motion.
- Adds contextual glow/page identity states.
- Adds scroll-reactive aura behavior.
- Keeps the Orb as a visual/presence layer only.
- Adds a sealed future adapter under `assets/js/modules/aurelia/adapters/event-bridge.ts`, but it is not imported and must not execute at runtime.

### Governance recovery
- Removed premature `SantisEventBus` runtime integration from `orb.ts`.
- Removed `santis:intent` listeners from the active Orb runtime.
- Removed `thinking` / interaction state coupling from active H1-B scope.
- Kept H1-D concepts isolated as a future sealed adapter only.

### Explicit non-actions
- No microphone.
- No speech recognition.
- No streaming.
- No AI runtime.
- No SANTIS_CORE code.
- No private runtime code.
- No active event-bus bridge.

### Reported local gates
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Required review focus
- Confirm `event-bridge.ts` is not imported by runtime code.
- Confirm reduced-motion quiets proximity/scroll animation.
- Confirm glow effects remain compositor-oriented: transform/opacity dynamic, blur/static layer only.

H1-C Interaction Layer remains blocked until this PR is reviewed and merged.