### PR TITLE
ci(vercel): deploy robust Vercel ignored build step (TD-002)

### DIFF
--- a/scripts/active/vercel-ignored-build.sh
+++ b/scripts/active/vercel-ignored-build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# SANTIS OS - Vercel Ignored Build Step Engine
+# Ensures the admin panel is only built when relevant files or dependencies change.
+
+set -euo pipefail
+
+WATCH_PATHS=(
+  "admin-panel"
+  "packages"
+  "package.json"
+  "pnpm-lock.yaml"
+  "pnpm-workspace.yaml"
+  "turbo.json"
+  "vercel.json"
+  "scripts/active/vercel-ignored-build.sh"
+)
+
+echo "=== VERCEL IGNORED BUILD STEP ENGINE ==="
+
+if [[ -z "${VERCEL_GIT_PREVIOUS_SHA:-}" || "${VERCEL_GIT_PREVIOUS_SHA}" =~ ^0+$ ]]; then
+  echo "No previous Vercel commit SHA available. Running Vercel build."
+  exit 1
+fi
+
+if ! git cat-file -e "${VERCEL_GIT_PREVIOUS_SHA}^{commit}" 2>/dev/null; then
+  echo "Previous Vercel commit SHA (${VERCEL_GIT_PREVIOUS_SHA}) is unavailable locally. Running Vercel build."
+  exit 1
+fi
+
+echo "Analyzing changes between ${VERCEL_GIT_PREVIOUS_SHA} and HEAD..."
+if git diff --quiet "${VERCEL_GIT_PREVIOUS_SHA}" HEAD -- "${WATCH_PATHS[@]}"; then
+  echo "No admin-panel, shared dependency, or deployment config changes detected. Skipping Vercel build."
+  exit 0
+fi
+
+echo "Relevant admin-panel, shared dependency, or deployment config changes detected. Running Vercel build."
+exit 1

--- a/vercel-ignored-build.sh
+++ b/vercel-ignored-build.sh
@@ -1,31 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Vercel Ignored Build Step for SANTIS OS
-# Resolves the Vercel deploy blocker for the admin panel by providing the expected script.
+# SANTIS OS - Vercel Ignored Build Step Redirector
+# Forwards execution to the governed scripts/active/vercel-ignored-build.sh
 
-echo "=== VERCEL IGNORED BUILD STEP ENGINE ==="
-echo "Target Project: santis-site-admin-panel"
-echo "Commit Ref: $VERCEL_GIT_COMMIT_REF"
-echo "Commit Message: $VERCEL_GIT_COMMIT_MESSAGE"
-
-# Safe fallback: if VERCEL_GIT_COMMIT_REF is not set, proceed with build.
-if [ -z "$VERCEL_GIT_COMMIT_REF" ]; then
-  echo "⚠️ VERCEL_GIT_COMMIT_REF is empty. Proceeding with build as safe fallback."
-  exit 1
-fi
-
-# Always build on production (main) and integration (develop) branches
-if [[ "$VERCEL_GIT_COMMIT_REF" == "develop" || "$VERCEL_GIT_COMMIT_REF" == "main" ]]; then
-  echo "✅ Integration/Production branch detected ($VERCEL_GIT_COMMIT_REF). Proceeding with build."
-  exit 1
-fi
-
-# For PRs or other feature branches, only build if relevant directories/files changed
-echo "Analyzing Git diff for changes..."
-if git diff --name-only HEAD~1 | grep -E "^(admin-panel/|assets/|package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|vercel\.json|vercel-ignored-build\.sh)" > /dev/null; then
-  echo "✅ Changes detected in admin-panel, assets, or workspace configs. Proceeding with build."
-  exit 1
-else
-  echo "🛑 No changes in relevant surfaces. Skipping build."
-  exit 0
-fi
+exec bash scripts/active/vercel-ignored-build.sh "$@"


### PR DESCRIPTION
Rescues and refactors PR #276 by deploying a highly robust, Bash-safe ignored build step script under scripts/active. Addresses Vercel shallow clone limitations by using VERCEL_GIT_PREVIOUS_SHA and checking local SHA existence before diffing.