### PR TITLE
feat(telemetry): add safe beacon stub

### DIFF
--- a/app/api/v1/endpoints/telemetry.py
+++ b/app/api/v1/endpoints/telemetry.py
@@ -1,0 +1,59 @@
+import time
+import logging
+from fastapi import APIRouter, Request, HTTPException, status
+from app.schemas.telemetry import TelemetryPayload
+from pydantic import ValidationError
+
+router = APIRouter()
+logger = logging.getLogger("santis.telemetry")
+
+_rate_limit_store = {}
+MAX_REQUESTS_PER_MINUTE = 60
+MAX_PAYLOAD_SIZE = 50 * 1024  # 50KB
+
+def _is_rate_limited(ip: str) -> bool:
+    now = time.time()
+    if ip not in _rate_limit_store:
+        _rate_limit_store[ip] = []
+    
+    _rate_limit_store[ip] = [t for t in _rate_limit_store[ip] if now - t < 60]
+    
+    if len(_rate_limit_store[ip]) >= MAX_REQUESTS_PER_MINUTE:
+        return True
+        
+    _rate_limit_store[ip].append(now)
+    return False
+
+@router.post("/beacon")
+async def receive_telemetry_beacon(request: Request):
+    client_ip = request.client.host if request.client else "unknown"
+    
+    # 1. Soft Guard Rate Limiter
+    if _is_rate_limited(client_ip):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS, 
+            detail="Too many telemetry requests"
+        )
+        
+    # 2. Payload Size Check BEFORE Pydantic parsing
+    body = await request.body()
+    if len(body) > MAX_PAYLOAD_SIZE:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, 
+            detail="Payload too large"
+        )
+        
+    # 3. Pydantic Schema Validation
+    try:
+        if not body:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empty body")
+        payload = TelemetryPayload.model_validate_json(body)
+    except ValidationError:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="Invalid payload schema")
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Malformed JSON")
+
+    # 4. Process (No-op logging)
+    logger.debug(f"Telemetry beacon accepted: event_type={payload.event_type} from {client_ip}")
+    
+    return {"status": "accepted"}

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from app.api.v1.endpoints import booking_engine, billing, aurelia_whisper, sovereign_memory
+from app.api.v1.endpoints import booking_engine, billing, aurelia_whisper, sovereign_memory, telemetry
 
 app = FastAPI(title="Santis OS API")
 
@@ -22,6 +22,7 @@ app.include_router(booking_engine.router, prefix="/api/v1")
 app.include_router(billing.router, prefix="/api/v1")
 app.include_router(aurelia_whisper.router, prefix="/api/v1")
 app.include_router(sovereign_memory.router, prefix="/api/v1")
+app.include_router(telemetry.router, prefix="/api/v1/telemetry")
 
 # Arayüzü tek bir port üzerinden (CORS sorunu olmaksızın) sunmak için statik dosyaları bağla:
 app.mount("/", StaticFiles(directory=".", html=True), name="static")

--- a/app/schemas/telemetry.py
+++ b/app/schemas/telemetry.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional, Dict, Any
+
+class TelemetryPayload(BaseModel):
+    model_config = ConfigDict(extra='ignore')
+    
+    event_type: str = Field(..., max_length=100)
+    session_id: Optional[str] = Field(None, max_length=100)
+    client_time: Optional[str] = Field(None, max_length=50)
+    metadata: Optional[Dict[str, Any]] = Field(default_factory=dict)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,64 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.api.v1.endpoints.telemetry import _rate_limit_store
+
+client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def clear_rate_limit_state():
+    """Testler arasinda rate limit store'u temizler"""
+    _rate_limit_store.clear()
+    yield
+    _rate_limit_store.clear()
+
+def test_telemetry_beacon_valid_payload():
+    payload = {
+        "event_type": "page_view",
+        "session_id": "test-123",
+        "client_time": "2026-05-20T08:00:00Z",
+        "metadata": {"url": "/test-url"}
+    }
+    response = client.post("/api/v1/telemetry/beacon", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+
+def test_telemetry_beacon_unknown_fields_ignored():
+    payload = {
+        "event_type": "click_event",
+        "hacker_field": "should be ignored completely",
+        "some_random_data": [1, 2, 3]
+    }
+    response = client.post("/api/v1/telemetry/beacon", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}
+
+def test_telemetry_beacon_large_payload_rejected():
+    large_payload = {
+        "event_type": "large_event",
+        "metadata": {"big_data": "A" * 60000}  # ~60KB string, exceeds 50KB limit
+    }
+    response = client.post("/api/v1/telemetry/beacon", json=large_payload)
+    assert response.status_code == 413
+    assert "too large" in response.json()["detail"].lower()
+
+def test_telemetry_beacon_missing_event_type():
+    payload = {
+        "session_id": "no-event-type"
+    }
+    response = client.post("/api/v1/telemetry/beacon", json=payload)
+    assert response.status_code == 422
+    assert "Invalid payload schema" in response.json()["detail"]
+
+def test_telemetry_beacon_rate_limiting():
+    payload = {"event_type": "spam"}
+    
+    # Send 60 requests (should all pass)
+    for _ in range(60):
+        response = client.post("/api/v1/telemetry/beacon", json=payload)
+        assert response.status_code == 200
+        
+    # 61st request should be rejected
+    response = client.post("/api/v1/telemetry/beacon", json=payload)
+    assert response.status_code == 429
+    assert "Too many" in response.json()["detail"]


### PR DESCRIPTION
﻿## Summary

Phase 29.5 adds a backend-only no-op telemetry beacon stub.

## Changes

- Add POST /api/v1/telemetry/beacon
- Add Pydantic telemetry payload schema
- Enforce 50KB request body limit before schema validation
- Add in-memory per-IP soft rate limit
- Ignore unknown JSON fields
- Avoid raw payload logging
- Add endpoint tests

## Validation

- python -m compileall app
- python -m pytest tests/test_telemetry.py
- pnpm run lint

## Scope Guard

- No DB write
- No file write
- No external network
- No auth mutation
- No frontend telemetry activation
- Frontend beacon flag remains disabled by default
