### PR TITLE
feat(payment): add payment readiness locked UI

### DIFF
--- a/assets/css/santis-v6/santis.booking.css
+++ b/assets/css/santis-v6/santis.booking.css
@@ -145,6 +145,33 @@
   opacity: 0.72;
 }
 
+.santis-payment-readiness {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 22px;
+  border: 1px solid color-mix(in srgb, var(--color-gold, #d4af37) 18%, transparent);
+  background: color-mix(in srgb, var(--color-ink, #0b0f14) 58%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.santis-payment-readiness-eyebrow {
+  margin: 0 0 0.5rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  opacity: 0.68;
+}
+
+.santis-payment-readiness h3 {
+  margin: 0;
+  font-size: clamp(1.15rem, 2.4vw, 1.65rem);
+  font-weight: 400;
+}
+
+.santis-payment-readiness p {
+  opacity: 0.72;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .santis-booking-modal,
   .santis-booking-modal-content {

--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -288,6 +288,13 @@
                 loaded: false
             },
             {
+                id: 'payment-readiness-ui',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-payment-readiness-ui.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -342,8 +349,9 @@
             "booking-confirmation-hold": { priority: 105, critical: true },
             "booking-ledger": { priority: 104, critical: true },
             "payment-eligibility": { priority: 103, critical: true },
-            journey: { priority: 102, critical: true },
-            atmosphere: { priority: 101, critical: true },
+            "payment-readiness-ui": { priority: 102, critical: true },
+            journey: { priority: 101, critical: true },
+            atmosphere: { priority: 100, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-payment-readiness-ui.js
+++ b/assets/js/modules/santis-payment-readiness-ui.js
@@ -1,0 +1,27 @@
+function renderPaymentReadiness(e) {
+  const payload = e.detail;
+  const panel = document.querySelector("[data-payment-readiness]");
+  const title = document.querySelector("[data-payment-readiness-title]");
+  const message = document.querySelector("[data-payment-readiness-message]");
+
+  if (!panel || !payload?.paymentEligibility) return;
+
+  panel.hidden = false;
+
+  if (payload.paymentEligibility.eligible) {
+    title.textContent = "Ödeme adımı hazırlanıyor.";
+    message.textContent = payload.paymentEligibility.message || "Ödeme adımı için ön koşullar tamamlandı.";
+    return;
+  }
+
+  title.textContent = "Ödeme adımı şu anda kapalı.";
+  message.textContent =
+    payload.paymentEligibility.message ||
+    "Spa ekibi ritüel zamanınızı ve fiyat bilgisini teyit ettikten sonra ödeme adımı açılacaktır.";
+}
+
+function bindPaymentReadinessUI() {
+  document.addEventListener("guest:payment_eligibility_checked", renderPaymentReadiness);
+}
+
+bindPaymentReadinessUI();

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "audit:booking": "node scripts/audit-booking-modal.cjs",
     "audit:booking-api": "node scripts/audit-booking-api.cjs",
     "audit:booking-api-contract": "node scripts/audit-booking-api-contract.cjs",
-    "audit:payment-eligibility": "node scripts/audit-payment-eligibility.cjs"
+    "audit:payment-eligibility": "node scripts/audit-payment-eligibility.cjs",
+    "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-payment-readiness-ui.cjs
+++ b/scripts/audit-payment-readiness-ui.cjs
@@ -1,0 +1,41 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const htmlFile = read("tr/index.html");
+const jsFile = read("assets/js/modules/santis-payment-readiness-ui.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "data-payment-readiness",
+  "data-payment-readiness-title",
+  "data-payment-readiness-message"
+].forEach(needle => assertIncludes(htmlFile, needle, "HTML Contract"));
+
+[
+  "guest:payment_eligibility_checked",
+  "Ödeme adımı şu anda kapalı"
+].forEach(needle => assertIncludes(jsFile, needle, "JS Logic"));
+
+[
+  "stripe",
+  "payment method"
+].forEach(needle => assertNotIncludes(jsFile, needle, "PII/Payment info"));
+
+assertIncludes(bootloader, "santis-payment-readiness-ui.js", "Bootloader registry");
+
+console.log("✅ Payment Readiness UI audit passed");

--- a/tr/index.html
+++ b/tr/index.html
@@ -370,6 +370,14 @@ html { font-display: optional; }
         Spa ekibi seçtiğiniz ritüel, tarih ve saat bilgisini teyit edecek.
       </p>
     </section>
+
+    <section class="santis-payment-readiness" data-payment-readiness hidden aria-live="polite">
+      <p class="santis-payment-readiness-eyebrow">Ödeme durumu</p>
+      <h3 data-payment-readiness-title>Ödeme adımı şu anda kapalı.</h3>
+      <p data-payment-readiness-message>
+        Spa ekibi ritüel zamanınızı ve fiyat bilgisini teyit ettikten sonra ödeme adımı açılacaktır.
+      </p>
+    </section>
   </div>
 </div>
 <!-- SECTION 2: SIGNATURE EXPERIENCES (V45 COVER FLOW MULTI-CARD) -->


### PR DESCRIPTION
Introduces the Payment Readiness UI. Integrates directly with 'guest:payment_eligibility_checked' to render a clear, locked state UI indicating to the guest that the checkout system is awaiting price data and host review approval before transitioning into an active Stripe session. Reinforces the zero-PII/non-transactional integrity of the first stage of booking.