### PR TITLE
feat(rvs): add telemetry endpoint backend stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "audit:rvs-scene-entropy-contract": "node scripts/active/audit-scene-entropy-contract.mjs",
     "audit:rvs-telemetry-endpoint-contract": "node scripts/active/audit-rvs-telemetry-endpoint-contract.mjs",
     "audit:rvs-client-telemetry-dispatcher": "node scripts/active/audit-rvs-client-telemetry-dispatcher.mjs",
-    "audit:rvs-santisdom-telemetry": "node scripts/active/audit-rvs-santisdom-telemetry.mjs"
+    "audit:rvs-santisdom-telemetry": "node scripts/active/audit-rvs-santisdom-telemetry.mjs",
+    "audit:rvs-telemetry-backend-stub": "node scripts/active/audit-rvs-telemetry-backend-stub.mjs"
   },
   "dependencies": {
     "gsap": "^3.15.0",

--- a/scripts/active/audit-rvs-telemetry-backend-stub.mjs
+++ b/scripts/active/audit-rvs-telemetry-backend-stub.mjs
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fsPromises from 'fs/promises';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '../../');
+
+const MOCK_LAYER_PATH = path.join(ROOT_DIR, 'scripts/sovereign-mock-layer.mjs');
+
+console.log('[SANTIS_RVS_BACKEND_AUDIT] Verifying RVS Telemetry Endpoint Backend Stub (RVS-8)...');
+
+let hasErrors = false;
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[FAILED] ${message}`);
+    hasErrors = true;
+  } else {
+    console.log(`[PASSED] ${message}`);
+  }
+}
+
+// 1. Check if mock layer exists
+assert(fs.existsSync(MOCK_LAYER_PATH), 'Sovereign Mock Layer exists at scripts/sovereign-mock-layer.mjs');
+
+if (!fs.existsSync(MOCK_LAYER_PATH)) {
+  console.error('[CRITICAL] Sovereign Mock Layer is missing. Aborting.');
+  process.exit(1);
+}
+
+const fileContent = fs.readFileSync(MOCK_LAYER_PATH, 'utf-8');
+
+// 2. Check if endpoint path is registered
+assert(
+  fileContent.includes('/api/v1/telemetry/rvs'),
+  'Mock layer registers /api/v1/telemetry/rvs endpoint.'
+);
+
+// 3. Verify POST method handling
+assert(
+  fileContent.includes("req.url === '/api/v1/telemetry/rvs' && req.method === 'POST'"),
+  'Mock layer enforces POST requests only for RVS telemetry.'
+);
+
+// 4. Verify max size (8KB payload guard)
+assert(
+  fileContent.includes('8192') && 
+  fileContent.includes('413'),
+  'Mock layer implements strict 8KB payload size guard returning HTTP 413.'
+);
+
+// 5. Verify strict envelope schema validation
+assert(
+  fileContent.includes('LAYOUT_REFLOW_ANOMALY') &&
+  fileContent.includes('CINEMATIC_BUDGET_WARNING') &&
+  fileContent.includes('SCENE_ENTROPY_SHIFT'),
+  'Mock layer validates all three standard RVS telemetry type classifications.'
+);
+
+assert(
+  fileContent.includes('envelope.type') &&
+  fileContent.includes('envelope.timestamp') &&
+  fileContent.includes('envelope.sessionToken') &&
+  fileContent.includes('envelope.normalizedPath') &&
+  fileContent.includes('envelope.details'),
+  'Mock layer validates full contract envelope properties.'
+);
+
+// 6. Verify response codes
+assert(
+  fileContent.includes('res.writeHead(204)'),
+  'Mock layer returns HTTP 204 No Content response on successful validation.'
+);
+
+assert(
+  fileContent.includes('res.writeHead(400)'),
+  'Mock layer returns HTTP 400 Bad Request on invalid/malformed telemetry.'
+);
+
+console.log('\n[SANTIS_RVS_BACKEND_AUDIT] Audit Scan Completed.');
+
+if (hasErrors) {
+  console.error('[FAILED] RVS Telemetry Backend Stub audit failed. Please align scripts/sovereign-mock-layer.mjs with boardroom specifications.');
+  process.exit(1);
+}
+
+console.log('[SUCCESS] RVS Telemetry Backend Stub verified and aligned perfectly with boardroom specifications.');
+process.exit(0);

--- a/scripts/sovereign-mock-layer.mjs
+++ b/scripts/sovereign-mock-layer.mjs
@@ -58,6 +58,60 @@ const truthLayer = http.createServer((req, res) => {
     return;
   }
 
+  // 2.1 RVS Telemetry Endpoint Stub (RVS-8 Enforced)
+  if (req.url === '/api/v1/telemetry/rvs' && req.method === 'POST') {
+    let body = '';
+    let bytesReceived = 0;
+    const maxBytes = 8192; // 8KB Guard
+
+    req.on('data', chunk => {
+      bytesReceived += chunk.length;
+      if (bytesReceived > maxBytes) {
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Payload Too Large: Maximum size is 8KB.' }));
+        req.destroy();
+      } else {
+        body += chunk.toString();
+      }
+    });
+
+    req.on('end', () => {
+      if (bytesReceived > maxBytes) return;
+
+      try {
+        const envelope = JSON.parse(body);
+        
+        // Envelope validation according to Telemetry Endpoint Contract (v1.0)
+        const allowedTypes = new Set(['LAYOUT_REFLOW_ANOMALY', 'CINEMATIC_BUDGET_WARNING', 'SCENE_ENTROPY_SHIFT']);
+        
+        const isValid = !!(
+          envelope &&
+          allowedTypes.has(envelope.type) &&
+          typeof envelope.timestamp === 'number' &&
+          typeof envelope.sessionToken === 'string' &&
+          typeof envelope.normalizedPath === 'string' &&
+          typeof envelope.details === 'object' &&
+          envelope.details !== null
+        );
+
+        if (!isValid) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Bad Request: Malformed telemetry envelope structure.' }));
+          return;
+        }
+
+        console.log(`🛡️ [RVS Telemetry Backend] Received telemetry payload: type=${envelope.type}, path=${envelope.normalizedPath}`);
+        
+        res.writeHead(204);
+        res.end();
+      } catch (error) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Bad Request: Invalid JSON payload.' }));
+      }
+    });
+    return;
+  }
+
   // 3. Socket.io Handshake (Vite üzerinden 8080 -> 3030 aktarımı için)
   if (req.url.startsWith('/socket.io/')) {
     res.writeHead(200);


### PR DESCRIPTION
Registers and implements the Phase RVS-8 telemetry endpoint backend stub inside scripts/sovereign-mock-layer.mjs, and its contract verification scanner under scripts/active/audit-rvs-telemetry-backend-stub.mjs. The backend endpoint handles POST requests at /api/v1/telemetry/rvs, supports text/plain and application/json parsing, enforces a strict 8KB payload size guard returning HTTP 413, performs envelope validation, and returns a safe HTTP 204 No Content response on success. All audits pass successfully.