### PR TITLE
feat(checkout): add booking handoff payload and event

### DIFF
--- a/assets/js/modules/santis-checkout-ceremony.js
+++ b/assets/js/modules/santis-checkout-ceremony.js
@@ -1,4 +1,5 @@
 import { SantisCheckoutEligibility } from "./santis-checkout-eligibility.js";
+import { SantisSovereignVault } from "./santis-sovereign-vault.js";
 
 export class SantisCheckoutCeremony {
   constructor() {
@@ -38,11 +39,6 @@ export class SantisCheckoutCeremony {
     panel.querySelector("[data-checkout-title]").textContent = ritual.title;
     panel.querySelector("[data-checkout-meta]").textContent =
       `${ritual.category} · ${ritual.duration}`;
-
-    const link = panel.querySelector("[data-checkout-link]");
-    if (link && ritual.href) {
-      link.href = ritual.href;
-    }
     
     // Bind Cancel
     const cancelBtn = panel.querySelector("[data-checkout-cancel]");
@@ -50,6 +46,37 @@ export class SantisCheckoutCeremony {
         cancelBtn.dataset.bound = "true";
         cancelBtn.addEventListener("click", () => {
             panel.hidden = true;
+        });
+    }
+
+    // Bind Confirm
+    const confirmBtn = panel.querySelector("[data-checkout-confirm]");
+    if (confirmBtn && !confirmBtn.dataset.bound) {
+        confirmBtn.dataset.bound = "true";
+        confirmBtn.addEventListener("click", () => {
+            console.log("[Checkout Ceremony] Ritual confirmed. Initiating booking handoff.");
+            
+            // Retrieve latest vault state for context
+            const vaultState = SantisSovereignVault.loadJourney() || {};
+
+            const payload = {
+                ritualTitle: ritual.title,
+                duration: ritual.duration,
+                category: ritual.category,
+                intent: vaultState.intent || null,
+                atmosphere: vaultState.atmosphere || null,
+                source: "checkout-ceremony",
+                timestamp: Date.now()
+            };
+
+            window.SantisBus?.emit?.("guest:booking_handoff_requested", payload);
+            
+            // Local fallback
+            document.dispatchEvent(new CustomEvent("guest:booking_handoff_requested", { detail: payload }));
+            
+            // Temporary UX feedback
+            confirmBtn.textContent = "Hazırlanıyor...";
+            confirmBtn.disabled = true;
         });
     }
   }

--- a/scripts/audit-checkout-ceremony.cjs
+++ b/scripts/audit-checkout-ceremony.cjs
@@ -20,11 +20,13 @@ const bootloader = read("assets/js/boot/santis-bootloader.js");
   "data-checkout-request",
   "data-checkout-ceremony",
   "data-checkout-title",
-  "data-checkout-meta"
+  "data-checkout-meta",
+  "data-checkout-confirm"
 ].forEach(needle => assertIncludes(index, needle, "HTML checkout contract"));
 
 assertIncludes(orchestrator, "guest:checkout_requested", "journey checkout event emission");
 assertIncludes(ceremony, "guest:checkout_requested", "ceremony event binding");
+assertIncludes(ceremony, "guest:booking_handoff_requested", "ceremony handoff event emission");
 assertIncludes(ceremony, "santis-checkout-eligibility.js", "eligibility module dependency");
 assertIncludes(bootloader, "santis-checkout-ceremony.js", "bootloader checkout module");
 assertIncludes(css, "prefers-reduced-motion", "reduced motion guard");

--- a/tr/index.html
+++ b/tr/index.html
@@ -313,9 +313,9 @@ html { font-display: optional; }
           </p>
 
           <div class="santis-checkout-actions">
-            <a class="santis-checkout-primary" data-checkout-link href="/tr/paketler/">
+            <button type="button" class="santis-checkout-primary" data-checkout-confirm>
               Ritüeli onayla
-            </a>
+            </button>
             <button type="button" class="santis-checkout-secondary" data-checkout-cancel>
               Geri dön
             </button>


### PR DESCRIPTION
Introduces the Booking Handoff Shell. Updates the Checkout Ceremony to intercept the final confirmation, enriches the intent/atmosphere data from the Sovereign Vault, and emits a structured 'guest:booking_handoff_requested' payload for the overarching system to handle (paving the way for the reservation engine).