### PR TITLE
docs(governance): define H1-D-C visual mapping rules

### DIFF
--- a/docs/audits/phase-h1-d-c-visual-mapping-rules.md
+++ b/docs/audits/phase-h1-d-c-visual-mapping-rules.md
@@ -1,0 +1,35 @@
+# SANTIS OS — Phase H1-D-C Visual Mapping Rules
+
+**Date:** 2026-05-15
+**Status:** DRAFT / UNDER REVIEW
+**Mission:** Define how inbound intelligence signals are visually represented without introducing business semantic interpretation.
+
+---
+
+## 1. Allowed Visual States (The Palette)
+
+The Aurelia Orb is restricted to the following visual state transitions. Any state outside this list is forbidden:
+
+*   **`IDLE`:** Default calm pulse. No active processing.
+*   **`THINKING`:** Accelerated glow frequency + variable opacity. Indicates core cognitive activity.
+*   **`ACTIVE`:** Success/Hydration pulse. Brief intensity spike then return to idle.
+*   **`ERROR`:** Desaturated aura + low-frequency strobe. Indicates non-critical system fault.
+
+## 2. Technical Constraints (Performance & UX)
+
+*   **Compositor-Only Rule:** All mapping-induced animations must use `transform`, `opacity`, or `filter`. No layout-triggering properties (`width`, `height`, `margin`).
+*   **Max Animation Duration:** Individual visual reactions shall not exceed **1200ms** to prevent interaction lag.
+*   **Reduced-Motion Fallback:** Inbound events must trigger **zero** movement/scale if `prefers-reduced-motion` is active. Only opacity/color shifts are allowed.
+
+## 3. Governance Boundaries
+
+*   **No Business Semantic Interpretation:** The Orb reacts to "types" of events (intent, success, error) but must not know the *content* of those events. It should not "know" which specific ritual is being booked or which user is logged in.
+*   **No State Persistence:** Visual mapping is transient. The Orb must not store history of past events or create a visual "memory" of interactions.
+*   **No Blocking UI:** Mapping logic must run on the Main Thread but prioritized via `requestAnimationFrame` or `requestIdleCallback` to ensure 120 FPS shell integrity.
+
+---
+
+## 4. Resilience Policy (Fail-Silent)
+
+*   **Silent Drop:** If an inbound event contains malformed metadata or an unsupported mapping type, it must be dropped silently without visual glitch or error reporting.
+*   **Visual Silence:** The experience shell maintains the "Quiet Luxury" aesthetic. No aggressive flashes, high-saturation colors, or sudden jarring transitions.

--- a/docs/audits/phase-h1-d-c-visual-mapping-rules.md
+++ b/docs/audits/phase-h1-d-c-visual-mapping-rules.md
@@ -23,13 +23,17 @@ The Aurelia Orb is restricted to the following visual state transitions. Any sta
 
 ## 3. Governance Boundaries
 
-*   **No Business Semantic Interpretation:** The Orb reacts to "types" of events (intent, success, error) but must not know the *content* of those events. It should not "know" which specific ritual is being booked or which user is logged in.
+*   **No Business Semantic Interpretation:** The Orb reacts to "types" of events (intent, success, error) but must not know the *content* of those events.
 *   **No State Persistence:** Visual mapping is transient. The Orb must not store history of past events or create a visual "memory" of interactions.
-*   **No Blocking UI:** Mapping logic must run on the Main Thread but prioritized via `requestAnimationFrame` or `requestIdleCallback` to ensure 120 FPS shell integrity.
+*   **No Blocking UI:** Mapping logic must run on the Main Thread but prioritized via `requestAnimationFrame`.
 
----
+## 4. Visual Mapping Rate Limits & Composure
 
-## 4. Resilience Policy (Fail-Silent)
+*   **Refractory Period:** The Orb shall not change its visual state more than once every **120ms** to prevent strobe effects during event storms.
+*   **Transition Smoothing:** Instant state flips (e.g., `ERROR` -> `ACTIVE`) are forbidden. Transitions must pass through a brief neutral state or use a fade-out/fade-in cycle.
+*   **Panic Suppression:** In the event of rapid inbound signals, the Orb must maintain a steady rhythm. **"Core panic edebilir, Orb panic etmez."** (The core may panic; the Orb maintains composure).
 
-*   **Silent Drop:** If an inbound event contains malformed metadata or an unsupported mapping type, it must be dropped silently without visual glitch or error reporting.
-*   **Visual Silence:** The experience shell maintains the "Quiet Luxury" aesthetic. No aggressive flashes, high-saturation colors, or sudden jarring transitions.
+## 5. Resilience Policy (Fail-Silent)
+
+*   **Silent Drop:** If an inbound event contains malformed metadata or an unsupported mapping type, it must be dropped silently.
+*   **Visual Silence:** The experience shell maintains the "Quiet Luxury" aesthetic. No aggressive flashes or high-saturation colors.

--- a/docs/audits/phase-h1-d-c-visual-mapping-rules.md
+++ b/docs/audits/phase-h1-d-c-visual-mapping-rules.md
@@ -17,23 +17,35 @@ The Aurelia Orb is restricted to the following visual state transitions. Any sta
 
 ## 2. Technical Constraints (Performance & UX)
 
-*   **Compositor-Only Rule:** All mapping-induced animations must use `transform`, `opacity`, or `filter`. No layout-triggering properties (`width`, `height`, `margin`).
-*   **Max Animation Duration:** Individual visual reactions shall not exceed **1200ms** to prevent interaction lag.
-*   **Reduced-Motion Fallback:** Inbound events must trigger **zero** movement/scale if `prefers-reduced-motion` is active. Only opacity/color shifts are allowed.
+*   **Compositor-Only Rule:** All mapping-induced animations must use `transform`, `opacity`, or `filter`.
+*   **Max Animation Duration:** Individual visual reactions shall not exceed **1200ms**.
+*   **Reduced-Motion Fallback:** Inbound events must trigger **zero** movement/scale if active.
 
 ## 3. Governance Boundaries
 
-*   **No Business Semantic Interpretation:** The Orb reacts to "types" of events (intent, success, error) but must not know the *content* of those events.
-*   **No State Persistence:** Visual mapping is transient. The Orb must not store history of past events or create a visual "memory" of interactions.
-*   **No Blocking UI:** Mapping logic must run on the Main Thread but prioritized via `requestAnimationFrame`.
+*   **No Business Semantic Interpretation:** The Orb reacts to "types" of events but does not know the content.
+*   **No State Persistence:** Visual mapping is transient.
+*   **No Blocking UI:** Mapping logic runs on Main Thread but prioritized via `requestAnimationFrame`.
 
 ## 4. Visual Mapping Rate Limits & Composure
 
-*   **Refractory Period:** The Orb shall not change its visual state more than once every **120ms** to prevent strobe effects during event storms.
-*   **Transition Smoothing:** Instant state flips (e.g., `ERROR` -> `ACTIVE`) are forbidden. Transitions must pass through a brief neutral state or use a fade-out/fade-in cycle.
-*   **Panic Suppression:** In the event of rapid inbound signals, the Orb must maintain a steady rhythm. **"Core panic edebilir, Orb panic etmez."** (The core may panic; the Orb maintains composure).
+*   **Refractory Period:** The Orb shall not change its visual state more than once every **120ms**.
+*   **Panic Suppression:** **"Core panic edebilir, Orb panic etmez."**
 
-## 5. Resilience Policy (Fail-Silent)
+## 5. State Transition Matrix (Allowed Topology)
 
-*   **Silent Drop:** If an inbound event contains malformed metadata or an unsupported mapping type, it must be dropped silently.
-*   **Visual Silence:** The experience shell maintains the "Quiet Luxury" aesthetic. No aggressive flashes or high-saturation colors.
+To maintain aesthetic composure, the following transition rules are enforced:
+
+| From | To | Allowed | Note |
+| :--- | :--- | :--- | :--- |
+| `IDLE` | `THINKING` | ✅ Yes | Standard start of processing |
+| `THINKING` | `ACTIVE` | ✅ Yes | Resolution of intent |
+| `ACTIVE` | `IDLE` | ✅ Yes | Return to calm after success |
+| `ERROR` | `IDLE` | ✅ Yes | Recovery via fade |
+| `ERROR` | `ACTIVE` | ❌ No | Direct jump forbidden. Must pass through IDLE/Fade. |
+| `IDLE` | `ACTIVE` | ✅ Yes | Passive success (no thinking phase needed) |
+
+## 6. Resilience Policy (Fail-Silent)
+
+*   **Silent Drop:** If an inbound event triggers an forbidden transition, it must be dropped silently.
+*   **Visual Silence:** No aggressive flashes or high-saturation colors.


### PR DESCRIPTION
## Phase H1-D-C — Visual Mapping Rules

Adds the governance rules for mapping passive Santis experience events into Aurelia visual states without allowing semantic interpretation or decision-making inside SANTIS_SITE.

### Scope
- Adds `docs/audits/phase-h1-d-c-visual-mapping-rules.md`.
- Defines allowed visual states: `IDLE`, `THINKING`, `ACTIVE`, `ERROR`.
- Defines non-semantic visual reaction rules.
- Defines visual silence constraints for Quiet Luxury behavior.
- Defines performance constraints for compositor-only visual mapping.
- Defines fail-silent handling for unknown or malformed signals.

### Governance boundaries
- Docs-only PR.
- No runtime listener changes.
- No event-bridge activation.
- No Orb runtime mapping code.
- No bootloader registration.
- No SANTIS_CORE code or private import.
- No semantic business interpretation in SANTIS_SITE.

### Required review focus
- Confirm event-to-visual mapping is non-authoritative.
- Confirm Orb reacts only to event meta-type, not payload business content.
- Confirm visual reactions are bounded, quiet, and compositor-oriented.
- Confirm H1-D-C implementation remains blocked until H1-D-B is reviewed and merged.

This PR prepares the governance boundary for a future H1-D-C implementation but does not implement runtime visual mapping.