### PR TITLE
feat(experience): add Aurelia runtime stress resistance (I2)

### DIFF
--- a/assets/js/modules/aurelia/adapters/event-bridge.ts
+++ b/assets/js/modules/aurelia/adapters/event-bridge.ts
@@ -1,11 +1,10 @@
 /**
  * ╔══════════════════════════════════════════════════════════════╗
- * ║  🧠 AURELIA — RUNTIME OBSERVABILITY (PHASE I1)               ║
- * ║  Health Counters · Transition Logs · Zero Outbound          ║
+ * ║  🧠 AURELIA — RUNTIME STRESS RESISTANCE (PHASE I2)           ║
+ * ║  Saturation Protection · Frame Guard · Panic Suppression    ║
  * ╚══════════════════════════════════════════════════════════════╝
  * 
- * 🛡️ GOVERNANCE: Inbound metrics only. 
- * PRINCIPLE: Zero outbound telemetry unless approved.
+ * 🛡️ GOVERNANCE: Core panic edebilir, Orb panic etmez.
  */
 
 export enum AureliaExperienceEvent {
@@ -14,9 +13,6 @@ export enum AureliaExperienceEvent {
     ERROR_VISUALIZE  = 'santis:experience.error.visualize'
 }
 
-/**
- * 🛰️ Aurelia Telemetry Service (Local Only)
- */
 class AureliaTelemetry {
     public metrics = {
         eventsReceived: 0,
@@ -24,19 +20,24 @@ class AureliaTelemetry {
         transitionsExecuted: 0,
         refractoryBlocks: 0,
         topologyViolations: 0,
+        saturationBlocks: 0,
         reducedMotionActive: window.matchMedia('(prefers-reduced-motion: reduce)').matches
     };
 
-    public logTransition(from: string, to: string): void {
+    public logTransition(): void {
         this.metrics.transitionsExecuted++;
-        // Quiet Luxury: Silent logging to window only for audit
-        (window as any).__AURELIA_METRICS__ = this.metrics;
+        this.sync();
     }
 
-    public reportDrop(reason: 'refractory' | 'topology'): void {
+    public reportDrop(reason: 'refractory' | 'topology' | 'saturation'): void {
         this.metrics.eventsDropped++;
         if (reason === 'refractory') this.metrics.refractoryBlocks++;
         if (reason === 'topology') this.metrics.topologyViolations++;
+        if (reason === 'saturation') this.metrics.saturationBlocks++;
+        this.sync();
+    }
+
+    private sync(): void {
         (window as any).__AURELIA_METRICS__ = this.metrics;
     }
 }
@@ -44,12 +45,41 @@ class AureliaTelemetry {
 const telemetry = new AureliaTelemetry();
 
 /**
- * Visual Scheduler: Enforces composure and valid visual topology.
+ * 🛡️ Frame Guard: Monitors UI performance to detect congestion.
+ */
+class FrameGuard {
+    private lastFrameTime = performance.now();
+    private isCongested = false;
+
+    constructor() {
+        this.monitor();
+    }
+
+    private monitor(): void {
+        const check = (now: number) => {
+            const delta = now - this.lastFrameTime;
+            // If frame delta > 32ms (~30fps threshold), we are congested
+            this.isCongested = delta > 32;
+            this.lastFrameTime = now;
+            requestAnimationFrame(check);
+        };
+        requestAnimationFrame(check);
+    }
+
+    public getSaturationMultiplier(): number {
+        return this.isCongested ? 2 : 1;
+    }
+}
+
+const frameGuard = new FrameGuard();
+
+/**
+ * Visual Scheduler: Enforces composure and saturation protection.
  */
 class VisualScheduler {
     private orb: any;
     private lastTransitionTime: number = 0;
-    private readonly REFRACTORY_PERIOD = 120; // ms
+    private readonly BASE_REFRACTORY = 120;
     private currentState: string = 'idle';
 
     private readonly ALLOWED_TRANSITIONS: Record<string, string[]> = {
@@ -67,41 +97,46 @@ class VisualScheduler {
         telemetry.metrics.eventsReceived++;
         const now = performance.now();
 
-        // 1. Rate Limiting
-        if (now - this.lastTransitionTime < this.REFRACTORY_PERIOD) {
+        // 1. Dynamic Saturation Protection
+        const multiplier = frameGuard.getSaturationMultiplier();
+        const effectiveRefractory = this.BASE_REFRACTORY * multiplier;
+
+        if (multiplier > 1) {
+            // System under load, extra caution applied
+            if (now - this.lastTransitionTime < effectiveRefractory) {
+                telemetry.reportDrop('saturation');
+                return;
+            }
+        }
+
+        // 2. Base Rate Limiting
+        if (now - this.lastTransitionTime < this.BASE_REFRACTORY) {
             telemetry.reportDrop('refractory');
             return;
         }
 
-        // 2. Transition Validation
+        // 3. Transition Validation
         const allowed = this.ALLOWED_TRANSITIONS[this.currentState] || [];
         if (!allowed.includes(targetState)) {
             telemetry.reportDrop('topology');
             return;
         }
 
-        // 3. Execution
-        const fromState = this.currentState;
+        // 4. Execution
         this.currentState = targetState;
         this.lastTransitionTime = now;
         
         requestAnimationFrame(() => {
             if (this.orb && typeof this.orb.setState === 'function') {
                 this.orb.setState(targetState);
-                telemetry.logTransition(fromState, targetState);
+                telemetry.logTransition();
             }
         });
     }
 }
 
-/**
- * 🛰️ Sovereign Bridge — Inbound Listener Logic
- */
 export function initSovereignBridge(orb: any): void {
-    if (!orb || typeof orb.setState !== 'function') {
-        console.warn('⚠️ [Aurelia Bridge] Invalid Orb instance. Bridge aborted.');
-        return;
-    }
+    if (!orb || typeof orb.setState !== 'function') return;
 
     const scheduler = new VisualScheduler(orb);
 
@@ -137,6 +172,5 @@ export function initSovereignBridge(orb: any): void {
         orb.registerCleanup(cleanup);
     }
 
-    // Expose metrics for I1-A audit
     (window as any).__AURELIA_METRICS__ = telemetry.metrics;
 }

--- a/scratch/aurelia-stress-test.js
+++ b/scratch/aurelia-stress-test.js
@@ -1,0 +1,36 @@
+/**
+ * 🧪 SANTIS OS — AURELIA STRESS TEST (PHASE I2)
+ * Purpose: Simulates an event storm to verify VisualScheduler composure.
+ * Usage: Run in browser console after importing the event bridge.
+ */
+
+(function runAureliaStressTest() {
+    console.log("🧪 [Stress Test] Starting Aurelia Event Storm...");
+    
+    const EVENT_TYPES = [
+        'santis:experience.intent.visualize',
+        'santis:experience.dataset.ready',
+        'santis:experience.error.visualize'
+    ];
+
+    let count = 0;
+    const TOTAL_EVENTS = 100;
+    const INTERVAL = 10; // 10ms (Higher frequency than the 120ms refractory period)
+
+    const timer = setInterval(() => {
+        const type = EVENT_TYPES[Math.floor(Math.random() * EVENT_TYPES.length)];
+        
+        const event = new CustomEvent(type, {
+            detail: { timestamp: performance.now(), storm: true }
+        });
+        
+        document.dispatchEvent(event);
+        count++;
+
+        if (count >= TOTAL_EVENTS) {
+            clearInterval(timer);
+            console.log(`✅ [Stress Test] Storm completed. ${TOTAL_EVENTS} events dispatched.`);
+            console.log("📊 [Stress Test] Check window.__AURELIA_METRICS__ for results.");
+        }
+    }, INTERVAL);
+})();


### PR DESCRIPTION
## Phase I2 — Aurelia Runtime Stress Resistance

Adds runtime stress resistance for Aurelia so the Experience Shell remains composed under event storms and frame pressure.

### Scope
- Adds FrameGuard-style congestion detection using `requestAnimationFrame` timing.
- Adds dynamic refractory behavior under load.
- Adds `saturationBlocks` / stress-related local metrics.
- Adds local-only diagnostic stress simulation under `scratch/aurelia-stress-test.js`.

### Scratch tooling isolation
`scratch/aurelia-stress-test.js` is local diagnostic tooling only.
It is not imported by `index.html`, the bootloader, `orb.ts`, or any production runtime module.
It must not be bundled or executed in production.

### Governance boundaries
- Zero outbound telemetry.
- No `fetch` / XHR / beacon telemetry.
- No WebSocket.
- No streaming.
- No microphone / speech recognition.
- No SANTIS_CORE import.
- No private runtime code.
- No persistence/history storage.
- No business semantic interpretation.

### Reported local validation
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.
- `rg "aurelia-stress-test" . -g "!docs/**" -g "!scratch/**"` confirms the stress tool is not referenced by runtime code.
- `rg "fetch|XMLHttpRequest|navigator.sendBeacon|WebSocket|getUserMedia|SpeechRecognition" assets/js/modules/aurelia scratch` reports no outbound or restricted API usage.

### Review focus
- Confirm stress resistance does not introduce telemetry egress.
- Confirm scratch tooling is isolated from runtime.
- Confirm dynamic refractory behavior preserves Quiet Luxury composure.
- Confirm no intelligence boundary regression.

Phase I2 keeps the principle: Core panic edebilir, Orb panic etmez.