### PR TITLE
feat(payment): introduce stripe session shell

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -302,6 +302,13 @@
                 loaded: false
             },
             {
+                id: 'stripe-session-shell',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-stripe-session-shell.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -358,8 +365,9 @@
             "payment-eligibility": { priority: 103, critical: true },
             "payment-readiness-ui": { priority: 102, critical: true },
             "payment-readiness-ledger": { priority: 101, critical: true },
-            journey: { priority: 100, critical: true },
-            atmosphere: { priority: 99, critical: true },
+            "stripe-session-shell": { priority: 100, critical: true },
+            journey: { priority: 99, critical: true },
+            atmosphere: { priority: 98, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-stripe-session-shell.js
+++ b/assets/js/modules/santis-stripe-session-shell.js
@@ -1,0 +1,31 @@
+function bindStripeSessionShell() {
+  document.addEventListener("guest:payment_eligibility_checked", (e) => {
+    const payload = e.detail;
+    const eligibility = payload?.paymentEligibility;
+
+    if (!eligibility?.eligible) {
+      const blockedPayload = {
+        reason: eligibility?.reason || "payment_not_eligible",
+        source: "stripe-session-shell",
+        timestamp: Date.now()
+      };
+      
+      window.SantisBus?.emit?.("guest:stripe_session_blocked", blockedPayload);
+      document.dispatchEvent(new CustomEvent("guest:stripe_session_blocked", { detail: blockedPayload }));
+      return;
+    }
+
+    const requestedPayload = {
+      ritualTitle: payload.ritualTitle,
+      preferredDate: payload.preferredDate,
+      preferredTime: payload.preferredTime,
+      source: "stripe-session-shell",
+      timestamp: Date.now()
+    };
+
+    window.SantisBus?.emit?.("guest:stripe_session_requested", requestedPayload);
+    document.dispatchEvent(new CustomEvent("guest:stripe_session_requested", { detail: requestedPayload }));
+  });
+}
+
+bindStripeSessionShell();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "audit:booking-api-contract": "node scripts/audit-booking-api-contract.cjs",
     "audit:payment-eligibility": "node scripts/audit-payment-eligibility.cjs",
     "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs",
-    "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs"
+    "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs",
+    "audit:stripe-session-shell": "node scripts/audit-stripe-session-shell.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-stripe-session-shell.cjs
+++ b/scripts/audit-stripe-session-shell.cjs
@@ -1,0 +1,39 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const jsFile = read("assets/js/modules/santis-stripe-session-shell.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "guest:payment_eligibility_checked",
+  "guest:stripe_session_blocked",
+  "guest:stripe_session_requested",
+  "payment_not_eligible",
+  "stripe-session-shell"
+].forEach(needle => assertIncludes(jsFile, needle, "Stripe Session Shell logic"));
+
+[
+  "secret",
+  "sk_",
+  "card",
+  "checkout.redirect"
+].forEach(needle => assertNotIncludes(jsFile, needle, "Real SDK/Secret leak"));
+
+assertIncludes(bootloader, "santis-stripe-session-shell.js", "Bootloader registry");
+
+console.log("✅ Stripe Session Shell audit passed");


### PR DESCRIPTION
Introduces the Stripe Session Shell. A secure, event-driven stub that intercepts 'payment_eligibility_checked'. It enforces that without a resolved price and explicit eligibility flag, it safely emits 'guest:stripe_session_blocked' and halts. When eligible, it yields 'guest:stripe_session_requested' without importing the SDK, holding zero PII, and avoiding premature API calls. Hardening prior to full backend session initialization.