### PR TITLE
feat(reception): add live bookings bridge

### DIFF
--- a/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
+++ b/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
@@ -1,6 +1,60 @@
 import React, { useState, useEffect } from 'react';
 import { useBoardroomMode } from "../../features/boardroom/context/BoardroomModeContext";
 
+function ReceptionLiveToday() {
+  const [data, setData] = useState(null);
+  const [status, setStatus] = useState('loading');
+
+  useEffect(() => {
+    const params = new URLSearchParams({ locationName: 'budva', environment: 'Live' });
+
+    fetch(`/api/v1/reception/bookings/today?${params.toString()}`, {
+      headers: { Accept: 'application/json' },
+    })
+      .then((response) => response.json())
+      .then((payload) => {
+        setData(payload);
+        setStatus('ready');
+      })
+      .catch(() => setStatus('error'));
+  }, []);
+
+  const bookings = data?.bookings || [];
+
+  return (
+    <section className="bg-sovereign-obsidian border border-sovereign-panel rounded-sm p-6 mb-6 font-sans">
+      <div className="flex items-center justify-between border-b border-sovereign-panel pb-4 mb-4">
+        <div>
+          <h3 className="text-sovereign-ink text-sm uppercase tracking-widest font-medium">Reception Live Today</h3>
+          <p className="text-sovereign-bronze text-xs mt-1">{status === 'ready' ? `${data?.location} · ${data?.date}` : 'Reading live bookings'}</p>
+        </div>
+        <span className="text-sovereign-accent font-serif text-2xl">{status === 'ready' ? data?.count || 0 : '—'}</span>
+      </div>
+
+      {status === 'loading' && <p className="text-sovereign-bronze text-sm">Live bookings are loading…</p>}
+      {status === 'error' && <p className="text-red-100 text-sm">Reception data could not be loaded.</p>}
+      {status === 'ready' && bookings.length === 0 && (
+        <p className="text-sovereign-ink text-sm">Bugün bu şube için canlı rezervasyon bulunmuyor.</p>
+      )}
+      {status === 'ready' && bookings.length > 0 && (
+        <div className="space-y-3">
+          {bookings.map((booking) => (
+            <div key={booking.id} className="border border-sovereign-panel bg-sovereign-coal/30 rounded-sm p-4">
+              <div className="text-sovereign-ink text-sm">{booking.timeDisplay || booking.startDateTime}</div>
+              <div className="text-sovereign-bronze text-xs mt-2">
+                {booking.clientName || '—'} · {booking.serviceName || '—'} · {booking.therapistName || '—'}
+              </div>
+              <div className="text-sovereign-bronze text-xs mt-1">
+                {booking.paymentStatus || 'Payment Unknown'} · Due €{booking.balanceDueEur || 0}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export default function LiveIntentMonitor() {
   const { mode } = useBoardroomMode();
   const [events, setEvents] = useState([]);
@@ -72,47 +126,48 @@ export default function LiveIntentMonitor() {
     }
   }, [mode]);
 
-  if (events.length === 0) {
-    return null;
-  }
-
   return (
-    <div className="bg-sovereign-obsidian border border-sovereign-panel rounded-sm p-8 flex flex-col transition-colors mb-6 font-sans">
-      <div className="flex items-center gap-3 mb-6 border-b border-sovereign-panel pb-4">
-        <h3 className="text-sovereign-ink text-sm uppercase tracking-widest font-medium">
-          Live Intent Monitor
-        </h3>
-      </div>
+    <>
+      <ReceptionLiveToday />
+      {events.length > 0 && (
+        <div className="bg-sovereign-obsidian border border-sovereign-panel rounded-sm p-8 flex flex-col transition-colors mb-6 font-sans">
+          <div className="flex items-center gap-3 mb-6 border-b border-sovereign-panel pb-4">
+            <h3 className="text-sovereign-ink text-sm uppercase tracking-widest font-medium">
+              Live Intent Monitor
+            </h3>
+          </div>
 
-      <div className="space-y-4">
-        {events.map((evt, index) => {
-          return (
-            <div
-              key={`${evt.traceId}-${index}`}
-              className="p-6 rounded-md border border-sovereign-line bg-sovereign-dark flex justify-between items-center transition-all hover:border-sovereign-gold/50"
-            >
-              <div className="flex flex-col gap-2">
-                <span className="text-sovereign-muted text-2xs tracking-widest uppercase font-medium">
-                  Trace ID: {evt.traceId} • {new Date(evt.occurredAt).toLocaleTimeString()}
-                </span>
-                <span className="text-lg font-serif tracking-wide text-sovereign-ink">
-                  {evt.payload.intentDetected}
-                </span>
-                <span className="text-xs text-sovereign-bronze font-mono mt-1">
-                  Mode: {evt.payload.recommendedMode || 'unknown'} | Confidence: {evt.payload.confidence}
-                </span>
-              </div>
+          <div className="space-y-4">
+            {events.map((evt, index) => {
+              return (
+                <div
+                  key={`${evt.traceId}-${index}`}
+                  className="p-6 rounded-md border border-sovereign-line bg-sovereign-dark flex justify-between items-center transition-all hover:border-sovereign-gold/50"
+                >
+                  <div className="flex flex-col gap-2">
+                    <span className="text-sovereign-muted text-2xs tracking-widest uppercase font-medium">
+                      Trace ID: {evt.traceId} • {new Date(evt.occurredAt).toLocaleTimeString()}
+                    </span>
+                    <span className="text-lg font-serif tracking-wide text-sovereign-ink">
+                      {evt.payload.intentDetected}
+                    </span>
+                    <span className="text-xs text-sovereign-bronze font-mono mt-1">
+                      Mode: {evt.payload.recommendedMode || 'unknown'} | Confidence: {evt.payload.confidence}
+                    </span>
+                  </div>
 
-              {/* Statü ve Rozet Alanı */}
-              <div className="flex items-center gap-6">
-                <div className="flex flex-col items-end">
-                  <span className="text-sovereign-gold text-sm font-mono tracking-widest">EVALUATED</span>
+                  {/* Statü ve Rozet Alanı */}
+                  <div className="flex items-center gap-6">
+                    <div className="flex flex-col items-end">
+                      <span className="text-sovereign-gold text-sm font-mono tracking-widest">EVALUATED</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/api/index.py
+++ b/api/index.py
@@ -6,6 +6,7 @@ from app.api.v1.endpoints import (
     aurelia_whisper,
     sovereign_memory,
     scheduling,
+    reception,
     telemetry,
 )
 
@@ -20,4 +21,5 @@ app.include_router(billing.router, prefix="/api/v1")
 app.include_router(aurelia_whisper.router, prefix="/api/v1")
 app.include_router(sovereign_memory.router, prefix="/api/v1")
 app.include_router(scheduling.router, prefix="/api/v1")
+app.include_router(reception.router, prefix="/api/v1")
 app.include_router(telemetry.router, prefix="/api/v1/telemetry")

--- a/app/api/v1/endpoints/reception.py
+++ b/app/api/v1/endpoints/reception.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from fastapi import APIRouter, HTTPException, Query
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Python < 3.9 fallback
+    ZoneInfo = None
+
+router = APIRouter(prefix="/reception", tags=["reception"])
+
+AIRTABLE_API_URL = "https://api.airtable.com/v0"
+AIRTABLE_BASE_ID_ENV_KEYS = ("AIRTABLE_BASE_ID", "AIRTABLE_SANTIS_BASE_ID")
+AIRTABLE_TOKEN_ENV_KEYS = ("AIRTABLE_PAT", "AIRTABLE_API_KEY")
+BOOKINGS_TABLE_ID = os.getenv("AIRTABLE_BOOKINGS_TABLE_ID", "tblocCFVgSNfaLAH6")
+TIMEZONE = "Europe/Podgorica"
+USER_LOCALE = "en-us"
+
+BOOKING_FIELDS = [
+    "Booking ID",
+    "Reception Time Display",
+    "Start_DateTime",
+    "Calculated_Finish_DateTime",
+    "Client_Link",
+    "Service_Link",
+    "Therapist_Link",
+    "Room_Link",
+    "Location_Link",
+    "Status_New",
+    "Payment_Status_New",
+    "Payment Method",
+    "Total Paid EUR",
+    "Balance_Due_EUR",
+    "Reception Ready Status",
+    "Therapist Shift Gate",
+    "Reception_Priority",
+    "Environment",
+]
+
+LOCATION_ALIASES = {
+    "budva": "01 BUDVA — Santis Club Budva",
+    "01 budva": "01 BUDVA — Santis Club Budva",
+    "rec1qc31hfqbulhzu": "01 BUDVA — Santis Club Budva",
+}
+
+EXCLUDED_STATUSES = {"cancelled", "no-show"}
+
+
+def _first_env(keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = os.getenv(key)
+        if value:
+            return value
+    return None
+
+
+def _airtable_token() -> str:
+    token = _first_env(AIRTABLE_TOKEN_ENV_KEYS)
+    if not token:
+        raise HTTPException(
+            status_code=503,
+            detail="Airtable token is not configured. Set AIRTABLE_PAT or AIRTABLE_API_KEY on the backend.",
+        )
+    return token
+
+
+def _airtable_base_id() -> str:
+    base_id = _first_env(AIRTABLE_BASE_ID_ENV_KEYS)
+    if not base_id:
+        raise HTTPException(
+            status_code=503,
+            detail="Airtable base is not configured. Set AIRTABLE_BASE_ID on the backend.",
+        )
+    return base_id
+
+
+def _today_in_podgorica() -> str:
+    if ZoneInfo is not None:
+        return datetime.now(ZoneInfo(TIMEZONE)).date().isoformat()
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _escape_formula_text(value: str) -> str:
+    return value.replace("'", "\\'")
+
+
+def _airtable_get(table_id: str, params: list[tuple[str, str]]) -> dict[str, Any]:
+    base_id = _airtable_base_id()
+    token = _airtable_token()
+    url = f"{AIRTABLE_API_URL}/{base_id}/{table_id}?{urlencode(params)}"
+    request = Request(url, headers={"Authorization": f"Bearer {token}"})
+
+    try:
+        with urlopen(request, timeout=15) as response:
+            payload = response.read().decode("utf-8")
+            return json.loads(payload)
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise HTTPException(status_code=502, detail=f"Airtable read failed: {body[:500]}") from exc
+    except URLError as exc:
+        raise HTTPException(status_code=502, detail=f"Airtable network error: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=502, detail="Airtable returned invalid JSON") from exc
+
+
+def _airtable_list_bookings(selected_date: str, environment: str) -> list[dict[str, Any]]:
+    safe_environment = _escape_formula_text(environment)
+    safe_date = _escape_formula_text(selected_date)
+    formula = (
+        "AND("
+        f"{{Environment}} = '{safe_environment}',"
+        f"DATETIME_FORMAT(SET_TIMEZONE({{Start_DateTime}}, '{TIMEZONE}'), 'YYYY-MM-DD') = '{safe_date}',"
+        "NOT(OR({Status_New} = 'Cancelled', {Status_New} = 'No-show'))"
+        ")"
+    )
+
+    params: list[tuple[str, str]] = [
+        ("cellFormat", "string"),
+        ("timeZone", TIMEZONE),
+        ("userLocale", USER_LOCALE),
+        ("pageSize", "100"),
+        ("filterByFormula", formula),
+        ("sort[0][field]", "Start_DateTime"),
+        ("sort[0][direction]", "asc"),
+    ]
+    for field_name in BOOKING_FIELDS:
+        params.append(("fields[]", field_name))
+
+    records: list[dict[str, Any]] = []
+    offset: str | None = None
+    while True:
+        page_params = list(params)
+        if offset:
+            page_params.append(("offset", offset))
+        payload = _airtable_get(BOOKINGS_TABLE_ID, page_params)
+        records.extend(payload.get("records", []))
+        offset = payload.get("offset")
+        if not offset:
+            return records
+
+
+def _normalize(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ", ".join(_normalize(item) for item in value if item is not None)
+    if isinstance(value, dict):
+        return _normalize(value.get("name") or value.get("id") or value)
+    return str(value).strip()
+
+
+def _number(value: Any) -> float:
+    if value is None or value == "":
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    cleaned = re.sub(r"[^0-9,.-]", "", str(value)).replace(",", ".")
+    if cleaned.count(".") > 1:
+        first, *rest = cleaned.split(".")
+        cleaned = first + "." + "".join(rest)
+    try:
+        return float(cleaned)
+    except ValueError:
+        return 0.0
+
+
+def _booking_id(value: Any) -> int | str | None:
+    normalized = _normalize(value)
+    if not normalized:
+        return None
+    try:
+        return int(float(normalized))
+    except ValueError:
+        return normalized
+
+
+def _location_filter(location_id: str | None, location_name: str | None, location: str | None) -> tuple[str, str]:
+    raw = _normalize(location_id or location_name or location or "budva")
+    key = raw.lower()
+    canonical = LOCATION_ALIASES.get(key, raw)
+    return key, canonical
+
+
+def _matches_location(fields: dict[str, Any], canonical_location: str, location_key: str) -> bool:
+    location_value = _normalize(fields.get("Location_Link"))
+    if not location_value:
+        return False
+    location_lower = location_value.lower()
+    canonical_lower = canonical_location.lower()
+    return canonical_lower in location_lower or location_key in location_lower
+
+
+def _normalize_booking(record: dict[str, Any]) -> dict[str, Any]:
+    fields = record.get("fields", {})
+    payment_status = _normalize(fields.get("Payment_Status_New"))
+    balance_due = _number(fields.get("Balance_Due_EUR"))
+    total_paid = _number(fields.get("Total Paid EUR"))
+    priority = _normalize(fields.get("Reception_Priority"))
+    payment_attention = payment_status.lower() == "unpaid" or balance_due > 0
+
+    if payment_attention:
+        priority = "Payment Attention"
+
+    return {
+        "id": record.get("id"),
+        "bookingId": _booking_id(fields.get("Booking ID")),
+        "timeDisplay": _normalize(fields.get("Reception Time Display")),
+        "startDateTime": _normalize(fields.get("Start_DateTime")),
+        "finishDateTime": _normalize(fields.get("Calculated_Finish_DateTime")),
+        "clientName": _normalize(fields.get("Client_Link")),
+        "serviceName": _normalize(fields.get("Service_Link")),
+        "therapistName": _normalize(fields.get("Therapist_Link")),
+        "roomName": _normalize(fields.get("Room_Link")),
+        "locationName": _normalize(fields.get("Location_Link")),
+        "status": _normalize(fields.get("Status_New")),
+        "paymentStatus": payment_status,
+        "paymentMethod": _normalize(fields.get("Payment Method")),
+        "totalPaidEur": total_paid,
+        "balanceDueEur": balance_due,
+        "receptionReadyStatus": _normalize(fields.get("Reception Ready Status")),
+        "therapistShiftGate": _normalize(fields.get("Therapist Shift Gate")),
+        "receptionPriority": priority,
+        "paymentAttention": payment_attention,
+        "environment": _normalize(fields.get("Environment")),
+    }
+
+
+@router.get("/bookings/today")
+def get_reception_bookings_today(
+    location_id: str | None = Query(default=None, alias="locationId"),
+    location_name: str | None = Query(default=None, alias="locationName"),
+    location: str | None = Query(default=None),
+    date: str | None = Query(default=None),
+    environment: str = Query(default="Live"),
+) -> dict[str, Any]:
+    selected_date = date or _today_in_podgorica()
+    location_key, canonical_location = _location_filter(location_id, location_name, location)
+
+    records = _airtable_list_bookings(selected_date, environment)
+    filtered_records = [
+        record for record in records if _matches_location(record.get("fields", {}), canonical_location, location_key)
+    ]
+    bookings = [_normalize_booking(record) for record in filtered_records]
+    bookings = [booking for booking in bookings if booking["status"].lower() not in EXCLUDED_STATUSES]
+
+    display_location = bookings[0]["locationName"] if bookings else canonical_location
+
+    return {
+        "date": selected_date,
+        "timezone": TIMEZONE,
+        "location": display_location,
+        "environment": environment,
+        "count": len(bookings),
+        "bookings": bookings,
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
-from app.api.v1.endpoints import billing, aurelia_whisper, sovereign_memory, telemetry
+from app.api.v1.endpoints import billing, aurelia_whisper, sovereign_memory, reception, telemetry
 
 app = FastAPI(title="Santis OS API")
 
@@ -11,7 +11,7 @@ app.add_middleware(
     allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
-    allow_headers=["*"],
+    allow_headers=["*"]
 )
 
 @app.get("/health")
@@ -21,9 +21,8 @@ def health_check():
 app.include_router(billing.router, prefix="/api/v1")
 app.include_router(aurelia_whisper.router, prefix="/api/v1")
 app.include_router(sovereign_memory.router, prefix="/api/v1")
+app.include_router(reception.router, prefix="/api/v1")
 app.include_router(telemetry.router, prefix="/api/v1/telemetry")
 
 # Arayüzü tek bir port üzerinden (CORS sorunu olmaksızın) sunmak için statik dosyaları bağla:
 app.mount("/", StaticFiles(directory=".", html=True), name="static")
-
-


### PR DESCRIPTION
## Summary
- Adds a read-only `/api/v1/reception/bookings/today` endpoint for live reception bookings.
- Reads Airtable from backend environment variables only.
- Normalizes booking data for the Santis Admin Panel.
- Shows a Reception Live Today card in the existing Boardroom telemetry surface.

## Runtime requirements
Set these on the backend runtime:
- `AIRTABLE_PAT` or `AIRTABLE_API_KEY`
- `AIRTABLE_BASE_ID`
- optional: `AIRTABLE_BOOKINGS_TABLE_ID`

## Manual checks
- `/api/v1/reception/bookings/today?locationName=budva`
- `/api/v1/reception/bookings/today?locationName=budva&date=2026-06-21`

## Scope
Read-only. No Airtable writes. No schema changes. No token in the frontend.