### PR TITLE
feat(booking): add backend availability endpoint

### DIFF
--- a/app/api/v1/endpoints/booking_engine.py
+++ b/app/api/v1/endpoints/booking_engine.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel, Field
+from typing import List, Optional
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/booking", tags=["booking"])
+
+
+class BookingAvailabilityRequest(BaseModel):
+    ritualTitle: str = Field(..., min_length=2)
+    category: Optional[str] = None
+    duration: Optional[str] = None
+    intent: Optional[str] = None
+    atmosphere: Optional[str] = None
+    preferredDate: str = Field(..., min_length=4)
+    preferredTime: str = Field(..., min_length=4)
+    partySize: int = Field(1, ge=1, le=6)
+    source: str = "booking-modal"
+
+
+class BookingAvailabilityResponse(BaseModel):
+    available: bool
+    confirmationMode: str = "host-review"
+    message: str
+    alternatives: List[str] = []
+
+
+@router.post("/availability", response_model=BookingAvailabilityResponse)
+async def check_booking_availability(payload: BookingAvailabilityRequest):
+    hour = int(payload.preferredTime.split(":")[0])
+
+    if hour < 10 or hour > 20:
+        return BookingAvailabilityResponse(
+            available=False,
+            message="Bu saat aralığı dışında müsaitlik bulunmuyor.",
+            alternatives=["11:00", "14:00", "17:30"],
+        )
+
+    return BookingAvailabilityResponse(
+        available=True,
+        message="Seçtiğiniz zaman ön uygunluk kontrolünden geçti. Spa ekibi tarafından teyit edilecektir.",
+        alternatives=[],
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+from app.api.v1.endpoints import booking_engine
+
+app = FastAPI(title="Santis OS API")
+
+app.include_router(booking_engine.router, prefix="/api/v1")

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "audit:guest-journey": "node scripts/audit-guest-journey.cjs",
     "audit:vault": "node scripts/audit-sovereign-vault.cjs",
     "audit:checkout": "node scripts/audit-checkout-ceremony.cjs",
-    "audit:booking": "node scripts/audit-booking-modal.cjs"
+    "audit:booking": "node scripts/audit-booking-modal.cjs",
+    "audit:booking-api": "node scripts/audit-booking-api.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-booking-api.cjs
+++ b/scripts/audit-booking-api.cjs
@@ -1,0 +1,27 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+const endpointPy = read("app/api/v1/endpoints/booking_engine.py");
+const mainPy = read("app/main.py");
+
+[
+  ".post(",
+  "/availability",
+  "BookingAvailabilityRequest",
+  "BookingAvailabilityResponse",
+  "host-review",
+  "alternatives"
+].forEach(needle => assertIncludes(endpointPy, needle, "Backend endpoint contract"));
+
+assertIncludes(mainPy, "/api/v1", "API version prefix in main app");
+
+console.log("✅ Booking API Backend audit passed");


### PR DESCRIPTION
Introduces the Booking API backend layer using FastAPI and Pydantic. Implements the /api/v1/booking/availability endpoint with deterministic mock logic that strictly honors the 'Zero-PII' contract. This completes the end-to-end integration loop from the Booking UI Adapter all the way to a server-side payload validation block.