### PR TITLE
feat(experience): define passive Aurelia DOM bridge lifecycle (H1-D-B)

### DIFF
--- a/assets/js/modules/aurelia/adapters/event-bridge.ts
+++ b/assets/js/modules/aurelia/adapters/event-bridge.ts
@@ -1,17 +1,14 @@
 /**
  * ╔══════════════════════════════════════════════════════════════╗
- * ║  🧠 AURELIA — STATIC ADAPTER CONTRACT (PHASE H1-D-A)         ║
- * ║  Technical Specification · Event Types · Payload Shapes     ║
+ * ║  🧠 AURELIA — PASSIVE DOM BRIDGE (PHASE H1-D-B)               ║
+ * ║  Runtime Listeners · Fail-Silent Reactivity · Sealed State   ║
  * ╚══════════════════════════════════════════════════════════════╝
  * 
- * 🛡️ GOVERNANCE: This file defines the technical contract. 
- * STATUS: SEALED (No runtime execution).
+ * 🛡️ GOVERNANCE: Passive inbound bridge only. 
  * PRINCIPLE: Visual events are advisory-only. Fail silent.
+ * NO OUTBOUND DISPATCH. NO CORE MUTATION.
  */
 
-/**
- * Permitted Experience Events (Inbound from Core)
- */
 export enum AureliaExperienceEvent {
     INTENT_VISUALIZE = 'santis:experience.intent.visualize',
     DATASET_READY    = 'santis:experience.dataset.ready',
@@ -19,26 +16,63 @@ export enum AureliaExperienceEvent {
 }
 
 /**
- * Payload Shapes for Inbound Signals
+ * 🛰️ Sovereign Bridge — Inbound Listener Logic
+ * This function connects the Orb to the System Event Bus via DOM.
+ * It is PASSIVE: it only listens and updates the Orb's local state.
  */
-export interface AureliaPayloadMap {
-    [AureliaExperienceEvent.INTENT_VISUALIZE]: {
-        intent: string;      // e.g., 'analyzing', 'thinking', 'fetching'
-        confidence?: number; // visual-only indicator
-    };
-    [AureliaExperienceEvent.DATASET_READY]: {
-        source: string;      // e.g., 'oracle', 'ritual_catalog'
-        timestamp: number;
-    };
-    [AureliaExperienceEvent.ERROR_VISUALIZE]: {
-        code: string;
-        message: string;
-        silent: boolean;     // If true, orb simply returns to idle
-    };
-}
+export function initSovereignBridge(orb: any): void {
+    if (!orb || typeof orb.setState !== 'function') {
+        console.warn('⚠️ [Aurelia Bridge] Invalid Orb instance provided. Bridge aborted.');
+        return;
+    }
 
-/**
- * 🛑 FUTURE REGISTRATION LOGIC (UNACTIVATED)
- * Implementation delayed to Phase H1-D-B
- */
-// export function initSovereignBridge(orb: any): void { ... }
+    const handleEvent = (event: Event) => {
+        try {
+            const customEvent = event as CustomEvent;
+            const detail = customEvent.detail;
+
+            switch (event.type) {
+                case AureliaExperienceEvent.INTENT_VISUALIZE:
+                    // Map core intent to Orb visual state
+                    orb.setState('thinking');
+                    break;
+
+                case AureliaExperienceEvent.DATASET_READY:
+                    // Map data readiness to Orb active state
+                    orb.setState('active');
+                    break;
+
+                case AureliaExperienceEvent.ERROR_VISUALIZE:
+                    // Map error signal to Orb idle/error visual
+                    orb.setState('idle');
+                    break;
+
+                default:
+                    // Fail silent for unknown whitelisted events
+                    break;
+            }
+        } catch (err) {
+            // 🛡️ Fail Silent: Core functionality must remain independent
+            // No error propagation to the global scope
+        }
+    };
+
+    // Whitelisted Listeners
+    Object.values(AureliaExperienceEvent).forEach(eventType => {
+        document.addEventListener(eventType, handleEvent);
+    });
+
+    /**
+     * Cleanup mechanism to prevent memory leaks during hot-reloads or navigation
+     */
+    const cleanup = () => {
+        Object.values(AureliaExperienceEvent).forEach(eventType => {
+            document.removeEventListener(eventType, handleEvent);
+        });
+    };
+
+    // Attach cleanup to orb for lifecycle management
+    if (orb.registerCleanup) {
+        orb.registerCleanup(cleanup);
+    }
+}


### PR DESCRIPTION
## Phase H1-D-B — Passive DOM Bridge Lifecycle

Defines the passive DOM bridge lifecycle for Aurelia experience events while keeping the bridge unmounted and inactive at runtime.

### Scope
- Updates `assets/js/modules/aurelia/adapters/event-bridge.ts`.
- Defines whitelisted passive DOM listeners for `santis:experience.*` visualization events.
- Adds fail-silent error isolation.
- Adds cleanup/lifecycle structure for future safe mounting.
- Keeps the bridge defined but unmounted.

### Defined but unmounted guarantee
- `initSovereignBridge` is defined but not called.
- `event-bridge.ts` is not imported by `orb.ts`.
- `event-bridge.ts` is not registered by the bootloader.
- No runtime activation occurs in this PR.

### Explicit non-actions
- No outbound `dispatchEvent` to core.
- No SANTIS_CORE import.
- No private runtime code.
- No shared private state access.
- No WebSocket.
- No streaming.
- No microphone.
- No speech recognition.
- No decision-making logic.

### Reported local validation
- `git diff --name-status develop...HEAD` confirms only `event-bridge.ts` changed.
- `rg "initSovereignBridge" assets/js index.html` confirms no runtime call/import outside the adapter context.
- `rg "event-bridge" assets/js index.html` confirms no runtime bootloader/orb reference.
- `rg "addEventListener.*santis:experience" assets/js/modules/aurelia/adapters/event-bridge.ts` confirms listeners exist only inside the sealed adapter.
- `rg "dispatchEvent.*santis:experience" assets/js` confirms no outbound event dispatch.
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Review focus
- Confirm this PR introduces no runtime mounting.
- Confirm fail-silent behavior.
- Confirm cleanup lifecycle is present.
- Confirm no outbound or bidirectional bridge behavior.

H1-D-C Visual Mapping remains blocked until this PR is reviewed and merged.