### PR TITLE
feat(telemetry): wire frontend beacon opt-in

### DIFF
--- a/assets/js/boot/santis-bootloader.js
+++ b/assets/js/boot/santis-bootloader.js
@@ -387,18 +387,17 @@
 
         function dispatchTelemetry(level, message) {
             // Background telemetry dispatch (fire and forget)
-            const endpoint = `${getBackendUrl()}/telemetry/beacon`;
-            fetch(endpoint, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ 
-                    event: 'BOOTLOADER_EVENT',
-                    ts: new Date().toISOString(),
-                    context: { tenantId: 'santis-club', sessionId: 'boot', source: window.location.pathname },
-                    meta: { level, message }
-                }),
-                keepalive: true
-            }).catch(() => {});
+            if (window.__SANTIS_ENABLE_TELEMETRY_BEACON__ !== true) return;
+            const endpoint = typeof getBackendUrl !== "undefined" ? `${getBackendUrl()}/telemetry/beacon` : '/api/v1/telemetry/beacon';
+            if (navigator.sendBeacon) {
+                const payload = { 
+                    event_type: 'BOOTLOADER_EVENT',
+                    session_id: 'boot',
+                    client_time: new Date().toISOString(),
+                    metadata: { level, message, tenantId: 'santis-club', source: window.location.pathname }
+                };
+                navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], { type: 'application/json' }));
+            }
         }
 
         function loadScriptV36(src, isModule = false) {
@@ -504,11 +503,15 @@
             }
             
             // 📡 V42 Telemetry Bridge (Fire & Forget)
-            if (navigator.sendBeacon) {
-                const endpoint = typeof getBackendUrl !== "undefined" ? `${getBackendUrl()}/telemetry/decision` : '/api/v1/telemetry/decision';
-                navigator.sendBeacon(endpoint, JSON.stringify({
-                    module: name, decision: decision, meta: meta, time: Date.now()
-                }));
+            if (window.__SANTIS_ENABLE_TELEMETRY_BEACON__ === true && navigator.sendBeacon) {
+                const endpoint = typeof getBackendUrl !== "undefined" ? `${getBackendUrl()}/telemetry/beacon` : '/api/v1/telemetry/beacon';
+                const payload = {
+                    event_type: 'POLICY_DECISION',
+                    session_id: 'boot',
+                    client_time: new Date().toISOString(),
+                    metadata: { module: name, decision: decision, meta: meta }
+                };
+                navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], { type: 'application/json' }));
             }
         }
 

--- a/assets/js/core/santis-runtime-resolver.js
+++ b/assets/js/core/santis-runtime-resolver.js
@@ -20,7 +20,8 @@
             wsUrl: cfg.wsUrl || (devFallbackWs ? `${devFallbackWs}/ws` : `${wsProtocol}://${window.location.host}/ws`),
             eventsWsUrl: cfg.eventsWsUrl || (devFallbackWs ? `${devFallbackWs}/events` : `${wsProtocol}://${window.location.host}/events`),
             physicalCommandUrl: cfg.physicalCommandUrl || (devFallbackUrl ? `${devFallbackUrl}/api/physical-command` : "/api/physical-command"),
-            streamGodUrl: cfg.streamGodUrl || (devFallbackUrl ? `${devFallbackUrl}/api/v1/streams/god` : "/api/v1/streams/god")
+            streamGodUrl: cfg.streamGodUrl || (devFallbackUrl ? `${devFallbackUrl}/api/v1/streams/god` : "/api/v1/streams/god"),
+            telemetryBeaconUrl: cfg.telemetryBeaconUrl || (devFallbackUrl ? `${devFallbackUrl}/api/v1/telemetry/beacon` : "/api/v1/telemetry/beacon")
         };
     };
 })();

--- a/assets/js/core/santis-telemetry-engine.js
+++ b/assets/js/core/santis-telemetry-engine.js
@@ -4,8 +4,8 @@
  */
 class SantisTelemetryEngine {
   constructor() {
-    // Sovereign Server telemetri rotası
-    this.endpoint = 'http://127.0.0.1:3030/api/v1/telemetry/beacon'; 
+    // Sovereign Server telemetri rotası (Runtime resolver'dan beslenir)
+    this.endpoint = typeof window.getRuntimeConfig === 'function' ? window.getRuntimeConfig().telemetryBeaconUrl : '/api/v1/telemetry/beacon'; 
     this.sessionId = this._generateSessionId();
     
     // Debounce kalkanı için zamanlayıcı (Timer) ve son hafıza
@@ -63,25 +63,32 @@ class SantisTelemetryEngine {
    * Veriyi ana iplikçiyi (main thread) bozmadan sunucuya ateşler
    */
   track(eventName, payload = {}) {
-    // 🛡️ Telemetry Feature Flag check to prevent 404 network noise in local dev
-    const TELEMETRY_BEACON_ENABLED = window.__SANTIS_ENABLE_TELEMETRY_BEACON__ === true;
-    if (!TELEMETRY_BEACON_ENABLED) {
+    // 🛡️ Telemetry Feature Flag check to prevent network noise in local dev and enforce opt-in
+    if (window.__SANTIS_ENABLE_TELEMETRY_BEACON__ !== true) {
         return false;
     }
 
     const data = {
+      event_type: eventName,
       session_id: this.sessionId,
-      event: eventName,
-      timestamp: new Date().toISOString(),
-      payload: payload
+      client_time: new Date().toISOString(),
+      metadata: payload
     };
 
-    // sendBeacon için veriyi Blob formatına çeviriyoruz
-    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    const payloadString = JSON.stringify(data);
     
-    // Tarayıcı bu işlemi arka planda otonom olarak yapar
-    navigator.sendBeacon(this.endpoint, blob);
-    console.log(`📡 [God's Eye] Sinyal Fırlatıldı: ${eventName}`);
+    // Payload limit guard (Max 45KB strictly on frontend to prevent 413 on backend)
+    if (new Blob([payloadString]).size > 45000) {
+        return false; 
+    }
+
+    // sendBeacon için veriyi Blob formatına çeviriyoruz
+    const blob = new Blob([payloadString], { type: 'application/json' });
+    
+    // Tarayıcı bu işlemi arka planda otonom olarak yapar, başarısız olursa retry fırtınası önlenir
+    if (navigator.sendBeacon) {
+        navigator.sendBeacon(this.endpoint, blob);
+    }
   }
 
   _generateSessionId() {


### PR DESCRIPTION
﻿## Summary

Phase 29.6 wires frontend telemetry beacon sending behind an explicit opt-in flag.

## Changes

- Gate frontend telemetry behind window.__SANTIS_ENABLE_TELEMETRY_BEACON__ === true
- Align frontend beacon payload with backend telemetry schema
- Use navigator.sendBeacon only
- Remove fetch fallback and retry behavior from telemetry sending
- Keep telemetry disabled by default
- Add telemetry beacon URL to runtime resolver
- Preserve local-only fallback observability behavior

## Validation

- pnpm run lint
- python -m compileall app
- python -m pytest tests/test_telemetry.py

## Scope Guard

- No backend changes
- No DB write
- No file write
- No external network beyond explicit opt-in beacon
- No fallback counter to telemetry bridge
- No UI/dashboard changes
- cilt-bakimi/ not included
