### PR TITLE
docs(governance): audit H1-D-C runtime activation

### DIFF
--- a/docs/audits/phase-h1-d-c-runtime-activation-audit.md
+++ b/docs/audits/phase-h1-d-c-runtime-activation-audit.md
@@ -1,0 +1,32 @@
+# Phase H1-D-C Runtime Activation Audit
+
+## Status
+Runtime activation was merged directly into develop.
+
+## Scope
+- assets/js/modules/aurelia/adapters/event-bridge.ts
+- assets/js/modules/aurelia/orb.ts
+
+## Governance deviation
+Expected flow was branch → PR → review → merge.
+Actual flow was direct develop commit/push.
+
+## Verification
+- ✅ no SANTIS_CORE imports
+- ✅ no outbound dispatchEvent
+- ✅ no WebSocket
+- ✅ no microphone
+- ✅ no speech recognition
+- ✅ no persistence
+- ✅ no business semantic interpretation
+
+## Runtime contract
+- ✅ inbound-only santis:experience.* events
+- ✅ transition matrix enforced
+- ✅ 120ms refractory period
+- ✅ fail-silent malformed events
+- ✅ cleanup lifecycle present
+
+## Final decision
+Accepted as trunk state after post-merge audit.
+Future runtime changes must follow PR review flow.


### PR DESCRIPTION
## Phase H1-D-C Runtime Activation Audit

This docs-only PR records the post-merge audit for the H1-D-C runtime activation.

### Context
H1-D-C runtime activation entered `develop` directly instead of the preferred branch → PR → review → merge flow.

### Scope
- Adds `docs/audits/phase-h1-d-c-runtime-activation-audit.md`.
- Documents the governance deviation.
- Documents verification evidence.
- Accepts the current trunk state after post-merge audit.

### Verification
- No SANTIS_CORE imports.
- No private runtime code.
- No outbound `santis:experience` dispatch.
- No WebSocket.
- No microphone / speech recognition.
- No persistence/history.
- Inbound-only visual mapping.
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Forward Rule
Future runtime changes must follow feature branch → PR → review → merge.

This PR closes the governance audit trail for the already-active H1-D-C runtime state.