### PR TITLE
fix(admin): resolve sovereign socket provider import

### DIFF
--- a/admin-panel/src/App.jsx
+++ b/admin-panel/src/App.jsx
@@ -7,7 +7,7 @@ import Login from './pages/Login';
 import useAuthStore from './store/useAuthStore';
 import ClinicScanner from './components/dashboard/ClinicScanner';
 import { BoardroomModeProvider } from './features/boardroom/context/BoardroomModeContext';
-import { SovereignSocketProvider } from './context/SovereignSocketContext';
+import { SovereignSocketProvider } from './context/SovereignSocketProvider';
 import {
   AdminLazyBoundary,
   LazyOperations,


### PR DESCRIPTION
﻿## Summary

Fixes the admin-panel build by correcting the SovereignSocketProvider import path.

## Change

```diff
- import { SovereignSocketProvider } from './context/SovereignSocketContext';
+ import { SovereignSocketProvider } from './context/SovereignSocketProvider';
```

## Validation

* `pnpm --filter admin-panel build` passed
* `pnpm run audit:all` was attempted but is currently blocked by an existing repo-boundary violation:
  * `apps/ingestion-api` is a forbidden operational path

## Scope

* Changed only `admin-panel/src/App.jsx`
* No `pnpm-workspace.yaml` changes
* No repo-boundary changes
* No ingestion-api changes
* No dependency or lockfile changes
* Local `apps/ingestion-api/.env` remains ignored and out of scope
