### PR TITLE
feat(experience): add Aurelia interaction layer ripple and pulse (H1-C)

### DIFF
--- a/assets/css/aurelia/orb.css
+++ b/assets/css/aurelia/orb.css
@@ -28,6 +28,18 @@
   will-change: transform;
 }
 
+/* 🌊 Ripple Layer (Interaction Layer H1-C) */
+.aurelia-ripple {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  border: 1px solid var(--color-base-gold);
+  opacity: 0;
+  pointer-events: none;
+  will-change: transform, opacity;
+}
+
 .aurelia-orb {
   position: relative;
   width: 100%;

--- a/assets/js/modules/aurelia/orb.ts
+++ b/assets/js/modules/aurelia/orb.ts
@@ -27,6 +27,7 @@ export class SovereignOrb {
         this.container = document.createElement('div');
         this.container.id = 'aurelia-orb-container';
         this.container.innerHTML = `
+            <div class="aurelia-ripple"></div>
             <div class="aurelia-glow"></div>
             <div class="aurelia-orb-ring"></div>
             <div class="aurelia-orb">
@@ -50,9 +51,38 @@ export class SovereignOrb {
     private bindEvents(): void {
         if (!this.container) return;
 
-        // Presence Layer: Proximity & Scroll Only
+        this.container.addEventListener('click', () => {
+            this.pulse();
+            this.ripple();
+        }, { passive: true });
+
+        // Presence Layer: Proximity & Scroll
         window.addEventListener('mousemove', (e) => this.handleProximity(e), { passive: true });
         window.addEventListener('scroll', () => this.handleScroll(), { passive: true });
+    }
+
+    private pulse(): void {
+        if (!this.container || typeof gsap === 'undefined') return;
+        
+        gsap.to(this.container, {
+            scale: 1.3,
+            duration: 0.2,
+            ease: "back.out(2)",
+            yoyo: true,
+            repeat: 1
+        });
+    }
+
+    private ripple(): void {
+        if (!this.container || typeof gsap === 'undefined') return;
+        
+        const rippleEl = this.container.querySelector('.aurelia-ripple');
+        if (rippleEl) {
+            gsap.fromTo(rippleEl, 
+                { scale: 0.8, opacity: 0.8 },
+                { scale: 2.5, opacity: 0, duration: 0.8, ease: "power2.out" }
+            );
+        }
     }
 
     private handleProximity(e: MouseEvent): void {


### PR DESCRIPTION
## Phase H1-C — Interaction Layer

Adds local-only interaction feedback to the Aurelia Orb after H1-B Presence Layer work.

### Scope
- Adds click ripple / pulse feedback.
- Adds local visual interaction state only.
- Keeps interaction compositor-oriented using transform/opacity.
- Preserves H1-B presence behaviors.

### Governance boundaries
- No microphone.
- No speech recognition.
- No streaming.
- No WebSocket bridge.
- No AI runtime.
- No SANTIS_CORE code.
- No private runtime code.
- No active SantisEventBus / `santis:intent` intelligence bridge.

### Reported local gates
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Required review focus
- Confirm H1-C is interaction-only.
- Confirm no H1-D intelligence-boundary integration is active.
- Confirm ripple/pulse are transform/opacity based and do not animate box-shadow/layout properties.
- Confirm reduced-motion mode disables or quiets interaction motion.

H1-D Intelligence Boundary Review remains blocked until H1-C is reviewed and merged.