### PR TITLE
ci: enforce pnpm 9.1.0 as single source of truth across workflows (Fixes #50)

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
             - name: Enable corepack and install pnpm
               run: |
                   corepack enable
-                  corepack prepare pnpm@10.24.0 --activate
+                  corepack prepare pnpm@9.1.0 --activate
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/santis-sovereign-diagnostic.yml
+++ b/.github/workflows/santis-sovereign-diagnostic.yml
@@ -22,7 +22,7 @@ jobs:
     - name: 📦 Install pnpm
       uses: pnpm/action-setup@v3
       with:
-        version: 10.24.0
+        version: 9.1.0
 
     - name: ⚙️ Boot Node.js Environment
       uses: actions/setup-node@v4

--- a/.github/workflows/sovereign-ci.yml
+++ b/.github/workflows/sovereign-ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: corepack enable
 
       - name: "Resolve pnpm version"
-        run: corepack prepare pnpm@10.24.0 --activate
+        run: corepack prepare pnpm@9.1.0 --activate
 
       - name: "Setup pnpm cache"
         uses: actions/setup-node@v4

--- a/.github/workflows/sovereign-guard.yml
+++ b/.github/workflows/sovereign-guard.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Resolve pnpm version
-        run: corepack prepare pnpm@10.24.0 --activate
+        run: corepack prepare pnpm@9.1.0 --activate
       - name: Setup pnpm cache
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/stitch-governance.yml
+++ b/.github/workflows/stitch-governance.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10.24.0
+          version: 9.1.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "engines": {
     "node": ">=20.0.0 <21.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=9.0.0"
   },
-  "packageManager": "pnpm@10.24.0",
+  "packageManager": "pnpm@9.1.0",
   "scripts": {
     "env:check": "node -v",
     "onboard": "fnm use && pnpm install",


### PR DESCRIPTION
This PR fixes the dependency mismatch issue and properly enforces pnpm 9.1.0 across all GitHub Action workflows and package.json, closing #50 without violating the strict no-npm repository rules.