### PR TITLE
feat(payment): introduce pricing readiness engine

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -309,6 +309,13 @@
                 loaded: false
             },
             {
+                id: 'pricing-readiness',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-pricing-readiness.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'journey',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-journey-orchestrator.js'],
@@ -362,6 +369,7 @@
             "booking-availability": { priority: 106, critical: true },
             "booking-confirmation-hold": { priority: 105, critical: true },
             "booking-ledger": { priority: 104, critical: true },
+            "pricing-readiness": { priority: 103.5, critical: true },
             "payment-eligibility": { priority: 103, critical: true },
             "payment-readiness-ui": { priority: 102, critical: true },
             "payment-readiness-ledger": { priority: 101, critical: true },

--- a/assets/js/modules/santis-pricing-readiness.js
+++ b/assets/js/modules/santis-pricing-readiness.js
@@ -1,0 +1,40 @@
+function resolvePricingReadiness(payload) {
+  const hasPrice = typeof payload?.price === "number" && payload.price > 0;
+
+  if (!hasPrice) {
+    return {
+      resolved: false,
+      reason: "price_required",
+      message: "Fiyat bilgisi spa ekibi tarafından teyit edildikten sonra ödeme adımı açılacaktır."
+    };
+  }
+
+  return {
+    resolved: true,
+    price: payload.price,
+    currency: payload.currency || "EUR",
+    message: "Fiyat bilgisi doğrulandı."
+  };
+}
+
+function bindPricingReadiness() {
+  document.addEventListener("guest:booking_confirmation_hold_created", (e) => {
+    const payload = e.detail;
+    if (!payload) return;
+
+    const result = resolvePricingReadiness(payload);
+    
+    const eventPayload = {
+      ...payload,
+      pricing: result,
+      timestamp: Date.now()
+    };
+
+    const eventName = result.resolved ? "guest:pricing_resolved" : "guest:pricing_required";
+    
+    window.SantisBus?.emit?.(eventName, eventPayload);
+    document.dispatchEvent(new CustomEvent(eventName, { detail: eventPayload }));
+  });
+}
+
+bindPricingReadiness();

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "audit:payment-eligibility": "node scripts/audit-payment-eligibility.cjs",
     "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs",
     "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs",
-    "audit:stripe-session-shell": "node scripts/audit-stripe-session-shell.cjs"
+    "audit:stripe-session-shell": "node scripts/audit-stripe-session-shell.cjs",
+    "audit:pricing-readiness": "node scripts/audit-pricing-readiness.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-pricing-readiness.cjs
+++ b/scripts/audit-pricing-readiness.cjs
@@ -1,0 +1,38 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const jsFile = read("assets/js/modules/santis-pricing-readiness.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "guest:pricing_required",
+  "guest:pricing_resolved",
+  "price_required",
+  "currency",
+  "EUR"
+].forEach(needle => assertIncludes(jsFile, needle, "Pricing Readiness contract"));
+
+[
+  "stripe",
+  "checkout",
+  "card"
+].forEach(needle => assertNotIncludes(jsFile, needle, "Real SDK/Secret leak"));
+
+assertIncludes(bootloader, "santis-pricing-readiness.js", "Bootloader registry");
+
+console.log("✅ Pricing Readiness Engine audit passed");


### PR DESCRIPTION
Introduces the Pricing Readiness Engine. Orchestrates early price resolution deterministically, acting as a gateway before Payment Eligibility logic. If price is unconfirmed, yields 'guest:pricing_required'; else yields 'guest:pricing_resolved'. Does not initiate any checkout redirects or Stripe calls, purely honoring the sovereign state separation.