### PR TITLE
feat(booking): add local booking request ledger

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -274,6 +274,13 @@
                 loaded: false
             },
             {
+                id: 'booking-ledger',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-booking-ledger.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -326,8 +333,9 @@
             "booking-modal": { priority: 107, critical: true },
             "booking-availability": { priority: 106, critical: true },
             "booking-confirmation-hold": { priority: 105, critical: true },
-            journey: { priority: 104, critical: true },
-            atmosphere: { priority: 103, critical: true },
+            "booking-ledger": { priority: 104, critical: true },
+            journey: { priority: 103, critical: true },
+            atmosphere: { priority: 102, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-booking-ledger.js
+++ b/assets/js/modules/santis-booking-ledger.js
@@ -1,0 +1,57 @@
+const STORAGE_KEY = "santis:booking-ledger:v1";
+
+export class SantisBookingLedger {
+  static append(entry) {
+    try {
+      const records = this.list();
+      const id = "br_" + Math.random().toString(36).substring(2, 9) + Date.now().toString(36);
+      
+      const newRecord = {
+        id,
+        type: "booking_confirmation_hold_created",
+        ritualTitle: entry.ritualTitle,
+        preferredDate: entry.preferredDate,
+        preferredTime: entry.preferredTime,
+        confirmationMode: entry.confirmationMode || "host-review",
+        source: entry.source || "availability-adapter",
+        createdAt: Date.now()
+      };
+
+      records.push(newRecord);
+      
+      // Keep only last 20 traces
+      if (records.length > 20) {
+        records.shift();
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+      console.log(`[Ledger] Appended booking trace: ${id}`);
+    } catch (error) {
+      console.warn("[Ledger] Append failed", error);
+    }
+  }
+
+  static list() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn("[Ledger] List failed", error);
+      return [];
+    }
+  }
+
+  static clear() {
+    localStorage.removeItem(STORAGE_KEY);
+    console.log("[Ledger] Cleared");
+  }
+}
+
+function bindLedger() {
+  document.addEventListener("guest:booking_confirmation_hold_created", (e) => {
+    SantisBookingLedger.append(e.detail);
+  });
+}
+
+bindLedger();

--- a/scripts/audit-booking-modal.cjs
+++ b/scripts/audit-booking-modal.cjs
@@ -16,6 +16,7 @@ const modalJs = read("assets/js/modules/santis-booking-modal.js");
 const bootloader = read("assets/js/boot/santis-bootloader.js");
 const availabilityJs = read("assets/js/modules/santis-booking-availability.js");
 const holdJs = read("assets/js/modules/santis-booking-confirmation-hold.js");
+const ledgerJs = read("assets/js/modules/santis-booking-ledger.js");
 
 [
   "data-booking-modal",
@@ -31,9 +32,13 @@ assertIncludes(modalJs, "guest:booking_intent_submitted", "intent submit event e
 assertIncludes(availabilityJs, "guest:booking_availability_checked", "availability event emission");
 assertIncludes(availabilityJs, "checkMockAvailability", "mock availability check");
 assertIncludes(holdJs, "guest:booking_confirmation_hold_created", "hold event emission");
+assertIncludes(ledgerJs, "santis:booking-ledger:v1", "ledger storage key");
+assertIncludes(ledgerJs, "guest:booking_confirmation_hold_created", "ledger hold tracking");
+assertIncludes(ledgerJs, "BookingLedger", "ledger class name");
 assertIncludes(bootloader, "santis-booking-modal.js", "bootloader booking module");
 assertIncludes(bootloader, "santis-booking-availability.js", "bootloader availability module");
 assertIncludes(bootloader, "santis-booking-confirmation-hold.js", "bootloader hold module");
+assertIncludes(bootloader, "santis-booking-ledger.js", "bootloader ledger module");
 assertIncludes(css, "prefers-reduced-motion", "reduced motion guard");
 
 console.log("✅ Booking Modal audit passed");


### PR DESCRIPTION
Introduces the Booking Request Ledger. Listens to 'guest:booking_confirmation_hold_created' and safely persists operational audit trails into 'santis:booking-ledger:v1' without capturing or storing any PII. Replaces implicit state with a fully deterministic history ledger, capped at the latest 20 events.