### PR TITLE
test(booking): add backend availability contract audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "audit:vault": "node scripts/audit-sovereign-vault.cjs",
     "audit:checkout": "node scripts/audit-checkout-ceremony.cjs",
     "audit:booking": "node scripts/audit-booking-modal.cjs",
-    "audit:booking-api": "node scripts/audit-booking-api.cjs"
+    "audit:booking-api": "node scripts/audit-booking-api.cjs",
+    "audit:booking-api-contract": "node scripts/audit-booking-api-contract.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-booking-api-contract.cjs
+++ b/scripts/audit-booking-api-contract.cjs
@@ -1,0 +1,42 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const endpointPy = read("app/api/v1/endpoints/booking_engine.py");
+
+[
+  "BookingAvailabilityRequest",
+  "BookingAvailabilityResponse",
+  "partySize",
+  "ge=1",
+  "le=6",
+  "preferredDate",
+  "preferredTime",
+  "available=False",
+  "available=True",
+  "host-review",
+  "alternatives"
+].forEach(needle => assertIncludes(endpointPy, needle, "Backend contract element"));
+
+[
+  "email",
+  "phone",
+  "name",
+  "payment"
+].forEach(needle => assertNotIncludes(endpointPy, needle, "PII/Payment element"));
+
+console.log("✅ Booking API Contract Hardening audit passed");


### PR DESCRIPTION
Hardening phase for the Booking API Backend Contract. Explicitly asserts that PII (email, phone, name, payment) is NOT collected at this stage. Enforces strict schema rules for 'partySize', 'preferredDate', 'preferredTime', and deterministic 'available=True/False' outcomes to prevent regressions.