### PR TITLE
feat(billing): add backend checkout session shell

### DIFF
--- a/app/api/v1/endpoints/billing.py
+++ b/app/api/v1/endpoints/billing.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/billing", tags=["billing"])
+
+
+class CheckoutSessionRequest(BaseModel):
+    ritualTitle: str = Field(..., min_length=2)
+    preferredDate: str = Field(..., min_length=4)
+    preferredTime: str = Field(..., min_length=4)
+    price: Optional[int] = Field(None, ge=1)
+    currency: str = "EUR"
+    source: str = "stripe-session-shell"
+
+
+class CheckoutSessionResponse(BaseModel):
+    ready: bool
+    reason: str
+    message: str
+    sessionUrl: Optional[str] = None
+
+
+@router.post("/checkout-session", response_model=CheckoutSessionResponse)
+async def create_checkout_session(payload: CheckoutSessionRequest):
+    if not payload.price:
+        return CheckoutSessionResponse(
+            ready=False,
+            reason="price_required",
+            message="Fiyat bilgisi teyit edilmeden ödeme oturumu açılamaz.",
+        )
+
+    return CheckoutSessionResponse(
+        ready=False,
+        reason="stripe_not_configured",
+        message="Ödeme oturumu henüz aktif değil. Spa ekibi fiyat ve zaman bilgisini teyit ettikten sonra açılacaktır.",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
-from app.api.v1.endpoints import booking_engine
+from app.api.v1.endpoints import booking_engine, billing
 
 app = FastAPI(title="Santis OS API")
 
 app.include_router(booking_engine.router, prefix="/api/v1")
+app.include_router(billing.router, prefix="/api/v1")

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "audit:payment-readiness": "node scripts/audit-payment-readiness-ui.cjs",
     "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs",
     "audit:stripe-session-shell": "node scripts/audit-stripe-session-shell.cjs",
-    "audit:pricing-readiness": "node scripts/audit-pricing-readiness.cjs"
+    "audit:pricing-readiness": "node scripts/audit-pricing-readiness.cjs",
+    "audit:billing-checkout": "node scripts/audit-billing-checkout-session.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-billing-checkout-session.cjs
+++ b/scripts/audit-billing-checkout-session.cjs
@@ -1,0 +1,38 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const endpointPy = read("app/api/v1/endpoints/billing.py");
+
+[
+  "/checkout-session",
+  "CheckoutSessionRequest",
+  "CheckoutSessionResponse",
+  "price_required",
+  "stripe_not_configured",
+  "sessionUrl"
+].forEach(needle => assertIncludes(endpointPy, needle, "Billing Backend contract"));
+
+[
+  "sk_",
+  "stripe.checkout",
+  "card",
+  "email",
+  "phone"
+].forEach(needle => assertNotIncludes(endpointPy, needle, "PII/Secret leak"));
+
+console.log("✅ Billing Checkout Session audit passed");


### PR DESCRIPTION
Introduces the Server-Side Billing Checkout Session endpoint (FastAPI). Before initializing a real Stripe session, this shell validates the presence of a resolved price. If missing, it correctly returns a 400-level conceptual rejection. Currently operates entirely safely without loading the actual Stripe SDK or any live keys, honoring the 'Zero-PII' phase.