### PR TITLE
fix(ui): resolve tailwind asset path debt

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,8 +7,8 @@
    ========================================================================== */
 
 /* ÇEKİRDEK SİNİR SİSTEMİ BAĞLANTILARI */
-/* ✨ TAILWIND v4 ENGINE — Sovereign Utility Sistemi */
-@import url('tailwind-input.css');
+/* ✨ TAILWIND ENGINE — Compiled runtime utility layer */
+@import url('output.css');
 
 @import url('santis-v6/santis.reset.css');
 @import url('santis-v6/santis.tokens.css');

--- a/docs/audits/phase-28-7-tailwind-asset-path-debt.md
+++ b/docs/audits/phase-28-7-tailwind-asset-path-debt.md
@@ -1,0 +1,20 @@
+# Phase 28.7 — Tailwind Asset Path Debt Resolution
+
+Status: PASS
+
+## Finding
+
+A load-time 404 existed for `/assets/css/tailwindcss`.
+
+## Resolution
+
+The runtime stylesheet chain was normalized to the actual compiled Tailwind CSS asset.
+
+`assets/css/style.css` now imports `output.css` instead of the source-only `tailwind-input.css` file.
+
+## Validation
+
+- Page load: PASS
+- `/assets/css/tailwindcss` 404: RESOLVED
+- Aurelia whisper path: UNAFFECTED
+- Secret exposure: NONE DETECTED


### PR DESCRIPTION
﻿## Summary

Phase 28.7 — TAILWIND ASSET PATH DEBT SEALED.

This PR resolves the load-time `/assets/css/tailwindcss` 404 by normalizing the runtime stylesheet chain to the compiled Tailwind asset.

## Changes

- Update `assets/css/style.css` to import `output.css` instead of source-only `tailwind-input.css`
- Add Phase 28.7 audit report for the Tailwind asset path debt resolution

## Validation

- Page load: PASS
- `assets/css/style.css`: 200
- `assets/css/output.css`: 200
- `/assets/css/tailwindcss` load-time request: RESOLVED
- Aurelia whisper path: UNAFFECTED
- Secret exposure: NONE DETECTED
- `pnpm run lint`: PASS with one pre-existing admin-panel warning
- `pnpm run audit:environment`: PASS
- Governance scanner: same pre-existing Zustand and Tailwind/inline-style findings, no new finding from this change

## Governance

- Scoped to Tailwind asset path debt only
- Does not touch Aurelia Gateway files or PR #312 content
- Direct push to develop avoided
- `test_aurelia.py` remains untracked and was not committed
