### PR TITLE
feat(booking): add host review confirmation hold

### DIFF
--- a/assets/css/santis-v6/santis.booking.css
+++ b/assets/css/santis-v6/santis.booking.css
@@ -118,6 +118,33 @@
   font-size: 0.85rem;
 }
 
+.santis-booking-hold {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--color-gold, #d4af37) 22%, transparent);
+  background: color-mix(in srgb, var(--color-ink, #0b0f14) 62%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.santis-booking-hold-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.68;
+}
+
+.santis-booking-hold h3 {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.4vw, 1.65rem);
+  font-weight: 400;
+}
+
+.santis-booking-hold p {
+  opacity: 0.72;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .santis-booking-modal,
   .santis-booking-modal-content {

--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -267,6 +267,13 @@
                 loaded: false
             },
             {
+                id: 'booking-confirmation-hold',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-booking-confirmation-hold.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -318,8 +325,9 @@
             "checkout-ceremony": { priority: 108, critical: true },
             "booking-modal": { priority: 107, critical: true },
             "booking-availability": { priority: 106, critical: true },
-            journey: { priority: 105, critical: true },
-            atmosphere: { priority: 104, critical: true },
+            "booking-confirmation-hold": { priority: 105, critical: true },
+            journey: { priority: 104, critical: true },
+            atmosphere: { priority: 103, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-booking-confirmation-hold.js
+++ b/assets/js/modules/santis-booking-confirmation-hold.js
@@ -1,0 +1,27 @@
+function renderConfirmationHold(e) {
+  const payload = e.detail;
+  const result = payload?.availability;
+  const panel = document.querySelector("[data-booking-hold]");
+
+  if (!panel || !result?.available) return;
+
+  panel.hidden = false;
+
+  const eventPayload = {
+    ritualTitle: payload.ritualTitle,
+    preferredDate: payload.preferredDate,
+    preferredTime: payload.preferredTime,
+    confirmationMode: result.confirmationMode || "host-review",
+    source: "availability-adapter",
+    timestamp: Date.now()
+  };
+
+  window.SantisBus?.emit?.("guest:booking_confirmation_hold_created", eventPayload);
+  document.dispatchEvent(new CustomEvent("guest:booking_confirmation_hold_created", { detail: eventPayload }));
+}
+
+function bindConfirmationHold() {
+  document.addEventListener("guest:booking_availability_checked", renderConfirmationHold);
+}
+
+bindConfirmationHold();

--- a/scripts/audit-booking-modal.cjs
+++ b/scripts/audit-booking-modal.cjs
@@ -15,21 +15,25 @@ const css = read("assets/css/santis-v6/santis.booking.css");
 const modalJs = read("assets/js/modules/santis-booking-modal.js");
 const bootloader = read("assets/js/boot/santis-bootloader.js");
 const availabilityJs = read("assets/js/modules/santis-booking-availability.js");
+const holdJs = read("assets/js/modules/santis-booking-confirmation-hold.js");
 
 [
   "data-booking-modal",
   "data-booking-form",
   "data-booking-cancel",
   "data-booking-submit",
-  "data-booking-availability"
+  "data-booking-availability",
+  "data-booking-hold"
 ].forEach(needle => assertIncludes(index, needle, "HTML booking modal contract"));
 
 assertIncludes(modalJs, "guest:booking_handoff_requested", "handoff event listening");
 assertIncludes(modalJs, "guest:booking_intent_submitted", "intent submit event emission");
 assertIncludes(availabilityJs, "guest:booking_availability_checked", "availability event emission");
 assertIncludes(availabilityJs, "checkMockAvailability", "mock availability check");
+assertIncludes(holdJs, "guest:booking_confirmation_hold_created", "hold event emission");
 assertIncludes(bootloader, "santis-booking-modal.js", "bootloader booking module");
 assertIncludes(bootloader, "santis-booking-availability.js", "bootloader availability module");
+assertIncludes(bootloader, "santis-booking-confirmation-hold.js", "bootloader hold module");
 assertIncludes(css, "prefers-reduced-motion", "reduced motion guard");
 
 console.log("✅ Booking Modal audit passed");

--- a/tr/index.html
+++ b/tr/index.html
@@ -362,6 +362,14 @@ html { font-display: optional; }
     </form>
     
     <div class="santis-booking-availability" data-booking-availability hidden aria-live="polite"></div>
+    
+    <section class="santis-booking-hold" data-booking-hold hidden aria-live="polite">
+      <p class="santis-booking-hold-eyebrow">Ön uygunluk alındı</p>
+      <h3 data-booking-hold-title>Ritüel zamanınız incelemeye alındı.</h3>
+      <p data-booking-hold-message>
+        Spa ekibi seçtiğiniz ritüel, tarih ve saat bilgisini teyit edecek.
+      </p>
+    </section>
   </div>
 </div>
 <!-- SECTION 2: SIGNATURE EXPERIENCES (V45 COVER FLOW MULTI-CARD) -->


### PR DESCRIPTION
Introduces the Host Review Seal for Booking Confirmation. Listens for the 'guest:booking_availability_checked' payload. When available is true, presents a visually distinct confirmation hold UI communicating to the guest that the spa team will verify the selected slot. Emits a 'guest:booking_confirmation_hold_created' payload for further auditing and ledger storage.