### PR TITLE
hardening(memory): seal read endpoint contract and fallback guards

### DIFF
--- a/docs/audits/phase-29-2-memory-read-hardening.md
+++ b/docs/audits/phase-29-2-memory-read-hardening.md
@@ -1,0 +1,27 @@
+# Phase 29.2 Reality Lock: Sovereign Memory Read Hardening
+
+## 1. Executive Summary
+This audit confirms the hardening of the Sovereign Memory read surface introduced in Phase 29.1. The endpoints and frontend integrations have been fortified to ensure strict data shape contracts and graceful failure under degraded network conditions.
+
+## 2. Hardening Measures
+
+### Frontend Resilience (sovereign_archive_v28.html)
+- **Timeout Guard:** Added `AbortController` to cap live fetch attempts at 5000ms.
+- **Contract Validation:** Introduced `isValidMemoryNode` to rigorously verify the JSON shape before handing data to the `MemoryMapEngine`.
+- **Safe Fallback:** In the event of a timeout, network failure, or contract violation, the UI falls back seamlessly to the static `historySeed`.
+
+### Backend Verification (tests/test_sovereign_memory.py)
+- **Contract Enforcement:** Added unit tests verifying Pydantic schema validation.
+- **Node Precision:** Verified the `/api/v1/memory/nodes/{date}` endpoint returns accurate `hrv` and other nested biometric structures.
+- **Graceful Failure:** Enforced 404 behavior for non-existent memory nodes (e.g. `2099-01-01`).
+
+## 3. Governance Checklist
+- [x] Read-only hardening only.
+- [x] No POST/write endpoint introduced.
+- [x] No database persistence added.
+- [x] No secret handling altered.
+- [x] No Aurelia Gateway mutation.
+
+## 4. Final Verification
+The runtime impact is strictly confined to read-only reliability enhancements.
+**Seal Status:** PASS

--- a/sovereign_archive_v28.html
+++ b/sovereign_archive_v28.html
@@ -1412,15 +1412,38 @@
             return date.toLocaleDateString('tr-TR', options).toUpperCase();
         }
 
+        function isValidMemoryNode(node) {
+            return node &&
+                typeof node.date === 'string' &&
+                node.biometrics &&
+                node.emotion &&
+                node.ritual &&
+                node.environment &&
+                node.diarist &&
+                node.atmosphere;
+        }
+
         async function loadMemoryNodes() {
+            const controller = new AbortController();
+            const timeoutId = setTimeout(() => controller.abort(), 5000);
+
             try {
-                const response = await fetch('/api/v1/memory/nodes');
+                const response = await fetch('/api/v1/memory/nodes', { signal: controller.signal });
+                clearTimeout(timeoutId);
+
                 if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                
                 const data = await response.json();
+                
+                if (!Array.isArray(data) || !data.every(isValidMemoryNode)) {
+                    throw new Error('Invalid memory node contract');
+                }
+
                 console.log("📥 [SovereignMemory] Fetched temporal nodes from server:", data);
                 return data;
             } catch (error) {
-                console.warn('⚠️ [SovereignMemory] Failed to fetch live memory nodes, falling back to static seed:', error);
+                clearTimeout(timeoutId);
+                console.warn('⚠️ [SovereignMemory] Failed to fetch live memory nodes, falling back to static seed:', error.message);
                 return historySeed;
             }
         }

--- a/tests/test_sovereign_memory.py
+++ b/tests/test_sovereign_memory.py
@@ -1,4 +1,3 @@
-import pytest
 from fastapi.testclient import TestClient
 from app.main import app
 from app.schemas.memory import MemoryNode

--- a/tests/test_sovereign_memory.py
+++ b/tests/test_sovereign_memory.py
@@ -1,0 +1,33 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.schemas.memory import MemoryNode
+
+client = TestClient(app)
+
+def test_get_memory_nodes():
+    response = client.get("/api/v1/memory/nodes")
+    assert response.status_code == 200
+    
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) > 0
+    
+    # Verify shape parsing via pydantic
+    MemoryNode(**data[0])
+
+def test_get_specific_memory_node():
+    target_date = "2026-03-04"
+    response = client.get(f"/api/v1/memory/nodes/{target_date}")
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["date"] == target_date
+    assert data["biometrics"]["hrv"] == 62
+    
+    MemoryNode(**data)
+
+def test_get_memory_node_not_found():
+    response = client.get("/api/v1/memory/nodes/2099-01-01")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Memory node not found"


### PR DESCRIPTION
## Summary

Phase 29.2 hardens the Sovereign Memory read surface.

## Changes

- Add frontend fetch timeout guard
- Add memory node JSON contract validation
- Preserve static fallback data path
- Add FastAPI tests for success and not-found responses
- Add Phase 29.2 audit report

## Validation

- python -m pytest tests/test_sovereign_memory.py
- pnpm run lint
- pnpm run audit:environment
- python -m compileall app