### PR TITLE
hardening(rvs): require sessionToken in basic envelope validation

### DIFF
--- a/assets/js/core/santis-rvs-telemetry-dispatcher.js
+++ b/assets/js/core/santis-rvs-telemetry-dispatcher.js
@@ -74,6 +74,7 @@
             envelope &&
             ALLOWED_TYPES.has(envelope.type) &&
             typeof envelope.timestamp === 'number' &&
+            typeof envelope.sessionToken === 'string' &&
             typeof envelope.normalizedPath === 'string' &&
             typeof envelope.details === 'object' &&
             envelope.details !== null

--- a/scripts/active/audit-rvs-client-telemetry-dispatcher.mjs
+++ b/scripts/active/audit-rvs-client-telemetry-dispatcher.mjs
@@ -83,8 +83,9 @@ assert(
 // 9. Verify basic envelope validation (validateEnvelope)
 assert(
   fileContent.includes('validateEnvelope') &&
-  fileContent.includes('ALLOWED_TYPES'),
-  'Module enforces basic RVS envelope schema validation.'
+  fileContent.includes('ALLOWED_TYPES') &&
+  fileContent.includes('envelope.sessionToken === \'string\''),
+  'Module enforces basic RVS envelope schema validation including sessionToken verification.'
 );
 
 console.log('\n[SANTIS_RVS_DISPATCHER_AUDIT] Audit Scan Completed.');


### PR DESCRIPTION
Implements RVS-6.1 to enforce that envelope.sessionToken is a required string in validateEnvelope, and updates the RVS Client Telemetry Dispatcher audit script to assert this constraint. All global audits are fully green.