### PR TITLE
feat(rvs): add telemetry endpoint backend stub

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "audit:rvs-cinematic-budget:strict": "node scripts/active/audit-cinematic-budget.mjs --strict",
     "audit:rvs-scene-entropy-contract": "node scripts/active/audit-scene-entropy-contract.mjs",
     "audit:rvs-telemetry-endpoint-contract": "node scripts/active/audit-rvs-telemetry-endpoint-contract.mjs",
+    "audit:rvs-telemetry-endpoint-behavior": "node scripts/active/audit-rvs-telemetry-endpoint-behavior.mjs",
     "audit:rvs-client-telemetry-dispatcher": "node scripts/active/audit-rvs-client-telemetry-dispatcher.mjs",
     "audit:rvs-santisdom-telemetry": "node scripts/active/audit-rvs-santisdom-telemetry.mjs"
   },

--- a/scripts/active/audit-rvs-telemetry-endpoint-behavior.mjs
+++ b/scripts/active/audit-rvs-telemetry-endpoint-behavior.mjs
@@ -1,0 +1,138 @@
+import { spawn } from 'child_process';
+import http from 'http';
+
+console.log('🛡️ [Sovereign Ingestion Guard] Starting RVS Telemetry Endpoint Behavior Audit...');
+
+const TEST_PORT = 3030;
+const ENDPOINT_URL = `http://localhost:${TEST_PORT}/api/v1/telemetry/rvs`;
+
+// Start the mock layer server
+const serverProcess = spawn('node', ['scripts/sovereign-mock-layer.mjs'], {
+  stdio: 'pipe',
+  env: { ...process.env, PORT: TEST_PORT }
+});
+
+let serverReady = false;
+
+// Wait for server to start
+await new Promise((resolve, reject) => {
+  const timeout = setTimeout(() => {
+    serverProcess.kill();
+    reject(new Error('Server failed to start within 5 seconds'));
+  }, 5000);
+
+  serverProcess.stdout.on('data', (data) => {
+    const output = data.toString();
+    if (output.includes('aktif ve dinleniyor') || output.includes('Truth Layer')) {
+      serverReady = true;
+      clearTimeout(timeout);
+      resolve();
+    }
+  });
+
+  serverProcess.on('error', (err) => {
+    clearTimeout(timeout);
+    reject(err);
+  });
+});
+
+console.log('✅ Mock Ingestion Server successfully started on port 3030.');
+
+let failedTests = 0;
+
+async function assertResponse(testName, payload, expectedStatus) {
+  try {
+    const res = await fetch(ENDPOINT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body: typeof payload === 'string' ? payload : JSON.stringify(payload)
+    });
+
+    if (res.status === expectedStatus) {
+      console.log(`[PASSED] ${testName} -> Returned expected status: ${res.status}`);
+    } else {
+      console.error(`[FAILED] ${testName} -> Expected: ${expectedStatus}, Got: ${res.status}`);
+      failedTests++;
+    }
+  } catch (err) {
+    console.error(`[FAILED] ${testName} -> Request error: ${err.message}`);
+    failedTests++;
+  }
+}
+
+// Test Case 1: Perfect Envelope
+const validEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_luxury_99',
+  normalizedPath: '/spa-booking',
+  details: {
+    targetNode: 'main#nv-main > div.nv-figure',
+    durationMs: 14,
+    violatingProperty: 'offsetHeight'
+  }
+};
+await assertResponse('Test 1: Valid Telemetry Envelope', validEnvelope, 204);
+
+// Test Case 2: Size Limit Violation (8KB+)
+const hugeDetails = 'A'.repeat(9000);
+const hugeEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_huge',
+  normalizedPath: '/spa-booking',
+  details: {
+    targetNode: 'main#nv-main',
+    violatingProperty: hugeDetails
+  }
+};
+await assertResponse('Test 2: Payload Size Violation (8KB+)', hugeEnvelope, 400);
+
+// Test Case 3: PII Security Violation (Contains password key)
+const piiEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_pii',
+  normalizedPath: '/spa-booking',
+  details: {
+    targetNode: 'main#nv-main',
+    password: 'supersecretpassword123'
+  }
+};
+await assertResponse('Test 3: PII Security Violation (Key pattern)', piiEnvelope, 400);
+
+// Test Case 4: sessionToken Formatting Violation (No anon_ prefix)
+const invalidTokenEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'invalid_token_123',
+  normalizedPath: '/spa-booking',
+  details: {
+    targetNode: 'main#nv-main'
+  }
+};
+await assertResponse('Test 4: sessionToken Format Violation (No prefix)', invalidTokenEnvelope, 400);
+
+// Test Case 5: Schema Violation (Missing type)
+const missingTypeEnvelope = {
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_missing',
+  normalizedPath: '/spa-booking',
+  details: {
+    targetNode: 'main#nv-main'
+  }
+};
+await assertResponse('Test 5: Schema Violation (Missing type)', missingTypeEnvelope, 400);
+
+// Cleanup
+serverProcess.kill();
+console.log('🔌 Test Ingestion Server terminated.');
+
+console.log('\n🛡️ [Sovereign Ingestion Guard] Behavior Audit Completed.');
+if (failedTests > 0) {
+  console.error(`❌ [FAILED] RVS Telemetry Endpoint behavior verification failed. Total failures: ${failedTests}`);
+  process.exit(1);
+} else {
+  console.log('✅ [SUCCESS] RVS Telemetry Ingestion endpoint behavior validated and fully verified.');
+  process.exit(0);
+}

--- a/scripts/active/audit-rvs-telemetry-endpoint-behavior.mjs
+++ b/scripts/active/audit-rvs-telemetry-endpoint-behavior.mjs
@@ -124,6 +124,28 @@ const missingTypeEnvelope = {
 };
 await assertResponse('Test 5: Schema Violation (Missing type)', missingTypeEnvelope, 400);
 
+// Test Case 6: normalizedPath Type Violation
+const invalidPathEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_path',
+  normalizedPath: 'invalid-route-no-slash',
+  details: {
+    targetNode: 'main#nv-main'
+  }
+};
+await assertResponse('Test 6: normalizedPath Type Violation (No leading slash)', invalidPathEnvelope, 400);
+
+// Test Case 7: details Type Violation (Is Array)
+const invalidDetailsEnvelope = {
+  type: 'LAYOUT_REFLOW_ANOMALY',
+  timestamp: Date.now(),
+  sessionToken: 'anon_session_details',
+  normalizedPath: '/spa-booking',
+  details: ['invalid-details-array']
+};
+await assertResponse('Test 7: details Type Violation (Is Array)', invalidDetailsEnvelope, 400);
+
 // Cleanup
 serverProcess.kill();
 console.log('🔌 Test Ingestion Server terminated.');

--- a/scripts/sovereign-mock-layer.mjs
+++ b/scripts/sovereign-mock-layer.mjs
@@ -104,6 +104,14 @@ const truthLayer = http.createServer((req, res) => {
           throw new Error('sessionToken must be an anonymous token starting with "anon_"');
         }
 
+        if (typeof normalizedPath !== 'string' || !normalizedPath.startsWith('/')) {
+          throw new Error('normalizedPath must be a normalized route string starting with "/"');
+        }
+
+        if (!details || typeof details !== 'object' || Array.isArray(details)) {
+          throw new Error('details must be a telemetry details object');
+        }
+
         // PII Guard (Zero PII Compliance)
         const PII_KEYS_PATTERN = /email|password|pass|token|phone|card|address|ssn|user|name|surname|fullname|credentials|auth/i;
         const ALLOWED_TELEMETRY_KEYS = new Set([
@@ -154,7 +162,10 @@ const truthLayer = http.createServer((req, res) => {
         console.log(`\n\x1b[38;2;140;140;140m─── [SANTIS RVS INGESTION] ───────────────────────────\x1b[0m`);
         console.log(`\x1b[38;2;180;180;180mType:\x1b[0m      \x1b[38;2;220;220;220m${type}\x1b[0m`);
         console.log(`\x1b[38;2;180;180;180mRoute:\x1b[0m     \x1b[38;2;200;200;200m${normalizedPath}\x1b[0m`);
-        console.log(`\x1b[38;2;180;180;180mToken:\x1b[0m     \x1b[38;2;160;160;160m${sessionToken}\x1b[0m`);
+        const maskedSessionToken = sessionToken.length > 13 
+          ? `${sessionToken.slice(0, 9)}…${sessionToken.slice(-4)}`
+          : sessionToken;
+        console.log(`\x1b[38;2;180;180;180mToken:\x1b[0m     \x1b[38;2;160;160;160m${maskedSessionToken}\x1b[0m`);
         if (details.durationMs) {
           console.log(`\x1b[38;2;180;180;180mDuration:\x1b[0m  \x1b[38;2;240;100;100m${details.durationMs}ms\x1b[0m`);
         }

--- a/scripts/sovereign-mock-layer.mjs
+++ b/scripts/sovereign-mock-layer.mjs
@@ -1,4 +1,5 @@
 import http from 'http';
+import { Server } from 'socket.io';
 
 // --- Port 3030: Single Truth Layer & Intelligence Bridge ---
 const truthLayer = http.createServer((req, res) => {
@@ -55,6 +56,122 @@ const truthLayer = http.createServer((req, res) => {
         decision: 'Sovereign_Continue', 
         status: 'accepted' 
     }));
+    return;
+  }
+
+  // 2.1 RVS Telemetry Ingestion API (RVS-8 Stub)
+  if (req.url === '/api/v1/telemetry/rvs' && req.method === 'POST') {
+    let body = '';
+    let byteLength = 0;
+
+    req.on('data', chunk => {
+      byteLength += chunk.length;
+      if (byteLength > 8192) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Payload size limit exceeded (Max 8KB)' }));
+        req.destroy();
+        return;
+      }
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      if (byteLength > 8192) return;
+
+      try {
+        const envelope = JSON.parse(body);
+
+        if (!envelope || typeof envelope !== 'object') {
+          throw new Error('Payload must be a valid JSON object');
+        }
+
+        const { type, timestamp, sessionToken, normalizedPath, details } = envelope;
+
+        if (!type || !timestamp || !sessionToken || !normalizedPath || !details) {
+          throw new Error('Missing mandatory envelope fields (type, timestamp, sessionToken, normalizedPath, details)');
+        }
+
+        const ALLOWED_TYPES = new Set(['LAYOUT_REFLOW_ANOMALY', 'CINEMATIC_BUDGET_WARNING', 'SCENE_ENTROPY_SHIFT']);
+        if (!ALLOWED_TYPES.has(type)) {
+          throw new Error(`Invalid telemetry type: ${type}`);
+        }
+
+        if (typeof timestamp !== 'number' || timestamp <= 0) {
+          throw new Error('Timestamp must be a valid positive number');
+        }
+
+        if (typeof sessionToken !== 'string' || !sessionToken.startsWith('anon_')) {
+          throw new Error('sessionToken must be an anonymous token starting with "anon_"');
+        }
+
+        // PII Guard (Zero PII Compliance)
+        const PII_KEYS_PATTERN = /email|password|pass|token|phone|card|address|ssn|user|name|surname|fullname|credentials|auth/i;
+        const ALLOWED_TELEMETRY_KEYS = new Set([
+          'type',
+          'timestamp',
+          'sessionToken',
+          'normalizedPath',
+          'details',
+          'targetNode',
+          'durationMs',
+          'violatingProperty',
+          'entropyScore',
+          'activeComponents',
+          'rafLoops',
+          'particleCount',
+          'heavyFilters'
+        ]);
+
+        const scanObject = (obj, seen = new WeakSet()) => {
+          if (!obj || typeof obj !== 'object') return;
+          if (seen.has(obj)) return;
+          seen.add(obj);
+
+          for (const key of Object.keys(obj)) {
+            if (PII_KEYS_PATTERN.test(key) && key !== 'sessionToken') {
+              throw new Error(`PII violation detected in payload key: "${key}"`);
+            }
+            if (!ALLOWED_TELEMETRY_KEYS.has(key)) {
+              if (isNaN(key)) {
+                throw new Error(`PII Guard: Forbidden key detected in telemetry envelope: "${key}"`);
+              }
+            }
+            const val = obj[key];
+            if (typeof val === 'string') {
+              const emailPattern = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/;
+              if (emailPattern.test(val)) {
+                throw new Error('PII violation detected: email-like string found in values');
+              }
+            } else if (typeof val === 'object' && val !== null) {
+              scanObject(val, seen);
+            }
+          }
+        };
+
+        scanObject(envelope);
+
+        // Quiet Luxury premium console logging
+        console.log(`\n\x1b[38;2;140;140;140m─── [SANTIS RVS INGESTION] ───────────────────────────\x1b[0m`);
+        console.log(`\x1b[38;2;180;180;180mType:\x1b[0m      \x1b[38;2;220;220;220m${type}\x1b[0m`);
+        console.log(`\x1b[38;2;180;180;180mRoute:\x1b[0m     \x1b[38;2;200;200;200m${normalizedPath}\x1b[0m`);
+        console.log(`\x1b[38;2;180;180;180mToken:\x1b[0m     \x1b[38;2;160;160;160m${sessionToken}\x1b[0m`);
+        if (details.durationMs) {
+          console.log(`\x1b[38;2;180;180;180mDuration:\x1b[0m  \x1b[38;2;240;100;100m${details.durationMs}ms\x1b[0m`);
+        }
+        if (details.violatingProperty) {
+          console.log(`\x1b[38;2;180;180;180mProperty:\x1b[0m  \x1b[38;2;220;180;100m${details.violatingProperty}\x1b[0m`);
+        }
+        console.log(`\x1b[38;2;140;140;140m────────────────────────────────────────────────────\x1b[0m`);
+
+        res.writeHead(204);
+        res.end();
+
+      } catch (err) {
+        console.error(`❌ [SANTIS RVS INGESTION ERROR] Validation failed: ${err.message}`);
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
     return;
   }
 
@@ -217,6 +334,7 @@ truthLayer.listen(3030, async () => {
             console.log('✅ [Strategist AI]: Stratejik makro sentez tamamlandı ve iletildi.');
         }, 2500); 
     });
+  });
 
 // --- Reality Globals ---
 let basePriceMultiplier = 1.0;


### PR DESCRIPTION
Phase RVS-8: Implement telemetry endpoint backend stub. Implements secure POST /api/v1/telemetry/rvs stub in scripts/sovereign-mock-layer.mjs, supporting JSON & plain text, size limit guards, schema validation, Zero-PII sanitization, and premium quiet luxury logs. Includes an integration behavior test.