### PR TITLE
Wire reception Airtable bridge v1

### DIFF
--- a/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
+++ b/admin-panel/src/components/boardroom/LiveIntentMonitor.jsx
@@ -3,6 +3,7 @@ import { useBoardroomMode } from "../../features/boardroom/context/BoardroomMode
 
 const LOCATION_OPTIONS = [
   { label: 'Budva', value: 'budva' },
+  { label: 'Podgorica', value: 'podgorica' },
   { label: 'Kotor', value: 'kotor' },
   { label: 'Tivat', value: 'tivat' },
 ];
@@ -16,6 +17,11 @@ function getTodayDate() {
 function formatUpdatedAt(value) {
   if (!value) return '—';
   return value.toLocaleTimeString('tr-TR', { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatMoney(value) {
+  const amount = Number(value || 0);
+  return amount.toLocaleString('tr-TR', { minimumFractionDigits: 0, maximumFractionDigits: 2 });
 }
 
 function ReceptionLiveToday() {
@@ -137,12 +143,28 @@ function ReceptionLiveToday() {
         <div className="space-y-3">
           {bookings.map((booking) => (
             <div key={booking.id} className="border border-sovereign-panel bg-sovereign-coal/30 rounded-sm p-4">
-              <div className="text-sovereign-ink text-sm">{booking.timeDisplay || booking.startDateTime}</div>
-              <div className="text-sovereign-bronze text-xs mt-2">
-                {booking.clientName || '—'} · {booking.serviceName || '—'} · {booking.therapistName || '—'}
-              </div>
-              <div className="text-sovereign-bronze text-xs mt-1">
-                {booking.paymentStatus || 'Payment Unknown'} · Due €{booking.balanceDueEur || 0}
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <div className="text-sovereign-ink text-sm">{booking.timeDisplay || booking.startDateTime}</div>
+                  <div className="text-sovereign-bronze text-xs mt-2">
+                    {booking.clientName || '—'} · {booking.serviceName || '—'} · {booking.therapistName || '—'}
+                  </div>
+                  <div className="text-sovereign-bronze text-xs mt-1">
+                    Oda: {booking.roomName || '—'} · Durum: {booking.status || '—'}
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap gap-2 md:justify-end">
+                  <span className="border border-sovereign-panel rounded-full px-3 py-1 text-sovereign-ink text-xs">
+                    Ödeme: {booking.paymentStatus || 'Unknown'}
+                  </span>
+                  <span className="border border-sovereign-panel rounded-full px-3 py-1 text-sovereign-ink text-xs">
+                    Kalan: €{formatMoney(booking.balanceDueEur)}
+                  </span>
+                  <span className="border border-sovereign-panel rounded-full px-3 py-1 text-sovereign-ink text-xs">
+                    Hazırlık: {booking.receptionReadyStatus || 'Unknown'}
+                  </span>
+                </div>
               </div>
             </div>
           ))}

--- a/scripts/audit-reception-runtime-contract.js
+++ b/scripts/audit-reception-runtime-contract.js
@@ -58,12 +58,17 @@ if (frontend) {
   requireIncludes(frontend, "environment: 'Live'", FRONTEND_FILE);
   requireIncludes(frontend, "LOCATION_OPTIONS", FRONTEND_FILE);
   requireIncludes(frontend, "value: 'budva'", FRONTEND_FILE);
+  requireIncludes(frontend, "value: 'podgorica'", FRONTEND_FILE);
   requireIncludes(frontend, "value: 'kotor'", FRONTEND_FILE);
   requireIncludes(frontend, "value: 'tivat'", FRONTEND_FILE);
   requireIncludes(frontend, "type=\"date\"", FRONTEND_FILE);
   requireIncludes(frontend, "setRefreshToken", FRONTEND_FILE);
   requireIncludes(frontend, "Son güncelleme", FRONTEND_FILE);
   requireIncludes(frontend, "formatUpdatedAt", FRONTEND_FILE);
+  requireIncludes(frontend, "formatMoney", FRONTEND_FILE);
+  requireIncludes(frontend, "booking.paymentStatus", FRONTEND_FILE);
+  requireIncludes(frontend, "booking.balanceDueEur", FRONTEND_FILE);
+  requireIncludes(frontend, "booking.receptionReadyStatus", FRONTEND_FILE);
   requireIncludes(frontend, "response.ok", FRONTEND_FILE);
   requireIncludes(frontend, "AbortController", FRONTEND_FILE);
 
@@ -82,6 +87,8 @@ if (backend) {
   requireIncludes(backend, "date: str | None", BACKEND_FILE);
   requireIncludes(backend, "environment: str = Query(default=\"Live\")", BACKEND_FILE);
   requireIncludes(backend, "AIRTABLE_TOKEN_ENV_KEYS", BACKEND_FILE);
+  requireIncludes(backend, "Reception Ready Status", BACKEND_FILE);
+  requireIncludes(backend, "Payment_Status_New", BACKEND_FILE);
 }
 
 if (failed) {


### PR DESCRIPTION
## Summary
- Keep the existing `/api/v1/reception/bookings/today` backend bridge as the source for today's branch bookings.
- Add Podgorica to the Admin Panel reception branch selector.
- Show payment status, balance due, room/status and reception preparation readiness on the live reception card.
- Extend the reception runtime contract audit so the UI cannot leak Airtable credentials and must keep payment/readiness fields visible.

## Airtable source checked
- Base: Santis OS (`app7VPfdgji5FzLHg`)
- Bookings table: `tblocCFVgSNfaLAH6`
- Locations verified: Budva, Podgorica, Kotor, Tivat, Antalya/Alba, demo/test locations.

## Endpoint contract
`GET /api/v1/reception/bookings/today?locationName=podgorica&date=YYYY-MM-DD&environment=Live`

Returns normalized booking rows with payment and reception readiness fields for Santis Admin Panel.

## Notes
- Today's Airtable check returned one booking for 2026-06-26, but it is `Environment = Test`, so it should not appear in the default Live admin card.
- The frontend only calls the backend endpoint; it does not expose Airtable PAT, base ID, Authorization header, or direct Airtable URL.