### PR TITLE
feat(experience): add Aurelia lifecycle integrity safeguards (I5)

### DIFF
--- a/assets/js/modules/aurelia/adapters/event-bridge.ts
+++ b/assets/js/modules/aurelia/adapters/event-bridge.ts
@@ -1,11 +1,11 @@
 /**
  * ╔══════════════════════════════════════════════════════════════╗
- * ║  🧠 AURELIA — RUNTIME SELF-HEALING (PHASE I3)                ║
- * ║  Stale State Watchdog · Soft Reset · Lifecycle Recovery     ║
+ * ║  🧠 AURELIA — LIFECYCLE INTEGRITY (PHASE I5)                 ║
+ * ║  Duplicate Guard · HMR Safety · Orphan Cleanup Audit        ║
  * ╚══════════════════════════════════════════════════════════════╝
  * 
- * 🛡️ GOVERNANCE: Core panic edebilir, Orb panic etmez.
- * 🛡️ RECOVERY: Bozulduğunda zarif şekilde toparlanabilmek.
+ * 🛡️ GOVERNANCE: Single Source of Bridge Truth.
+ * 🛡️ INTEGRITY: No duplicate listeners, no orphan timers.
  */
 
 export enum AureliaExperienceEvent {
@@ -57,6 +57,7 @@ const telemetry = new AureliaTelemetry();
 class FrameGuard {
     private lastFrameTime = performance.now();
     private isCongested = false;
+    private active: boolean = true;
 
     constructor() {
         this.monitor();
@@ -64,6 +65,7 @@ class FrameGuard {
 
     private monitor(): void {
         const check = (now: number) => {
+            if (!this.active) return;
             const delta = now - this.lastFrameTime;
             this.isCongested = delta > 32;
             this.lastFrameTime = now;
@@ -75,9 +77,13 @@ class FrameGuard {
     public getSaturationMultiplier(): number {
         return this.isCongested ? 2 : 1;
     }
+
+    public destroy(): void {
+        this.active = false;
+    }
 }
 
-const frameGuard = new FrameGuard();
+let frameGuardInstance: FrameGuard | null = null;
 
 /**
  * Visual Scheduler: Enforces composure, saturation protection, and self-healing.
@@ -88,7 +94,7 @@ class VisualScheduler {
     private readonly BASE_REFRACTORY = 120;
     private currentState: string = 'idle';
     private staleWatchdog: any = null;
-    private readonly STALE_TIMEOUT = 10000; // 10s (Maximum time in non-idle state)
+    private readonly STALE_TIMEOUT = 10000;
 
     private readonly ALLOWED_TRANSITIONS: Record<string, string[]> = {
         'idle':     ['thinking', 'active'],
@@ -105,8 +111,7 @@ class VisualScheduler {
         telemetry.metrics.eventsReceived++;
         const now = performance.now();
 
-        // 1. Dynamic Saturation Protection
-        const multiplier = frameGuard.getSaturationMultiplier();
+        const multiplier = frameGuardInstance ? frameGuardInstance.getSaturationMultiplier() : 1;
         const effectiveRefractory = this.BASE_REFRACTORY * multiplier;
 
         if (multiplier > 1 && now - this.lastTransitionTime < effectiveRefractory) {
@@ -114,13 +119,11 @@ class VisualScheduler {
             return;
         }
 
-        // 2. Base Rate Limiting
         if (now - this.lastTransitionTime < this.BASE_REFRACTORY) {
             telemetry.reportDrop('refractory');
             return;
         }
 
-        // 3. Transition Validation
         const allowed = this.ALLOWED_TRANSITIONS[this.currentState] || [];
         if (!allowed.includes(targetState)) {
             telemetry.reportDrop('topology');
@@ -130,20 +133,15 @@ class VisualScheduler {
         this.executeTransition(targetState);
     }
 
-    /**
-     * Executes the visual transition and resets the stale watchdog.
-     */
     private executeTransition(targetState: string): void {
         this.currentState = targetState;
         this.lastTransitionTime = performance.now();
         
-        // 🛡️ Stale Watchdog: Clear existing timer
         if (this.staleWatchdog) {
             clearTimeout(this.staleWatchdog);
             this.staleWatchdog = null;
         }
 
-        // 🛡️ Stale Watchdog: Set new timer for non-idle states
         if (targetState !== 'idle') {
             this.staleWatchdog = setTimeout(() => {
                 this.softReset('stale state detected');
@@ -158,21 +156,38 @@ class VisualScheduler {
         });
     }
 
-    /**
-     * 🛡️ Soft Reset: Emergency return to idle state.
-     * Bypasses transition matrix to ensure recovery.
-     */
     public softReset(reason: string): void {
         if (this.currentState === 'idle') return;
-        
         console.warn(`🛡️ [Aurelia Recovery] Soft Reset: ${reason}`);
         telemetry.reportSelfHeal();
         this.executeTransition('idle');
     }
+
+    public destroy(): void {
+        if (this.staleWatchdog) {
+            clearTimeout(this.staleWatchdog);
+            this.staleWatchdog = null;
+        }
+    }
 }
 
+/**
+ * 🛰️ Sovereign Bridge — Global Instance Guard
+ */
+let activeBridgeCleanup: (() => void) | null = null;
+
 export function initSovereignBridge(orb: any): void {
+    // 🛡️ Duplicate Guard: Ensure old bridge is destroyed before new one starts
+    if (activeBridgeCleanup) {
+        console.warn('🛡️ [Aurelia Bridge] Duplicate mount detected. Cleaning up old bridge...');
+        activeBridgeCleanup();
+    }
+
     if (!orb || typeof orb.setState !== 'function') return;
+
+    if (!frameGuardInstance) {
+        frameGuardInstance = new FrameGuard();
+    }
 
     const scheduler = new VisualScheduler(orb);
 
@@ -202,15 +217,23 @@ export function initSovereignBridge(orb: any): void {
         Object.values(AureliaExperienceEvent).forEach(eventType => {
             document.removeEventListener(eventType, handleEvent);
         });
+        scheduler.destroy();
+        if (frameGuardInstance) {
+            frameGuardInstance.destroy();
+            frameGuardInstance = null;
+        }
+        activeBridgeCleanup = null;
     };
+
+    activeBridgeCleanup = cleanup;
 
     if (orb.registerCleanup) {
         orb.registerCleanup(cleanup);
     }
 
-    // Expose reset for I3 manual audit
     (window as any).__AURELIA_RECOVERY__ = {
-        softReset: () => scheduler.softReset('manual trigger')
+        softReset: () => scheduler.softReset('manual trigger'),
+        destroy: () => cleanup()
     };
 
     (window as any).__AURELIA_METRICS__ = telemetry.metrics;


### PR DESCRIPTION
## Phase I5 — Aurelia Lifecycle Integrity

Adds lifecycle integrity safeguards so the Aurelia experience bridge remains singleton-safe, cleanup-safe, and HMR-resilient.

### Scope
- Adds duplicate bridge guard so only one active bridge instance exists at a time.
- Adds deterministic cleanup for listeners, timers, and RAF loops.
- Adds destroy lifecycle for FrameGuard / VisualScheduler resources.
- Adds HMR / hot-reload resilience to prevent orphan listeners and stale timers.
- Expands local diagnostic surface with `window.__AURELIA_RECOVERY__.destroy()` for audit-only cleanup testing.

### Diagnostic surface boundaries
`window.__AURELIA_RECOVERY__.destroy()` is local diagnostic/audit tooling only.
It must not expose private state, dispatch outbound events, mutate core state, or act as a business control API.
It only destroys local Aurelia bridge resources and visual timers/listeners.

### Governance boundaries
- No outbound dispatch.
- No network calls / telemetry egress.
- No `fetch` / XHR / beacon telemetry.
- No WebSocket.
- No streaming.
- No microphone / speech recognition.
- No SANTIS_CORE import.
- No private runtime access.
- No core state mutation.
- No persistence/history storage.
- No business semantic interpretation.

### Reported local validation
- `audit:repo-boundary` PASS.
- `audit:all` PASS.
- `lint` PASS.
- `stitch:enforce` PASS.

### Review focus
- Confirm duplicate mounts clean up the previous bridge before starting a new one.
- Confirm timers and RAF loops are cancelled during cleanup.
- Confirm listeners do not accumulate across HMR / remount cycles.
- Confirm `destroy()` is idempotent and safe to call multiple times.
- Confirm the diagnostic destroy method cannot become a control API.
- Confirm no intelligence boundary regression.

Phase I5 preserves the principle: Aurelia may clean up its own local visual runtime, but it never controls the core.