### PR TITLE
docs(governance): backport technical debt register and release flow to develop

### DIFF
--- a/docs/deployment/vercel-project-map.md
+++ b/docs/deployment/vercel-project-map.md
@@ -1,0 +1,12 @@
+# Vercel Project Truth Map
+
+**Date:** 2026-05-21
+**Context:** The Santis OS project has multiple deployment targets in Vercel which has caused confusion regarding the true production environment.
+
+## Canonical Projects
+
+*   **`sovereign-os`**: **PRODUCTION TRUTH.** This is the primary, canonical production project. All production builds, final deployments, and canonical domains are routed here.
+*   **`santis-site-admin-panel`**: **SECONDARY / PREVIEW.** This project is not the production source of truth. It is used for preview, secondary UI isolation, or testing purposes only.
+
+**Action Required:**
+All Boardroom governance decisions, pipeline approvals, and production hotfixes must be verified against the `sovereign-os` Vercel project.

--- a/docs/governance/release-flow.md
+++ b/docs/governance/release-flow.md
@@ -1,0 +1,23 @@
+# Santis OS - Release Flow & Branch Governance
+
+This document outlines the canonical branching strategy and release flow for Santis OS. All developers and automated agents must adhere to these rules.
+
+## Canonical Branches
+
+*   **`main`**: **PRODUCTION BRANCH.** This branch is directly tied to the `sovereign-os` Vercel project. Any push or merge into this branch triggers a production deployment. It must remain pristine and only accept tested, approved merges via Pull Requests.
+*   **`develop`**: **DEVELOPMENT INTEGRATION BRANCH.** This should be the GitHub **default branch**. All normal feature work, bug fixes, and documentation updates are merged here first for integration testing before being bundled into a release PR for `main`.
+
+## Branch Prefixes & Workflows
+
+*   **`feature/*`**, **`fix/*`**, **`docs/*`**, **`chore/*`**, **`refactor/*`**, **`archive/*`**:
+    *   **Target:** `develop`
+    *   **Usage:** Standard daily development branches. Must be merged into `develop` via PR.
+*   **`hotfix/*`**:
+    *   **Target:** `main` (and subsequently backported to `develop`)
+    *   **Usage:** Emergency production patches only. Branched directly from `main` and merged directly back into `main` to bypass standard release cycles.
+
+## Release Process (`develop` → `main`)
+A formal Release PR must be created to promote changes from `develop` to `main`. This PR requires:
+1. Full build pipeline validation (`pnpm run build`).
+2. Production Readiness Seal approval.
+3. Boardroom governance sign-off.

--- a/docs/technical-debt-register.md
+++ b/docs/technical-debt-register.md
@@ -1,30 +1,67 @@
-# Technical Debt Register
+# Santis OS - Technical Debt Register
 
-## Santis Vite Recovery Fallback Debt
+## Governance Rules & Status Matrix
+*   **OPEN**: Active technical debt requiring remediation.
+*   **DEFERRED**: Acknowledged but intentionally pushed to a later phase.
+*   **DO NOT TOUCH**: Legacy or sensitive system that must remain as-is until a formal Boardroom architectural rewrite.
+*   **RESOLVED / CLOSED**: Debt has been paid and verified.
+*   **PROMOTED TO MAIN**: Feature or hotfix successfully sealed into the `main` production branch.
 
-1. hq-dashboard/js/admin-radar.js şu an no-op fallback olarak oluşturuldu.
-   Not: [RESOLVED CANDIDATE / INTEGRATION IN PROGRESS] Gerçek admin-radar.js kopyası _archive içinde bulundu. İleride mimariye uygun şekilde geri entegre edilmeli.
+---
 
-2. js/santis-decoy-matrix.js şu an no-op fallback olarak oluşturuldu.
-   Not: [RESOLVED CANDIDATE / INTEGRATION IN PROGRESS] Gerçek işlevi araştırılmalı; eğer aktif sistem tarafından gerekiyorsa gerçek modül olarak yeniden yazılmalı.
+## 🛑 P0 — Critical Debt
 
-3. assets/vendor/barba.umd.js.map placeholder olarak oluşturuldu.
-   Not: Runtime için kritik değil, debug/source-map amacı taşır.
+| ID | Issue | Risk | Status | Action Plan |
+| :--- | :--- | :--- | :--- | :--- |
+| **P0-1** | **`main` / `develop` governance drift** | **HIGH** | OPEN | GitHub and Vercel use `main` for production, but GitHub default branch is not `develop`. PRs must flow strictly `develop` → `main`. Set default branch to `develop`. |
+| **P0-2** | **`develop` → `main` delta strategy** | **HIGH** | OPEN | The divergence between `develop` and `main` is too large. Need a strict release strategy PR to merge `develop` into `main` safely without skipping runtime files. |
 
-4. assets/vendor/swiper-bundle.min.js.map placeholder olarak oluşturuldu.
-   Not: Runtime için kritik değil, debug/source-map amacı taşır.
+---
 
-## Missing Admin Command Launcher Module
+## ⚠️ P1 — High Priority Debt
 
-Status: RESOLVED CANDIDATE / REBUILT AS SAFE READ-ONLY COMMAND PALETTE
+| ID | Issue | Risk | Status | Action Plan |
+| :--- | :--- | :--- | :--- | :--- |
+| **P1-1** | **Multiple Service Worker Architecture** | MEDIUM | OPEN | `sw.js`, `santis-sw.js`, `santis-sanctuary-sw.js`, `service-worker.js`, etc. Need audit-only phase to map active/legacy registrations. |
+| **P1-2** | **Color System & Design Token Fragmentation** | HIGH | OPEN | `#d4af37` hardcoded 159+ times. Tokens conflict between `editorial.css` and `style.css`. Needs Phase C1-C5 audit and refactor. |
 
-admin-command-launcher.js is currently absent from the active admin dashboard path and could not be found in _archive. Its script reference in admin-dashboard.html was disabled to prevent a Vite development runtime 404. Future work should either rebuild the launcher module intentionally or permanently remove the feature path from the dashboard architecture.
+---
 
-The missing admin-command-launcher.js module has been rebuilt as a safe, read-only command palette. It currently avoids backend mutations, storage writes, and destructive commands. Future work may connect privileged actions only after RBAC/session guards exist.
+## 🟡 P2 — Medium Priority Debt
 
-Related file:
-- admin-dashboard.html
+| ID | Issue | Risk | Status | Action Plan |
+| :--- | :--- | :--- | :--- | :--- |
+| **P2-1** | **Tailwind Dependency Ownership** | MEDIUM | OPEN | `tailwindcss` exists in both `dependencies` and `devDependencies`. Needs normalization (chore PR). |
+| **P2-2** | **Nav Manifest & WebSocket Gateway** | MED-HIGH | OPEN | Frontend encounters `Unexpected token '<'` on 404 manifest. Telemetry client expects `ws://localhost:8080`. Needs fallback fix. |
+| **P2-3** | **Branch Policy Enforcement** | MEDIUM | OPEN | Orphaned `phase-*` branches need cleanup. GitHub settings need to match `docs/governance/release-flow.md`. |
 
-Reason:
-- Prevents runtime 404 during development.
-- Keeps dashboard stable while preserving the missing command launcher as tracked technical debt.
+---
+
+## ⏸️ Deferred Debt
+
+| ID | Issue | Reason for Deferral |
+| :--- | :--- | :--- |
+| **DEF-01** | **Vite MPA Config Refactor** | Currently relying on Vite defaults. Proper integration of `admin-dashboard.html` requires dedicated refactoring of `vite.config.ts`. |
+| **DEF-02** | **CSS Grid Optimization** | Minor layout shifts are acceptable for now. Waiting for design system tokenization (Phase C) before layout refactoring. |
+
+---
+
+## 🔒 Do Not Touch (Frozen Systems)
+
+| ID | Component | Reason |
+| :--- | :--- | :--- |
+| **DNT-01** | **CoreState Runtime Kernel** | Canonical SSOT. Modifications without Boardroom approval will violate `RuntimeContracts.md`. |
+| **DNT-02** | **Legacy Zod Validation Pipelines** | Fragile. Changing them without full test suite coverage will break booking validation. |
+
+---
+
+## ✅ Closed / Sealed Debt
+
+*   **Tailwind CDN production warning:** CLOSED
+*   **`tailwind is not defined` runtime risk:** CLOSED
+*   **Guest Zen Tailwind suppressor legacy:** CLOSED
+*   **Service Worker non-http cache crash:** CLOSED
+*   **Develop -> main incorrect full merge risk:** Prevented
+*   **Runtime Integrity Patch v1.0.1:** SEALED / PROMOTED TO MAIN
+*   **Vercel Project Ambiguity:** RESOLVED (Mapped in `docs/deployment/vercel-project-map.md`)
+*   **Technical Debt Register Structure:** RESOLVED (This document)


### PR DESCRIPTION
Docs-only backport from main to develop.

Scope:
- Backports technical debt register v2
- Backports Vercel project truth map
- Backports release flow / branch governance documentation
- No runtime code changes
- No Docker changes
- No CSS/JS/HTML/package changes

Validation:
- Working tree clean
- git show --check PASS
- origin/develop...HEAD contains only 3 docs files