### PR TITLE
feat(experience): define Aurelia H1-D-A static adapter contract

### DIFF
--- a/assets/js/modules/aurelia/adapters/event-bridge.ts
+++ b/assets/js/modules/aurelia/adapters/event-bridge.ts
@@ -1,25 +1,44 @@
 /**
  * ╔══════════════════════════════════════════════════════════════╗
- * ║  🧠 AURELIA — FUTURE SEALED ADAPTER (PHASE H1-D)             ║
- * ║  Intelligence Bridge · Event-Bus Proxy · NOT ACTIVE         ║
+ * ║  🧠 AURELIA — STATIC ADAPTER CONTRACT (PHASE H1-D-A)         ║
+ * ║  Technical Specification · Event Types · Payload Shapes     ║
  * ╚══════════════════════════════════════════════════════════════╝
  * 
- * 🛑 GOVERNANCE NOTICE: This file is for architectural reference only.
- * It is NOT imported by any module and is NOT part of the runtime.
+ * 🛡️ GOVERNANCE: This file defines the technical contract. 
+ * STATUS: SEALED (No runtime execution).
+ * PRINCIPLE: Visual events are advisory-only. Fail silent.
  */
 
-export function initSovereignBridge(orbInstance: any): void {
-    // Santis OS Kernel'in Event Bus'ını dinle
-    window.addEventListener('santis:intent', (e: any) => {
-        console.log(`🌌 [Aurelia Bridge] Intent detected: ${e.detail}`);
-        // future: orbInstance.setState('thinking');
-        
-        // Simüle edilmiş AI işlem süresi (Boundary Guarantee)
-        // future: setTimeout(() => orbInstance.setState('idle'), 2500);
-    });
-
-    window.addEventListener('santis:dataset_ready', () => {
-        console.log("🌌 [Aurelia Bridge] Sovereign Dataset hydrated.");
-        // future: orbInstance.pulse();
-    });
+/**
+ * Permitted Experience Events (Inbound from Core)
+ */
+export enum AureliaExperienceEvent {
+    INTENT_VISUALIZE = 'santis:experience.intent.visualize',
+    DATASET_READY    = 'santis:experience.dataset.ready',
+    ERROR_VISUALIZE  = 'santis:experience.error.visualize'
 }
+
+/**
+ * Payload Shapes for Inbound Signals
+ */
+export interface AureliaPayloadMap {
+    [AureliaExperienceEvent.INTENT_VISUALIZE]: {
+        intent: string;      // e.g., 'analyzing', 'thinking', 'fetching'
+        confidence?: number; // visual-only indicator
+    };
+    [AureliaExperienceEvent.DATASET_READY]: {
+        source: string;      // e.g., 'oracle', 'ritual_catalog'
+        timestamp: number;
+    };
+    [AureliaExperienceEvent.ERROR_VISUALIZE]: {
+        code: string;
+        message: string;
+        silent: boolean;     // If true, orb simply returns to idle
+    };
+}
+
+/**
+ * 🛑 FUTURE REGISTRATION LOGIC (UNACTIVATED)
+ * Implementation delayed to Phase H1-D-B
+ */
+// export function initSovereignBridge(orb: any): void { ... }

--- a/docs/audits/phase-h1-d-intelligence-boundary-review.md
+++ b/docs/audits/phase-h1-d-intelligence-boundary-review.md
@@ -11,6 +11,7 @@
 *   **Intelligence Sovereignty:** The public-facing site (`SANTIS_SITE`) shall never host inference logic, personal data processing, or decision-making algorithms.
 *   **Passive Interaction (Visualize-Only):** The Experience Shell is a passive observer of system-wide events. It reacts visually but does not initiate state changes, generate intents, or trigger decisions in the core.
 *   **Adapter Isolation:** All connectivity to the Intelligence Engine must pass through a "Sealed Adapter" with a strict event whitelist.
+*   **Non-Authoritative Resilience:** Visual events are **advisory-only** and non-authoritative. Dropped events or adapter failures **must fail silently**. The core system functionality shall never depend on the state or availability of the experience shell.
 
 ## 2. Permitted Event Surface (The Visual-Only Contract)
 


### PR DESCRIPTION
## Phase H1-D-A — Static Adapter Contract

Defines the static, sealed Aurelia experience event bridge contract without activating runtime listeners.

### Scope
- Updates `assets/js/modules/aurelia/adapters/event-bridge.ts` only.
- Defines permitted Aurelia experience event names.
- Defines payload map / payload shape for visualize-only inbound events.
- Documents advisory-only / non-authoritative / fail-silent rules at code-contract level.
- Keeps adapter sealed and inactive.

### Explicit non-actions
- No runtime listener activation.
- No `document.addEventListener` / `window.addEventListener` activation.
- No outbound `dispatchEvent` to core.
- No `orb.ts` import of `event-bridge.ts`.
- No bootloader registration.
- No SANTIS_CORE import.
- No private runtime code.
- No websocket.
- No streaming.
- No microphone.

### Reported local validation
- `rg "event-bridge" assets/js index.html` confirms no runtime import/bootloader reference outside the sealed adapter context.
- `rg "addEventListener.*santis:experience" assets/js` reports no active listener.
- `rg "dispatchEvent.*santis:experience" assets/js` reports no outbound event dispatch.
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Review focus
- Confirm this PR is limited to static contract only.
- Confirm H1-D-B Passive DOM Bridge remains blocked until this PR is reviewed and merged.