### PR TITLE
feat(billing): add frontend billing session adapter

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -309,6 +309,13 @@
                 loaded: false
             },
             {
+                id: 'billing-session-adapter',
+                selectors: ['body'],
+                dependencies: ['/assets/js/modules/santis-billing-session-adapter.js'],
+                isModule: true,
+                loaded: false
+            },
+            {
                 id: 'pricing-readiness',
                 selectors: ['body'],
                 dependencies: ['/assets/js/modules/santis-pricing-readiness.js'],
@@ -374,8 +381,9 @@
             "payment-readiness-ui": { priority: 102, critical: true },
             "payment-readiness-ledger": { priority: 101, critical: true },
             "stripe-session-shell": { priority: 100, critical: true },
-            journey: { priority: 99, critical: true },
-            atmosphere: { priority: 98, critical: true },
+            "billing-session-adapter": { priority: 99, critical: true },
+            journey: { priority: 98, critical: true },
+            atmosphere: { priority: 97, critical: true },
             nav: { priority: 100, critical: true },
             checkout: { priority: 90, critical: true },
             bento: { priority: 70, critical: true },

--- a/assets/js/modules/santis-billing-session-adapter.js
+++ b/assets/js/modules/santis-billing-session-adapter.js
@@ -1,0 +1,43 @@
+async function requestCheckoutSession(payload) {
+  try {
+    const response = await fetch("/api/v1/billing/checkout-session", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(payload)
+    });
+
+    return await response.json();
+  } catch (error) {
+    console.warn("[BillingSession] checkout session request failed", error);
+
+    return {
+      ready: false,
+      reason: "billing_api_unreachable",
+      message: "Ödeme oturumu şu anda hazırlanamadı."
+    };
+  }
+}
+
+function bindBillingSessionAdapter() {
+  document.addEventListener("guest:stripe_session_requested", async (e) => {
+    const payload = e.detail;
+    if (!payload) return;
+
+    const result = await requestCheckoutSession(payload);
+    
+    const eventName = result.ready ? "guest:billing_session_ready" : "guest:stripe_session_blocked";
+    const eventPayload = {
+      ...payload,
+      billingSession: result,
+      source: "billing-session-adapter",
+      timestamp: Date.now()
+    };
+
+    window.SantisBus?.emit?.(eventName, eventPayload);
+    document.dispatchEvent(new CustomEvent(eventName, { detail: eventPayload }));
+  });
+}
+
+bindBillingSessionAdapter();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "audit:payment-readiness-ledger": "node scripts/audit-payment-readiness-ledger.cjs",
     "audit:stripe-session-shell": "node scripts/audit-stripe-session-shell.cjs",
     "audit:pricing-readiness": "node scripts/audit-pricing-readiness.cjs",
-    "audit:billing-checkout": "node scripts/audit-billing-checkout-session.cjs"
+    "audit:billing-checkout": "node scripts/audit-billing-checkout-session.cjs",
+    "audit:billing-session-adapter": "node scripts/audit-billing-session-adapter.cjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/audit-billing-session-adapter.cjs
+++ b/scripts/audit-billing-session-adapter.cjs
@@ -1,0 +1,39 @@
+const fs = require("fs");
+
+function read(path) {
+  return fs.readFileSync(path, "utf8");
+}
+
+function assertIncludes(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`Missing ${label}: ${needle}`);
+  }
+}
+
+function assertNotIncludes(source, needle, label) {
+  if (source.includes(needle)) {
+    throw new Error(`Forbidden ${label} found: ${needle}`);
+  }
+}
+
+const jsFile = read("assets/js/modules/santis-billing-session-adapter.js");
+const bootloader = read("assets/js/boot/santis-bootloader.js");
+
+[
+  "/api/v1/billing/checkout-session",
+  "guest:stripe_session_requested",
+  "guest:billing_session_ready",
+  "guest:stripe_session_blocked",
+  "billing_api_unreachable"
+].forEach(needle => assertIncludes(jsFile, needle, "Billing Session Adapter contract"));
+
+[
+  "window.location",
+  "redirect",
+  "sk_",
+  "card"
+].forEach(needle => assertNotIncludes(jsFile, needle, "PII/Redirect/Secret leak"));
+
+assertIncludes(bootloader, "santis-billing-session-adapter.js", "Bootloader registry");
+
+console.log("✅ Billing Session Adapter audit passed");


### PR DESCRIPTION
Introduces the Frontend Billing Session Adapter. It listens for the 'guest:stripe_session_requested' handoff event from the shell, safely dispatches a network request to the backend checkout-session API, and processes the deterministic 'ready: false' server reply. By broadcasting 'guest:stripe_session_blocked' back out to the UI space, it successfully closes the mock feedback loop without invoking Stripe.