### PR TITLE
feat(vault): add clear memory journey control

### DIFF
--- a/assets/css/santis-v6/santis.journey.css
+++ b/assets/css/santis-v6/santis.journey.css
@@ -175,3 +175,33 @@
     flex-direction: column;
   }
 }
+
+.santis-vault-clear {
+  min-height: 44px;
+  padding: 0.75rem 1rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  opacity: 0.52;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 0.28em;
+  transition: opacity 220ms ease, transform 220ms ease;
+}
+
+.santis-vault-clear:hover,
+.santis-vault-clear:focus-visible {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .santis-vault-clear {
+    transition: none;
+  }
+
+  .santis-vault-clear:hover,
+  .santis-vault-clear:focus-visible {
+    transform: none;
+  }
+}

--- a/assets/js/modules/santis-journey-orchestrator.js
+++ b/assets/js/modules/santis-journey-orchestrator.js
@@ -100,6 +100,7 @@ class GuestJourneyOrchestrator {
     });
 
     this.bindItineraryActions();
+    this.bindVaultClearAction();
   }
 
   bindItineraryActions() {
@@ -123,6 +124,41 @@ class GuestJourneyOrchestrator {
       
       // Dispatch local event for state machine
       document.dispatchEvent(new CustomEvent("guest:itinerary_ready", { detail: { ritual: this.currentRecommendation } }));
+    });
+  }
+
+  bindVaultClearAction() {
+    const button = document.querySelector("[data-vault-clear]");
+
+    if (!button) return;
+
+    button.addEventListener("click", () => {
+      SantisSovereignVault.clearJourney();
+
+      document.querySelectorAll("[data-intent]").forEach((item) => {
+        item.classList.remove("is-selected");
+      });
+
+      const recommendation = document.querySelector("[data-ritual-recommendation]");
+      const itinerary = document.querySelector("[data-itinerary-preview]");
+      const result = document.querySelector("[data-journey-result]");
+
+      if (recommendation) recommendation.hidden = true;
+      if (itinerary) itinerary.hidden = true;
+      if (result) result.textContent = "Yolculuğunuz sıfırlandı. Yeni bir niyet seçebilirsiniz.";
+
+      if (window.SantisAtmosphere && typeof window.SantisAtmosphere.setTheme === 'function') {
+        window.SantisAtmosphere.setTheme("mediterranean-zen", "Vault Reset");
+      }
+
+      window.SantisBus?.emit?.("guest:journey_reset", {
+        source: "vault-clear",
+        timestamp: Date.now()
+      });
+      
+      this.intent = null;
+      this.currentRecommendation = null;
+      this.transitionTo(JourneyState.IDLE);
     });
   }
 

--- a/scripts/audit-sovereign-vault.cjs
+++ b/scripts/audit-sovereign-vault.cjs
@@ -24,6 +24,12 @@ const bootloader = read("assets/js/boot/santis-bootloader.js");
   "Do not store payment data"
 ].forEach((needle) => assertIncludes(vault, needle, "vault contract"));
 
+[
+  "data-vault-clear",
+  "clearJourney",
+  "guest:journey_reset"
+].forEach((needle) => assertIncludes(orchestrator, needle, "clear memory UX"));
+
 assertIncludes(bootloader, "santis-sovereign-vault.js", "bootloader vault module");
 assertIncludes(orchestrator, "SantisSovereignVault.saveJourney", "orchestrator save usage");
 assertIncludes(orchestrator, "SantisSovereignVault.loadJourney", "orchestrator load usage");

--- a/tr/index.html
+++ b/tr/index.html
@@ -294,6 +294,10 @@ html { font-display: optional; }
             <a class="santis-itinerary-continue" href="/tr/paketler/">
               Planı tamamla
             </a>
+            
+            <button type="button" class="santis-vault-clear" data-vault-clear>
+              Yeniden Başla
+            </button>
           </div>
         </section>
 


### PR DESCRIPTION
Adds a discreet guest-facing reset control for clearing Sovereign Vault journey memory and returning the homepage journey UI to its default state.