### PR TITLE
chore(seo): stabilize public site identity and canonical alternate links (TD-006)

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
             }
         }
     </style>
-<meta content="website" property="og:type"/><meta content="Santis Club • Wellness &amp; Spa" property="og:title"/><meta content="Santis Club - Premium Spa &amp; Wellness. Select your language to begin." property="og:description"/><meta content="https://santisclub.com/index.html" property="og:url"/><meta content="https://santisclub.com/assets/img/logo-santis.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Santis Club • Wellness &amp; Spa" name="twitter:title"/><meta content="Santis Club - Premium Spa &amp; Wellness. Select your language to begin." name="twitter:description"/><meta content="https://santisclub.com/assets/img/logo-santis.webp" name="twitter:image"/></head>
+<meta content="website" property="og:type"/><meta content="Santis Club • Wellness &amp; Spa" property="og:title"/><meta content="Santis Club - Premium Spa &amp; Wellness. Select your language to begin." property="og:description"/><meta content="https://santis.club/" property="og:url"/><meta content="https://santis.club/assets/img/logo-santis.webp" property="og:image"/><meta content="Santis Club" property="og:site_name"/><meta content="summary_large_image" name="twitter:card"/><meta content="Santis Club • Wellness &amp; Spa" name="twitter:title"/><meta content="Santis Club - Premium Spa &amp; Wellness. Select your language to begin." name="twitter:description"/><meta content="https://santis.club/assets/img/logo-santis.webp" name="twitter:image"/></head>
 <body>
 <script type="module" src="/assets/js/core/santis-core.js" defer></script>
     <script type="module" src="/assets/js/app.js" defer></script>

--- a/tr/index.html
+++ b/tr/index.html
@@ -52,6 +52,13 @@ if (['127.0.0.1', 'localhost'].includes(window.location.hostname)) {
 <meta content="Santis Club • Spa &amp; Wellness" name="twitter:title"/>
 <meta content="Santis Club – Antalya'da özel lüks spa, hamam ritüelleri ve terapötik wellness deneyimi." name="twitter:description"/>
 <meta content="https://santis.club/assets/img/cards/hammam.webp" name="twitter:image"/>
+<link rel="canonical" href="https://santis.club/tr/" id="santis-canonical" />
+<link rel="alternate" hreflang="tr" href="https://santis.club/tr/" />
+<link rel="alternate" hreflang="ru" href="https://santis.club/ru/" />
+<link rel="alternate" hreflang="de" href="https://santis.club/de/" />
+<link rel="alternate" hreflang="ar" href="https://santis.club/ar/" />
+<link rel="alternate" hreflang="fr" href="https://santis.club/fr/" />
+<link rel="alternate" hreflang="x-default" href="https://santis.club/" />
 
 <link rel="preload" href="/assets/css/fonts.css" as="style">
 <link rel="stylesheet" href="/assets/css/fonts.css" media="print" onload="this.media='all'">


### PR DESCRIPTION
Rescues stable metadata, og:url, canonical, and alternate hreflang link tags from stale PR #2. Ported domain switches to santis.club and verified with lint/build/audit.