### PR TITLE
feat(reception): add live booking controls

### DIFF
--- a/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
+++ b/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
@@ -1,14 +1,39 @@
 import React, { useState, useEffect } from 'react';
 import { useBoardroomMode } from "../../features/boardroom/context/BoardroomModeContext";
 
+const LOCATION_OPTIONS = [
+  { label: 'Budva', value: 'budva' },
+  { label: 'Kotor', value: 'kotor' },
+  { label: 'Tivat', value: 'tivat' },
+];
+
+function getTodayDate() {
+  const today = new Date();
+  today.setMinutes(today.getMinutes() - today.getTimezoneOffset());
+  return today.toISOString().slice(0, 10);
+}
+
+function formatUpdatedAt(value) {
+  if (!value) return '—';
+  return value.toLocaleTimeString('tr-TR', { hour: '2-digit', minute: '2-digit' });
+}
+
 function ReceptionLiveToday() {
   const [data, setData] = useState(null);
   const [status, setStatus] = useState('loading');
   const [errorMessage, setErrorMessage] = useState('');
+  const [locationName, setLocationName] = useState('budva');
+  const [selectedDate, setSelectedDate] = useState(getTodayDate);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(null);
+  const [refreshToken, setRefreshToken] = useState(0);
 
   useEffect(() => {
     const controller = new AbortController();
-    const params = new URLSearchParams({ locationName: 'budva', environment: 'Live' });
+    const params = new URLSearchParams({
+      locationName,
+      date: selectedDate,
+      environment: 'Live',
+    });
 
     const loadBookings = async () => {
       try {
@@ -26,6 +51,7 @@ function ReceptionLiveToday() {
         }
 
         setData(payload);
+        setLastUpdatedAt(new Date());
         setStatus('ready');
       } catch (error) {
         if (error?.name === 'AbortError') {
@@ -39,22 +65,71 @@ function ReceptionLiveToday() {
     loadBookings();
 
     return () => controller.abort();
-  }, []);
+  }, [locationName, selectedDate, refreshToken]);
 
   const bookings = data?.bookings || [];
+  const activeLocation = LOCATION_OPTIONS.find((option) => option.value === locationName)?.label || locationName;
+  const isLoading = status === 'loading';
 
   return (
     <section className="bg-sovereign-obsidian border border-sovereign-panel rounded-sm p-6 mb-6 font-sans">
-      <div className="flex items-center justify-between border-b border-sovereign-panel pb-4 mb-4">
+      <div className="flex flex-col gap-4 border-b border-sovereign-panel pb-4 mb-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <h3 className="text-sovereign-ink text-sm uppercase tracking-widest font-medium">Reception Live Today</h3>
-          <p className="text-sovereign-bronze text-xs mt-1">{status === 'ready' ? `${data?.location} · ${data?.date}` : 'Reading live bookings'}</p>
+          <p className="text-sovereign-bronze text-xs mt-1">
+            {status === 'ready' ? `${data?.location || activeLocation} · ${data?.date || selectedDate}` : `${activeLocation} · ${selectedDate}`}
+          </p>
+          <p className="text-sovereign-bronze text-xs mt-1">
+            Son güncelleme: {formatUpdatedAt(lastUpdatedAt)}
+          </p>
         </div>
+
         <span className="text-sovereign-accent font-serif text-2xl">{status === 'ready' ? data?.count || 0 : '—'}</span>
       </div>
 
+      <div className="grid gap-3 mb-5 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+        <label className="flex flex-col gap-1 text-sovereign-bronze text-xs uppercase tracking-widest">
+          Şube
+          <select
+            className="bg-sovereign-dark border border-sovereign-panel rounded-sm px-3 py-2 text-sovereign-ink text-sm normal-case tracking-normal"
+            value={locationName}
+            disabled={isLoading}
+            onChange={(event) => setLocationName(event.target.value)}
+          >
+            {LOCATION_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-sovereign-bronze text-xs uppercase tracking-widest">
+          Tarih
+          <input
+            className="bg-sovereign-dark border border-sovereign-panel rounded-sm px-3 py-2 text-sovereign-ink text-sm normal-case tracking-normal"
+            type="date"
+            value={selectedDate}
+            disabled={isLoading}
+            onChange={(event) => setSelectedDate(event.target.value || getTodayDate())}
+          />
+        </label>
+
+        <button
+          className="border border-sovereign-panel rounded-sm px-4 py-2 text-sovereign-ink text-xs uppercase tracking-widest disabled:opacity-50 md:self-end"
+          type="button"
+          disabled={isLoading}
+          onClick={() => setRefreshToken((value) => value + 1)}
+        >
+          {isLoading ? 'Yükleniyor' : 'Refresh'}
+        </button>
+      </div>
+
       {status === 'loading' && <p className="text-sovereign-bronze text-sm">Live bookings are loading…</p>}
-      {status === 'error' && <p className="text-red-100 text-sm">{errorMessage}</p>}
+      {status === 'error' && (
+        <div className="border border-red-100/30 bg-sovereign-dark rounded-sm p-4">
+          <p className="text-red-100 text-sm">{errorMessage}</p>
+          <p className="text-sovereign-bronze text-xs mt-2">Airtable/Vercel environment variables veya backend bağlantısını kontrol edin.</p>
+        </div>
+      )}
       {status === 'ready' && bookings.length === 0 && (
         <p className="text-sovereign-ink text-sm">Bugün bu şube için canlı rezervasyon bulunmuyor.</p>
       )}


### PR DESCRIPTION
## Summary
- Adds branch/location selector to Reception Live Today.
- Adds date picker so reception can test today or historical dates.
- Adds manual refresh button.
- Adds last updated time display.
- Keeps existing error handling from the previous hardening PR.

## Scope
- `admin-panel/src/components/boardroom/LiveIntentMonitor.jsx` only.
- No backend changes.
- No Airtable writes.
- No schema changes.

## P0-SEAL-02
This turns the Reception Live Today card from a hardcoded Budva/today widget into an operational control card while avoiding check-in/payment/cancel workflows for now.