### PR TITLE
fix(runtime): backport integrity patch v1.0.1 to main

### DIFF
--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -8,15 +8,11 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="theme-color" content="#050505">
     
-    <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
     
     <link rel="stylesheet" href="hq-dashboard/css/hq-cyber-luxury.css">
     
-    <script>
-        tailwind.config = { theme: { extend: { colors: { santisBlack: '#050505', santisEmerald: '#10b981', santisGold: '#d4af37' }, fontFamily: { sans: ['Inter', 'sans-serif'], serif: ['Playfair Display', 'serif'] } } } }
-    </script>
 </head>
 <body class="bg-santisBlack text-white min-h-screen overflow-x-hidden p-4 md:p-8 selection:bg-santisEmerald/30 bg-[radial-gradient(circle_at_top_right,rgba(16,185,129,0.05),transparent_40%),radial-gradient(circle_at_bottom_left,rgba(212,175,55,0.03),transparent_40%)]">
     

--- a/build-your-ritual.html
+++ b/build-your-ritual.html
@@ -6,11 +6,7 @@
     <meta name="view-transition" content="same-origin">
     <title>SANTIS | Ritüelini Yarat</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
-    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <script>
-        tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter', 'sans-serif'] } } } }
-    </script>
 </head>
 <body class="min-h-screen bg-[#050505] text-white overflow-x-hidden flex flex-col font-sans relative selection:bg-[#D4AF37] selection:text-black pb-40">
     

--- a/guest-zen/index.html
+++ b/guest-zen/index.html
@@ -9,14 +9,6 @@
     <meta name="description" content="Santis | Guest Zen — Santis Club Spa & Wellness Antalya. Lüks hamam, masaj ve cilt bakımı deneyimleri Konyaaltı'nda.">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Santis | Guest Zen</title>
-    <!-- Tailwind Warning Suppressor -->
-    <script>
-        const originalWarn = console.warn;
-        console.warn = function(...args) {
-            if (typeof args[0] === 'string' && args[0].includes('cdn.tailwindcss.com should not be used in production')) return;
-            originalWarn.apply(console, args);
-        };
-    </script>
     <!-- Tailwind CSS (CDN for rapid architecture) -->
     <script src="/assets/js/tailwindcss.min.js" crossorigin="anonymous" defer></script>
     <script defer="" src="/assets/js/perf-head.js"></script>
@@ -27,30 +19,6 @@
     <link rel="stylesheet" href="../assets/css/editorial.css?v=2.2.1">
     
     <!-- Tailwind Custom Configuration -->
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-            theme: {
-                extend: {
-                    fontSize: { micro: '10px', nano: '9px' },
-                    fontFamily: {
-                        sans: ['Inter', 'sans-serif'],
-                        mono: ['JetBrains Mono', 'monospace'],
-                    },
-                    animation: {
-                        'pulse-slow': 'pulse 4s cubic-bezier(0.4, 0, 0.6, 1) infinite',
-                        'float': 'float 6s ease-in-out infinite',
-                    },
-                    keyframes: {
-                        float: {
-                            '0%, 100%': { transform: 'translateY(0)' },
-                            '50%': { transform: 'translateY(-10px)' },
-                        }
-                    }
-                }
-            }
-        }
-    </script>
     <style>
         :root {
             --bg-app: #020617;

--- a/katalog.html
+++ b/katalog.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sovereign Spa | Editorial Catalog</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Montserrat:wght@300;400;500&display=swap" rel="stylesheet">
     
     <style>

--- a/oracle-checkout-stage.html
+++ b/oracle-checkout-stage.html
@@ -4,11 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SANTIS | The Oracle Matcher</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
-    <script>
-        tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter', 'sans-serif'], mono: ['JetBrains Mono', 'monospace'] }, fontSize: { micro: '10px', nano: '9px' } } } }
-    </script>
     <style>
         /* Siber-Radar ve Labor Illusion Animasyonları */
         .radar-sweep {

--- a/santis-reality-sw.js
+++ b/santis-reality-sw.js
@@ -30,6 +30,7 @@ self.addEventListener('activate', (e) => {
 // 2. DYNAMIC MODULE INTERCEPTION
 // -----------------------------
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('http')) return;
   const url = new URL(event.request.url);
 
   // Kural 1: Sadece JS modüllerini denetle

--- a/santis-sanctuary-sw.js
+++ b/santis-sanctuary-sw.js
@@ -123,6 +123,7 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
+    if (!event.request.url.startsWith('http')) return;
     // Sadece Navigation (HTML Görüntüleme) isteklerini pusuya düşür
     if (event.request.mode === 'navigate') {
         event.respondWith(

--- a/santis-sw.js
+++ b/santis-sw.js
@@ -81,6 +81,7 @@ const fetchWithTimeout = (request, timeout = 1200) => {
  * FETCH HOOK: İsteklerin yönlendirildiği ana trafik kontrolörü.
  */
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('http')) return;
     const { request } = event;
 
     // 1. Video & Range Request Bypass: Büyük medyalar ve Safari/iOS Range istekleri 

--- a/santis_boardroom_sw.js
+++ b/santis_boardroom_sw.js
@@ -45,6 +45,7 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('http')) return;
     const url = new URL(event.request.url);
 
     // 📡 1. WEBSOCKET BAĞLANTILARI: BYPASS (Asla önbelleğe alma)

--- a/service-worker.js
+++ b/service-worker.js
@@ -53,6 +53,7 @@ self.addEventListener('activate', (event) => {
  * 3. Fetching: Stale-While-Revalidate + Offline Fallback
  */
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('http')) return;
     if (event.request.method !== 'GET') return;
 
     event.respondWith(

--- a/spa-booking.html
+++ b/spa-booking.html
@@ -4,20 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sovereign | Ritüel Konfigürasyonu</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Playfair+Display:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
     
-    <script>
-        tailwind.config = {
-            darkMode: 'class',
-            theme: {
-                extend: {
-                    colors: { santisBlack: '#050505', santisEmerald: '#10b981', santisGold: '#d4af37' },
-                    fontFamily: { sans: ['Inter', 'sans-serif'], serif: ['Playfair Display', 'serif'] }
-                }
-            }
-        }
-    </script>
     <style>
         body {
             background-color: #050505; color: #e5e5e5;

--- a/spa-menu.html
+++ b/spa-menu.html
@@ -3,7 +3,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Santis Club Fitness & Spa - Spa Menüsü</title>
-    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,600;1,400&family=Lato:ital,wght@0,300;0,400;1,300&display=swap" rel="stylesheet">
     <style>
         body { 

--- a/sw.js
+++ b/sw.js
@@ -28,6 +28,7 @@ self.addEventListener('activate', (event) => {
 });
 
 self.addEventListener('fetch', (event) => {
+    if (!event.request.url.startsWith('http')) return;
     // Network First, Fallback to Cache (Veri güncelliği için)
     event.respondWith(
         fetch(event.request).catch(() => {


### PR DESCRIPTION
Manual production hotfix backport from main base.

Scope:
- Removes Tailwind CDN/script leftovers from active production HTML.
- Removes obsolete Tailwind warning suppressor from guest-zen.
- Adds non-http request guards to active service worker fetch handlers.
- Does not merge develop into main.
- Does not include archive/legacy files.
- Does not include Radar patch because admin-radar.js is not present on current main.

Validation:
- pnpm install --frozen-lockfile PASS
- pnpm run build PASS
- git diff --check PASS
- Scope reduced to 13 active production/runtime files
- No temp scripts, scratch files, or test artifacts included