### PR TITLE
feat(booking): add availability API adapter with mock fallback

### DIFF
--- a/assets/js/modules/santis-booking-api-adapter.js
+++ b/assets/js/modules/santis-booking-api-adapter.js
@@ -1,0 +1,22 @@
+export class SantisBookingAPI {
+  static async checkAvailability(payload) {
+    try {
+      const response = await fetch("/api/v1/booking/availability", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify(payload)
+      });
+
+      if (!response.ok) {
+        throw new Error(`Availability API failed: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.warn("[BookingAPI] falling back to mock availability", error);
+      return null;
+    }
+  }
+}

--- a/assets/js/modules/santis-booking-availability.js
+++ b/assets/js/modules/santis-booking-availability.js
@@ -1,3 +1,5 @@
+import { SantisBookingAPI } from "./santis-booking-api-adapter.js";
+
 export function checkMockAvailability(payload) {
   const hour = Number(String(payload.preferredTime || "").split(":")[0]);
 
@@ -41,11 +43,17 @@ function renderAvailability(result) {
 }
 
 function bindAvailabilityAdapter() {
-  document.addEventListener("guest:booking_intent_submitted", (e) => {
+  document.addEventListener("guest:booking_intent_submitted", async (e) => {
     const payload = e.detail;
     if (!payload) return;
     
-    const result = checkMockAvailability(payload);
+    // First try the API
+    let result = await SantisBookingAPI.checkAvailability(payload);
+
+    // If API fails or is not available, fallback to mock
+    if (!result) {
+      result = checkMockAvailability(payload);
+    }
 
     renderAvailability(result);
 

--- a/scripts/audit-booking-modal.cjs
+++ b/scripts/audit-booking-modal.cjs
@@ -17,6 +17,7 @@ const bootloader = read("assets/js/boot/santis-bootloader.js");
 const availabilityJs = read("assets/js/modules/santis-booking-availability.js");
 const holdJs = read("assets/js/modules/santis-booking-confirmation-hold.js");
 const ledgerJs = read("assets/js/modules/santis-booking-ledger.js");
+const apiAdapterJs = read("assets/js/modules/santis-booking-api-adapter.js");
 
 [
   "data-booking-modal",
@@ -31,6 +32,9 @@ assertIncludes(modalJs, "guest:booking_handoff_requested", "handoff event listen
 assertIncludes(modalJs, "guest:booking_intent_submitted", "intent submit event emission");
 assertIncludes(availabilityJs, "guest:booking_availability_checked", "availability event emission");
 assertIncludes(availabilityJs, "checkMockAvailability", "mock availability check");
+assertIncludes(availabilityJs, "SantisBookingAPI.checkAvailability", "API adapter usage");
+assertIncludes(apiAdapterJs, "/api/v1/booking/availability", "API endpoint contract");
+assertIncludes(apiAdapterJs, "falling back to mock availability", "fallback warning log");
 assertIncludes(holdJs, "guest:booking_confirmation_hold_created", "hold event emission");
 assertIncludes(ledgerJs, "santis:booking-ledger:v1", "ledger storage key");
 assertIncludes(ledgerJs, "guest:booking_confirmation_hold_created", "ledger hold tracking");


### PR DESCRIPTION
Introduces the Booking API Adapter. Attempts to validate the booking intent payload against the real '/api/v1/booking/availability' endpoint. If the backend is unreachable or returns an error, it seamlessly falls back to the deterministic 'checkMockAvailability' logic. Ensures progressive enhancement without breaking the frontend experience.