### PR TITLE
feat(vault): add sovereign journey memory layer

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -239,6 +239,13 @@
                 loaded: false
             },
             {
+                id: 'vault',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-sovereign-vault.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -286,6 +293,7 @@
         // 🧬 V40 DECISION MATRIX (SAFE VERSION)
         window.__SANTIS_DECISION_MATRIX__ ??= {
             reveal: { priority: 110, critical: true },
+            vault: { priority: 109, critical: true },
             journey: { priority: 108, critical: true },
             atmosphere: { priority: 105, critical: true },
             nav: { priority: 100, critical: true },

--- a/assets/js/modules/santis-journey-orchestrator.js
+++ b/assets/js/modules/santis-journey-orchestrator.js
@@ -4,6 +4,7 @@
    ========================================================================== */
 
 import { getRitualRecommendation } from "./santis-ritual-recommender.js";
+import { SantisSovereignVault } from "./santis-sovereign-vault.js";
 
 const JourneyState = {
   IDLE: "idle",
@@ -32,6 +33,44 @@ class GuestJourneyOrchestrator {
     
     // Bind UI
     this.attachUIBindings();
+    
+    // Restore from Vault
+    this.hydrate();
+  }
+
+  hydrate() {
+    const restored = SantisSovereignVault.loadJourney();
+    if (restored && restored.intent) {
+      console.log("🦅 [Journey Orchestrator] Hydrating state from Sovereign Vault:", restored);
+      
+      this.intent = restored.intent;
+      
+      // 1. Restore Intent Chip
+      const btn = document.querySelector(`[data-intent="${restored.intent}"]`);
+      if (btn) btn.classList.add("is-selected");
+      
+      // 2. Restore Atmosphere
+      if (restored.atmosphere && window.SantisAtmosphere) {
+        window.SantisAtmosphere.setTheme(restored.atmosphere, "Vault Hydration");
+      }
+      
+      // 3. Render Recommendation
+      this.renderRecommendation(restored.intent);
+      
+      // 4. Render Itinerary Preview if it was saved
+      // (The user instruction said "Itinerary preview tekrar oluşsun")
+      if (restored.ritual) {
+        const preview = document.querySelector("[data-itinerary-preview]");
+        if (preview) {
+          preview.hidden = false;
+          preview.querySelector("[data-itinerary-title]").textContent = restored.ritual.title;
+          preview.querySelector("[data-itinerary-meta]").textContent =
+            `${restored.ritual.category} · ${restored.ritual.duration}`;
+        }
+      }
+      
+      this.transitionTo(JourneyState.ITINERARY_READY);
+    }
   }
 
   attachUIBindings() {
@@ -93,10 +132,17 @@ class GuestJourneyOrchestrator {
     this.transitionTo(JourneyState.INTENT_CAPTURED);
     
     // Step 3: Align Atmosphere
-    this.alignAtmosphere(this.intent);
+    const atmosphere = this.alignAtmosphere(this.intent);
     
     // Step 4: Recommend Ritual
     this.renderRecommendation(this.intent);
+    
+    // Step 5: Save to Vault
+    SantisSovereignVault.saveJourney({
+      intent: this.intent,
+      atmosphere: atmosphere,
+      ritual: this.currentRecommendation
+    });
   }
 
   renderRecommendation(intent) {
@@ -141,6 +187,8 @@ class GuestJourneyOrchestrator {
     } else {
         console.warn("[Journey] SantisAtmosphere module not found. Atmosphere cannot be aligned.");
     }
+    
+    return targetTheme;
   }
 
   handleAtmosphereAligned(e) {

--- a/assets/js/modules/santis-sovereign-vault.js
+++ b/assets/js/modules/santis-sovereign-vault.js
@@ -1,0 +1,44 @@
+const STORAGE_KEY = "santis:journey:v1";
+
+export class SantisSovereignVault {
+  static saveJourney(payload) {
+    try {
+      const data = {
+        ...payload,
+        updatedAt: Date.now()
+      };
+
+      window.__SANTIS_VAULT_CACHE__ = data;
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (error) {
+      console.warn("[Vault] save failed", error);
+    }
+  }
+
+  static loadJourney() {
+    try {
+      if (window.__SANTIS_VAULT_CACHE__) {
+        return window.__SANTIS_VAULT_CACHE__;
+      }
+
+      const raw = localStorage.getItem(STORAGE_KEY);
+
+      if (!raw) return null;
+
+      const parsed = JSON.parse(raw);
+
+      window.__SANTIS_VAULT_CACHE__ = parsed;
+
+      return parsed;
+    } catch (error) {
+      console.warn("[Vault] load failed", error);
+      return null;
+    }
+  }
+
+  static clearJourney() {
+    window.__SANTIS_VAULT_CACHE__ = null;
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}

--- a/assets/js/modules/santis-sovereign-vault.js
+++ b/assets/js/modules/santis-sovereign-vault.js
@@ -1,3 +1,6 @@
+// Vault v1 stores experience continuity only.
+// Do not store payment data, email, phone, health data, or identity data here.
+
 const STORAGE_KEY = "santis:journey:v1";
 
 export class SantisSovereignVault {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "audit:repo-boundary": "node scripts/active/audit-repo-boundary.mjs",
     "audit:all": "pnpm run audit:repo-boundary && pnpm run audit:environment && pnpm run audit:workspace && pnpm run audit:contract && pnpm run audit:localhost",
     "verify:ports": "node scripts/verify-ports.mjs",
-    "audit:guest-journey": "node scripts/audit-guest-journey.cjs"
+    "audit:guest-journey": "node scripts/audit-guest-journey.cjs",
+    "audit:vault": "node scripts/audit-sovereign-vault.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-sovereign-vault.cjs
+++ b/scripts/audit-sovereign-vault.cjs
@@ -1,0 +1,31 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+const vault = read("assets/js/modules/santis-sovereign-vault.js");
+const orchestrator = read("assets/js/modules/santis-journey-orchestrator.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "STORAGE_KEY",
+  "saveJourney",
+  "loadJourney",
+  "clearJourney",
+  "localStorage",
+  "__SANTIS_VAULT_CACHE__",
+  "Do not store payment data"
+].forEach((needle) => assertIncludes(vault, needle, "vault contract"));
+
+assertIncludes(bootloader, "santis-sovereign-vault.js", "bootloader vault module");
+assertIncludes(orchestrator, "SantisSovereignVault.saveJourney", "orchestrator save usage");
+assertIncludes(orchestrator, "SantisSovereignVault.loadJourney", "orchestrator load usage");
+
+console.log("✅ Sovereign Vault audit passed");


### PR DESCRIPTION
Adds a client-side Sovereign Vault for guest journey continuity using memory cache and localStorage. Persists intent, atmosphere, and recommended ritual state without storing PII, payment, contact, or health data.