### PR TITLE
feat(checkout): add ritual confirmation ceremony UI

### DIFF
--- a/assets/css/santis-v6/santis.checkout.css
+++ b/assets/css/santis-v6/santis.checkout.css
@@ -1,0 +1,58 @@
+.santis-checkout-ceremony {
+  margin: 1rem auto 0;
+  max-width: 980px;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border-radius: 28px;
+  border: 1px solid color-mix(in srgb, var(--color-gold, #d4af37) 24%, transparent);
+  background: color-mix(in srgb, var(--color-ink, #0b0f14) 70%, transparent);
+  backdrop-filter: blur(20px);
+}
+
+.santis-checkout-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.68;
+}
+
+.santis-checkout-ceremony h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 2.2rem);
+  font-weight: 400;
+}
+
+.santis-checkout-meta,
+.santis-checkout-message {
+  opacity: 0.72;
+}
+
+.santis-checkout-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.santis-checkout-primary,
+.santis-checkout-secondary {
+  min-height: 44px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-gold, #d4af37) 24%, transparent);
+  color: inherit;
+  background: transparent;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.santis-checkout-primary {
+  border-color: var(--color-gold, #d4af37);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .santis-checkout-primary,
+  .santis-checkout-secondary {
+    transition: none;
+  }
+}

--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -246,6 +246,13 @@
                 loaded: false
             },
             {
+                id: 'checkout-ceremony',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-checkout-ceremony.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -294,7 +301,8 @@
         window.__SANTIS_DECISION_MATRIX__ ??= {
             reveal: { priority: 110, critical: true },
             vault: { priority: 109, critical: true },
-            journey: { priority: 108, critical: true },
+            "checkout-ceremony": { priority: 108, critical: true },
+            journey: { priority: 107, critical: true },
             atmosphere: { priority: 105, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },

--- a/assets/js/modules/santis-checkout-ceremony.js
+++ b/assets/js/modules/santis-checkout-ceremony.js
@@ -1,0 +1,39 @@
+import { SantisCheckoutEligibility } from "./santis-checkout-eligibility.js";
+
+export class SantisCheckoutCeremony {
+  constructor() {
+    this.ritual = null;
+    this.init();
+  }
+
+  init() {
+    console.log("🦅 [Checkout Ceremony] Initialized.");
+    
+    // Listen for checkout requests
+    document.addEventListener("guest:checkout_requested", this.handleCheckoutRequested.bind(this));
+  }
+
+  handleCheckoutRequested(e) {
+    this.ritual = e.detail?.ritual;
+    console.log(`[Checkout Ceremony] Checkout requested for:`, this.ritual);
+
+    const eligibility = SantisCheckoutEligibility.checkEligibility(this.ritual);
+
+    if (!eligibility.eligible) {
+      console.warn("[Checkout Ceremony] Guest is NOT eligible for checkout:", eligibility.reasons);
+      return;
+    }
+
+    console.log("[Checkout Ceremony] Guest is eligible. Proceeding to Ritual Confirmation.");
+    this.transitionToConfirmation();
+  }
+
+  transitionToConfirmation() {
+    console.log("[Checkout Ceremony] Ritual Confirmation step active.");
+    // Shell implementation - UI logic will go here
+  }
+}
+
+// Bootstrap
+window.Santis = window.Santis || {};
+window.Santis.CheckoutCeremony = new SantisCheckoutCeremony();

--- a/assets/js/modules/santis-checkout-ceremony.js
+++ b/assets/js/modules/santis-checkout-ceremony.js
@@ -25,12 +25,33 @@ export class SantisCheckoutCeremony {
     }
 
     console.log("[Checkout Ceremony] Guest is eligible. Proceeding to Ritual Confirmation.");
-    this.transitionToConfirmation();
+    this.transitionToConfirmation(this.ritual);
   }
 
-  transitionToConfirmation() {
+  transitionToConfirmation(ritual) {
     console.log("[Checkout Ceremony] Ritual Confirmation step active.");
-    // Shell implementation - UI logic will go here
+    
+    const panel = document.querySelector("[data-checkout-ceremony]");
+    if (!panel || !ritual) return;
+
+    panel.hidden = false;
+    panel.querySelector("[data-checkout-title]").textContent = ritual.title;
+    panel.querySelector("[data-checkout-meta]").textContent =
+      `${ritual.category} · ${ritual.duration}`;
+
+    const link = panel.querySelector("[data-checkout-link]");
+    if (link && ritual.href) {
+      link.href = ritual.href;
+    }
+    
+    // Bind Cancel
+    const cancelBtn = panel.querySelector("[data-checkout-cancel]");
+    if (cancelBtn && !cancelBtn.dataset.bound) {
+        cancelBtn.dataset.bound = "true";
+        cancelBtn.addEventListener("click", () => {
+            panel.hidden = true;
+        });
+    }
   }
 }
 

--- a/assets/js/modules/santis-checkout-eligibility.js
+++ b/assets/js/modules/santis-checkout-eligibility.js
@@ -1,0 +1,26 @@
+export class SantisCheckoutEligibility {
+  static checkEligibility(ritual) {
+    const report = {
+      eligible: true,
+      reasons: []
+    };
+
+    if (!ritual) {
+      report.eligible = false;
+      report.reasons.push("NO_RITUAL_SELECTED");
+      return report;
+    }
+
+    if (!ritual.title) {
+      report.eligible = false;
+      report.reasons.push("MISSING_RITUAL_TITLE");
+    }
+
+    if (!ritual.duration) {
+      report.eligible = false;
+      report.reasons.push("MISSING_RITUAL_DURATION");
+    }
+
+    return report;
+  }
+}

--- a/assets/js/modules/santis-journey-orchestrator.js
+++ b/assets/js/modules/santis-journey-orchestrator.js
@@ -101,6 +101,25 @@ class GuestJourneyOrchestrator {
 
     this.bindItineraryActions();
     this.bindVaultClearAction();
+    this.bindCheckoutRequest();
+  }
+
+  bindCheckoutRequest() {
+    const button = document.querySelector("[data-checkout-request]");
+
+    if (!button) return;
+
+    button.addEventListener("click", () => {
+      if (!this.currentRecommendation) return;
+
+      window.SantisBus?.emit?.("guest:checkout_requested", {
+        ritual: this.currentRecommendation,
+        source: "itinerary-preview",
+        timestamp: Date.now()
+      });
+      
+      document.dispatchEvent(new CustomEvent("guest:checkout_requested", { detail: { ritual: this.currentRecommendation } }));
+    });
   }
 
   bindItineraryActions() {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "audit:all": "pnpm run audit:repo-boundary && pnpm run audit:environment && pnpm run audit:workspace && pnpm run audit:contract && pnpm run audit:localhost",
     "verify:ports": "node scripts/verify-ports.mjs",
     "audit:guest-journey": "node scripts/audit-guest-journey.cjs",
-    "audit:vault": "node scripts/audit-sovereign-vault.cjs"
+    "audit:vault": "node scripts/audit-sovereign-vault.cjs",
+    "audit:checkout": "node scripts/audit-checkout-ceremony.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-checkout-ceremony.cjs
+++ b/scripts/audit-checkout-ceremony.cjs
@@ -1,0 +1,32 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+const index = read("tr/index.html");
+const css = read("assets/css/santis-v6/santis.checkout.css");
+const orchestrator = read("assets/js/modules/santis-journey-orchestrator.js");
+const ceremony = read("assets/js/modules/santis-checkout-ceremony.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "data-checkout-request",
+  "data-checkout-ceremony",
+  "data-checkout-title",
+  "data-checkout-meta"
+].forEach(needle => assertIncludes(index, needle, "HTML checkout contract"));
+
+assertIncludes(orchestrator, "guest:checkout_requested", "journey checkout event emission");
+assertIncludes(ceremony, "guest:checkout_requested", "ceremony event binding");
+assertIncludes(ceremony, "santis-checkout-eligibility.js", "eligibility module dependency");
+assertIncludes(bootloader, "santis-checkout-ceremony.js", "bootloader checkout module");
+assertIncludes(css, "prefers-reduced-motion", "reduced motion guard");
+
+console.log("✅ Checkout Ceremony audit passed");

--- a/tr/index.html
+++ b/tr/index.html
@@ -182,7 +182,9 @@ html { font-display: optional; }
 }
 </script>
 <link href="/assets/css/nav-final.css?v=nav-3a6f8730" rel="stylesheet"/>
-<link rel="stylesheet" href="/assets/css/santis-v6/santis.journey.css">
+    <!-- Journey & Checkout Orchestrator Styles -->
+    <link rel="stylesheet" href="/assets/css/santis-v6/santis.journey.css">
+    <link rel="stylesheet" href="/assets/css/santis-v6/santis.checkout.css">
 </head>
 <body class="santis-cinematic-lock">
 <!-- Page Overlay for Cinematic Transitions -->
@@ -291,12 +293,31 @@ html { font-display: optional; }
               <p data-itinerary-meta></p>
             </div>
 
-            <a class="santis-itinerary-continue" href="/tr/paketler/">
+            <button type="button" class="santis-itinerary-continue" data-checkout-request>
               Planı tamamla
-            </a>
+            </button>
             
             <button type="button" class="santis-vault-clear" data-vault-clear>
               Yeniden Başla
+            </button>
+          </div>
+        </section>
+
+        <!-- FAZ 1.5: RITUAL CHECKOUT CEREMONY -->
+        <section class="santis-checkout-ceremony sovereign-reveal-item reveal-delay-600" data-checkout-ceremony hidden aria-live="polite">
+          <p class="santis-checkout-eyebrow">Ritüel onayı</p>
+          <h3 data-checkout-title></h3>
+          <p class="santis-checkout-meta" data-checkout-meta></p>
+          <p class="santis-checkout-message">
+            Ritüeliniz hazır. Son adımda zaman, tercih ve müsaitlik bilgileri netleştirilecektir.
+          </p>
+
+          <div class="santis-checkout-actions">
+            <a class="santis-checkout-primary" data-checkout-link href="/tr/paketler/">
+              Ritüeli onayla
+            </a>
+            <button type="button" class="santis-checkout-secondary" data-checkout-cancel>
+              Geri dön
             </button>
           </div>
         </section>


### PR DESCRIPTION
Adds the UI layer and event bindings for the Ritual Checkout Ceremony. Replaces the direct checkout link with a button that triggers the ceremony, passes deterministic eligibility checks, and renders a localized confirmation panel.