### PR TITLE
feat(payment): add payment readiness ledger

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -295,6 +295,13 @@
                 loaded: false
             },
             {
+                id: 'payment-readiness-ledger',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-payment-readiness-ledger.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -350,8 +357,9 @@
             "booking-ledger": { priority: 104, critical: true },
             "payment-eligibility": { priority: 103, critical: true },
             "payment-readiness-ui": { priority: 102, critical: true },
-            journey: { priority: 101, critical: true },
-            atmosphere: { priority: 100, critical: true },
+            "payment-readiness-ledger": { priority: 101, critical: true },
+            journey: { priority: 100, critical: true },
+            atmosphere: { priority: 99, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-payment-readiness-ledger.js
+++ b/assets/js/modules/santis-payment-readiness-ledger.js
@@ -1,0 +1,57 @@
+const STORAGE_KEY = "santis:payment-readiness-ledger:v1";
+
+export class SantisPaymentReadinessLedger {
+  static append(payload) {
+    try {
+      const records = this.list();
+      const id = "pr_" + Math.random().toString(36).substring(2, 9) + Date.now().toString(36);
+      
+      const newRecord = {
+        id,
+        type: "payment_eligibility_checked",
+        eligible: payload?.paymentEligibility?.eligible || false,
+        reason: payload?.paymentEligibility?.reason || "price_required",
+        ritualTitle: payload?.ritualTitle,
+        confirmationMode: payload?.confirmationMode || "host-review",
+        source: "payment-eligibility",
+        createdAt: Date.now()
+      };
+
+      records.push(newRecord);
+      
+      // Keep only last 20 traces
+      if (records.length > 20) {
+        records.shift();
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+      console.log(`[ReadinessLedger] Appended payment readiness trace: ${id}`);
+    } catch (error) {
+      console.warn("[ReadinessLedger] Append failed", error);
+    }
+  }
+
+  static list() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      return JSON.parse(raw);
+    } catch (error) {
+      console.warn("[ReadinessLedger] List failed", error);
+      return [];
+    }
+  }
+
+  static clear() {
+    localStorage.removeItem(STORAGE_KEY);
+    console.log("[ReadinessLedger] Cleared");
+  }
+}
+
+function bindReadinessLedger() {
+  document.addEventListener("guest:payment_eligibility_checked", (e) => {
+    SantisPaymentReadinessLedger.append(e.detail);
+  });
+}
+
+bindReadinessLedger();

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "audit:booking-api": "node scripts/audit-booking-api.cjs",
     "audit:booking-api-contract": "node scripts/audit-booking-api-contract.cjs",
     "audit:payment-eligibility": "node scripts/audit-payment-eligibility.cjs",
-    "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs"
+    "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs",
+    "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-payment-readiness-ledger.cjs
+++ b/scripts/audit-payment-readiness-ledger.cjs
@@ -1,0 +1,40 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const jsFile = read("assets/js/modules/santis-payment-readiness-ledger.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "santis:payment-readiness-ledger:v1",
+  "guest:payment_eligibility_checked",
+  "payment_eligibility_checked",
+  "price_required"
+].forEach(needle => assertIncludes(jsFile, needle, "Readiness Ledger contract"));
+
+[
+  "email",
+  "phone",
+  "name",
+  "card",
+  "stripeSession",
+  "stripe"
+].forEach(needle => assertNotIncludes(jsFile, needle, "PII/Payment info leak check"));
+
+assertIncludes(bootloader, "santis-payment-readiness-ledger.js", "Bootloader registry");
+
+console.log("✅ Payment Readiness Ledger audit passed");


### PR DESCRIPTION
Introduces the Payment Readiness Ledger. Persists the 'payment_eligibility_checked' state into 'santis:payment-readiness-ledger:v1' local storage key for audit and traceability, explicitly stripping out any sensitive elements (email, phone, payment fields). Reinforces operational observability leading up to the final Stripe Session phase.